### PR TITLE
Made README link to RYA on apache.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ under the License. -->
 
 ## Overview
 
-RYA is a scalable RDF Store that is built on top of a Columnar Index Store (such as Accumulo). It is implemented as an extension to OpenRdf to provide easy query mechanisms (SPARQL, SERQL, etc) and Rdf data storage (RDF/XML, NTriples, etc).
+[RYA] is a scalable RDF Store that is built on top of a Columnar Index Store (such as Accumulo). It is implemented as an extension to OpenRdf to provide easy query mechanisms (SPARQL, SERQL, etc) and Rdf data storage (RDF/XML, NTriples, etc).
 
 RYA stands for RDF y(and) Accumulo.
 
@@ -315,3 +315,7 @@ tupleQuery.evaluate(new TupleQueryResultHandler() {
 conn.close();
 myRepository.shutDown();
 ```
+
+
+[RYA]: http://rya.incubator.apache.org/ 
+


### PR DESCRIPTION
When I Googled for Apache RYA it brought me to Github and [this](https://projects.apache.org/project.html?rya).   I'm sure this will improve over time.  But it made me realize it would be nice if the Readme on GH had a link to the website.