### PR TITLE
RYA-25 Apache RAT check during maven build

### DIFF
--- a/extras/tinkerpop.rya/src/test/resources/log4j.properties
+++ b/extras/tinkerpop.rya/src/test/resources/log4j.properties
@@ -16,4 +16,14 @@
 # under the License.
 
 
+log4j.debug=false
 
+#log4j.rootLogger=INFO, console
+log4j.category.org.openrdf=INFO, mob
+log4j.category.org.xml=INFO, mob
+
+log4j.appender.mob=org.apache.log4j.FileAppender
+log4j.appender.mob.file=target/blueprints.log
+log4j.appender.mob.append=true
+log4j.appender.mob.layout=org.apache.log4j.PatternLayout
+log4j.appender.mob.layout.ConversionPattern=%d [%t] %p %C{1} - %m%n

--- a/pom.xml
+++ b/pom.xml
@@ -608,12 +608,20 @@ under the License.
                         </execution>
                     </executions>
                 </plugin>
-                <plugin>
-                    <!-- Apache Release Audit Tool - reports missing license headers and other issues. -->
-                    <!-- mvn apache-rat:rat -->
-                    <!-- mvn apache-rat:check -->
-                    <groupId>org.apache.rat</groupId>
-                    <artifactId>apache-rat-plugin</artifactId>
+            </plugins>
+        </pluginManagement>
+
+        <plugins>
+            <plugin>
+                <!-- Apache Release Audit Tool - reports missing license headers and other issues. -->
+                <groupId>org.apache.rat</groupId>
+                <artifactId>apache-rat-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>check-licenses</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
                     <configuration>
                         <excludes>
                             <!-- RDF data Files -->
@@ -627,15 +635,8 @@ under the License.
                             <exclude>**/resources/META-INF/services/**</exclude>
                         </excludes>
                     </configuration>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>2.3</version>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <artifactId>maven-source-plugin</artifactId>


### PR DESCRIPTION
Modified the parent POM so that the Apache RAT plugin runs by default;
modified log4j properties for blueprints to put temp log in target;
removed extraneous shading.