### PR TITLE
Updated config to not use inferencing by default 

### DIFF
--- a/common/rya.api/src/main/java/mvm/rya/api/RdfCloudTripleStoreConfiguration.java
+++ b/common/rya.api/src/main/java/mvm/rya/api/RdfCloudTripleStoreConfiguration.java
@@ -8,9 +8,9 @@ package mvm.rya.api;
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -66,48 +66,58 @@ public abstract class RdfCloudTripleStoreConfiguration extends Configuration {
     public static final String CONF_OPTIMIZERS = "query.optimizers";
     public static final String CONF_PCJ_OPTIMIZER = "pcj.query.optimizer";
     public static final String CONF_PCJ_TABLES = "pcj.index.tables";
-  
+
 
     /**
      * @deprecated use CONF_*
      */
-    public static final String BINDING_DISP_QUERYPLAN = CONF_QUERYPLAN_FLAG;
+    @Deprecated
+	public static final String BINDING_DISP_QUERYPLAN = CONF_QUERYPLAN_FLAG;
     /**
      * @deprecated use CONF_*
      */
-    public static final String BINDING_AUTH = CONF_QUERY_AUTH;
+    @Deprecated
+	public static final String BINDING_AUTH = CONF_QUERY_AUTH;
     /**
      * @deprecated use CONF_*
      */
-    public static final String BINDING_CV = CONF_CV;
+    @Deprecated
+	public static final String BINDING_CV = CONF_CV;
     /**
      * @deprecated use CONF_*
      */
-    public static final String BINDING_TTL = CONF_TTL;
+    @Deprecated
+	public static final String BINDING_TTL = CONF_TTL;
     /**
      * @deprecated use CONF_*
      */
-    public static final String BINDING_STARTTIME = CONF_STARTTIME;
+    @Deprecated
+	public static final String BINDING_STARTTIME = CONF_STARTTIME;
     /**
      * @deprecated use CONF_*
      */
-    public static final String BINDING_PERFORMANT = CONF_PERFORMANT;
+    @Deprecated
+	public static final String BINDING_PERFORMANT = CONF_PERFORMANT;
     /**
      * @deprecated use CONF_*
      */
-    public static final String BINDING_INFER = CONF_INFER;
+    @Deprecated
+	public static final String BINDING_INFER = CONF_INFER;
     /**
      * @deprecated use CONF_*
      */
-    public static final String BINDING_USESTATS = CONF_USE_STATS;
+    @Deprecated
+	public static final String BINDING_USESTATS = CONF_USE_STATS;
     /**
      * @deprecated use CONF_*
      */
-    public static final String BINDING_OFFSET = CONF_OFFSET;
+    @Deprecated
+	public static final String BINDING_OFFSET = CONF_OFFSET;
     /**
      * @deprecated use CONF_*
      */
-    public static final String BINDING_LIMIT = CONF_LIMIT;
+    @Deprecated
+	public static final String BINDING_LIMIT = CONF_LIMIT;
 
     public static final String STATS_PUSH_EMPTY_RDFTYPE_DOWN = "conf.stats.rdftype.down";
     public static final String INFER_INCLUDE_INVERSEOF = "infer.include.inverseof";
@@ -136,7 +146,8 @@ public abstract class RdfCloudTripleStoreConfiguration extends Configuration {
         }
     }
 
-    public abstract RdfCloudTripleStoreConfiguration clone();
+    @Override
+	public abstract RdfCloudTripleStoreConfiguration clone();
 
     public TableLayoutStrategy getTableLayoutStrategy() {
         return tableLayoutStrategy;
@@ -203,7 +214,7 @@ public abstract class RdfCloudTripleStoreConfiguration extends Configuration {
     }
 
     public Boolean isInfer() {
-        return getBoolean(CONF_INFER, true);
+        return getBoolean(CONF_INFER, false);
     }
 
     public void setInfer(Boolean val) {
@@ -223,7 +234,7 @@ public abstract class RdfCloudTripleStoreConfiguration extends Configuration {
     public Boolean isUseSelectivity() {
         return getBoolean(CONF_USE_SELECTIVITY, false);
     }
-    
+
     public void setUseSelectivity(Boolean val) {
         Preconditions.checkNotNull(val);
         setBoolean(CONF_USE_SELECTIVITY, val);
@@ -232,7 +243,7 @@ public abstract class RdfCloudTripleStoreConfiguration extends Configuration {
     public Boolean isPrefixRowsWithHash() {
         return getBoolean(CONF_PREFIX_ROW_WITH_HASH, false);
     }
-    
+
     public void setPrefixRowsWithHash(Boolean val) {
         Preconditions.checkNotNull(val);
         setBoolean(CONF_PREFIX_ROW_WITH_HASH, val);
@@ -304,7 +315,8 @@ public abstract class RdfCloudTripleStoreConfiguration extends Configuration {
      * @return
      * @deprecated
      */
-    public String getAuth() {
+    @Deprecated
+	public String getAuth() {
         return Joiner.on(",").join(getAuths());
     }
 
@@ -312,7 +324,8 @@ public abstract class RdfCloudTripleStoreConfiguration extends Configuration {
      * @param auth
      * @deprecated
      */
-    public void setAuth(String auth) {
+    @Deprecated
+	public void setAuth(String auth) {
         Preconditions.checkNotNull(auth);
         setStrings(CONF_QUERY_AUTH, auth);
     }
@@ -324,7 +337,7 @@ public abstract class RdfCloudTripleStoreConfiguration extends Configuration {
     public void setAuths(String... auths) {
         setStrings(CONF_QUERY_AUTH, auths);
     }
-	
+
 	public String getEmit() {
 		return get(CONF_RESULT_FORMAT);
     }
@@ -343,17 +356,17 @@ public abstract class RdfCloudTripleStoreConfiguration extends Configuration {
         set(CONF_CV, cv);
     }
 
-    
+
     public Boolean isUseCompositeCardinality() {
         return getBoolean(CONF_USE_COMPOSITE, true);
     }
-    
+
     public void setCompositeCardinality(Boolean val) {
         Preconditions.checkNotNull(val);
         setBoolean(CONF_USE_COMPOSITE, val);
     }
-    
-    
+
+
     public Boolean isStatsPushEmptyRdftypeDown() {
         return getBoolean(STATS_PUSH_EMPTY_RDFTYPE_DOWN, true);
     }
@@ -416,14 +429,14 @@ public abstract class RdfCloudTripleStoreConfiguration extends Configuration {
     public Class<? extends RdfEvalStatsDAO> getRdfEvalStatsDaoClass() {
         return getClass(RDF_EVAL_STATS_DAO_CLASS, null, RdfEvalStatsDAO.class);
     }
-    
-    
+
+
     public void setPcjTables(List<String> indexTables) {
         Preconditions.checkNotNull(indexTables);
         setStrings(CONF_PCJ_TABLES, indexTables.toArray(new String[]{}));
     }
-    
-    
+
+
     public List<String> getPcjTables() {
         List<String> pcjTables = Lists.newArrayList();
         String[] tables = getStrings(CONF_PCJ_TABLES);
@@ -436,13 +449,13 @@ public abstract class RdfCloudTripleStoreConfiguration extends Configuration {
         }
         return pcjTables;
     }
-    
-    
+
+
     public void setPcjOptimizer(Class<? extends QueryOptimizer> optimizer) {
         Preconditions.checkNotNull(optimizer);
         setClass(CONF_PCJ_OPTIMIZER, optimizer, QueryOptimizer.class);
     }
-    
+
     public Class<QueryOptimizer> getPcjOptimizer() {
         Class<? extends QueryOptimizer> opt = getClass(CONF_PCJ_OPTIMIZER, null, QueryOptimizer.class);
         if (opt != null) {
@@ -451,9 +464,9 @@ public abstract class RdfCloudTripleStoreConfiguration extends Configuration {
         } else {
             return null;
         }
-        
+
     }
-    
+
 
     public void setOptimizers(List<Class<? extends QueryOptimizer>> optimizers) {
         Preconditions.checkNotNull(optimizers);
@@ -462,21 +475,21 @@ public abstract class RdfCloudTripleStoreConfiguration extends Configuration {
             Preconditions.checkNotNull(ai);
             strs.add(ai.getName());
         }
-        
+
         setStrings(CONF_OPTIMIZERS, strs.toArray(new String[]{}));
     }
 
     public List<Class<QueryOptimizer>> getOptimizers() {
         List<Class<QueryOptimizer>> opts = Lists.newArrayList();
-        for (Class<?> clazz : getClasses(CONF_OPTIMIZERS)){ 
+        for (Class<?> clazz : getClasses(CONF_OPTIMIZERS)){
             Preconditions.checkArgument(QueryOptimizer.class.isAssignableFrom(clazz));
             opts.add((Class<QueryOptimizer>) clazz);
         }
-        
+
         return opts;
     }
-    
-    
+
+
 
     public String getRegexSubject() {
         return get(REGEX_SUBJECT);

--- a/sail/src/test/java/mvm/rya/RdfCloudTripleStoreConnectionTest.java
+++ b/sail/src/test/java/mvm/rya/RdfCloudTripleStoreConnectionTest.java
@@ -8,9 +8,9 @@ package mvm.rya;
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -79,7 +79,8 @@ public class RdfCloudTripleStoreConnectionTest extends TestCase {
     URI cpu = vf.createURI(litdupsNS, "cpu");
     protected RdfCloudTripleStore store;
 
-    public void setUp() throws Exception {
+    @Override
+	public void setUp() throws Exception {
         super.setUp();
         store = new MockRdfCloudStore();
 //        store.setDisplayQueryPlan(true);
@@ -90,7 +91,8 @@ public class RdfCloudTripleStoreConnectionTest extends TestCase {
         repository.initialize();
     }
 
-    public void tearDown() throws Exception {
+    @Override
+	public void tearDown() throws Exception {
         super.tearDown();
         repository.shutDown();
     }
@@ -349,7 +351,7 @@ public class RdfCloudTripleStoreConnectionTest extends TestCase {
         conn.close();
         assertEquals(cth.getCount(), 2);
     }
-    
+
     public void testRegexFilter() throws Exception {
         RepositoryConnection conn = repository.getConnection();
         URI loadPerc = vf.createURI(litdupsNS, "loadPerc");
@@ -488,7 +490,10 @@ public class RdfCloudTripleStoreConnectionTest extends TestCase {
     }
 
     public void testSubPropertyOf() throws Exception {
-        if(internalInferenceEngine == null) return; //infer not supported;
+        if(internalInferenceEngine == null)
+		 {
+			return; //infer not supported;
+		}
 
         RepositoryConnection conn = repository.getConnection();
         conn.add(new StatementImpl(vf.createURI(litdupsNS, "undergradDegreeFrom"), RDFS.SUBPROPERTYOF, vf.createURI(litdupsNS, "degreeFrom")));
@@ -549,7 +554,10 @@ public class RdfCloudTripleStoreConnectionTest extends TestCase {
     }
 
     public void testEquivPropOf() throws Exception {
-        if(internalInferenceEngine == null) return; //infer not supported;
+        if(internalInferenceEngine == null)
+		 {
+			return; //infer not supported;
+		}
 
         RepositoryConnection conn = repository.getConnection();
         conn.add(new StatementImpl(vf.createURI(litdupsNS, "undergradDegreeFrom"), OWL.EQUIVALENTPROPERTY, vf.createURI(litdupsNS, "ugradDegreeFrom")));
@@ -577,7 +585,10 @@ public class RdfCloudTripleStoreConnectionTest extends TestCase {
     }
 
     public void testSymmPropOf() throws Exception {
-        if(internalInferenceEngine == null) return; //infer not supported;
+        if(internalInferenceEngine == null)
+		 {
+			return; //infer not supported;
+		}
 
         RepositoryConnection conn = repository.getConnection();
         conn.add(new StatementImpl(vf.createURI(litdupsNS, "friendOf"), RDF.TYPE, OWL.SYMMETRICPROPERTY));
@@ -624,7 +635,10 @@ public class RdfCloudTripleStoreConnectionTest extends TestCase {
     }
 
     public void testTransitiveProp() throws Exception {
-        if(internalInferenceEngine == null) return; //infer not supported;
+        if(internalInferenceEngine == null)
+		 {
+			return; //infer not supported;
+		}
 
         RepositoryConnection conn = repository.getConnection();
         conn.add(new StatementImpl(vf.createURI(litdupsNS, "subRegionOf"), RDF.TYPE, OWL.TRANSITIVEPROPERTY));
@@ -684,7 +698,10 @@ public class RdfCloudTripleStoreConnectionTest extends TestCase {
     }
 
     public void testInverseOf() throws Exception {
-        if(internalInferenceEngine == null) return; //infer not supported;
+        if(internalInferenceEngine == null)
+		 {
+			return; //infer not supported;
+		}
 
         RepositoryConnection conn = repository.getConnection();
         conn.add(new StatementImpl(vf.createURI(litdupsNS, "degreeFrom"), OWL.INVERSEOF, vf.createURI(litdupsNS, "hasAlumnus")));
@@ -722,7 +739,10 @@ public class RdfCloudTripleStoreConnectionTest extends TestCase {
     }
 
     public void testSubClassOf() throws Exception {
-        if(internalInferenceEngine == null) return; //infer not supported;
+        if(internalInferenceEngine == null)
+		 {
+			return; //infer not supported;
+		}
 
         RepositoryConnection conn = repository.getConnection();
         conn.add(new StatementImpl(vf.createURI(litdupsNS, "UndergraduateStudent"), RDFS.SUBCLASSOF, vf.createURI(litdupsNS, "Student")));
@@ -781,7 +801,10 @@ public class RdfCloudTripleStoreConnectionTest extends TestCase {
     }
 
     public void testSameAs() throws Exception {
-        if(internalInferenceEngine == null) return; //infer not supported;
+        if(internalInferenceEngine == null)
+		 {
+			return; //infer not supported;
+		}
 
         RepositoryConnection conn = repository.getConnection();
         conn.add(new StatementImpl(vf.createURI(litdupsNS, "StudentA1"), OWL.SAMEAS, vf.createURI(litdupsNS, "StudentA2")));
@@ -850,7 +873,7 @@ public class RdfCloudTripleStoreConnectionTest extends TestCase {
         tupleQuery = conn.prepareTupleQuery(QueryLanguage.SPARQL, query);
         tupleHandler = new CountTupleHandler();
         tupleQuery.evaluate(tupleHandler);
-        assertEquals(1, tupleHandler.getCount()); 
+        assertEquals(1, tupleHandler.getCount());
 
         conn.close();
     }
@@ -1016,11 +1039,12 @@ public class RdfCloudTripleStoreConnectionTest extends TestCase {
 //    }
 
     private static String escape(Value r) {
-        if (r instanceof URI)
-            return "<" + r.toString() +">";
+        if (r instanceof URI) {
+			return "<" + r.toString() +">";
+		}
         return r.toString();
     }
-    
+
     private static String getSparqlUpdate() throws Exception {
         InputStream stream = Thread.currentThread().getContextClassLoader().getResourceAsStream("namedgraphs.trig");
         assertNotNull(stream);
@@ -1053,7 +1077,7 @@ public class RdfCloudTripleStoreConnectionTest extends TestCase {
     // Set the persistence visibilites on the config
     public void testUpdateWAuthOnConfig() throws Exception {
         String sparqlUpdate = getSparqlUpdate();
-        
+
         RdfCloudTripleStore tstore = new MockRdfCloudStore();
         NamespaceManager nm = new NamespaceManager(tstore.getRyaDAO(), tstore.getConf());
         tstore.setNamespaceManager(nm);
@@ -1064,7 +1088,7 @@ public class RdfCloudTripleStoreConnectionTest extends TestCase {
         RepositoryConnection conn = repo.getConnection();
         Update u = conn.prepareUpdate(QueryLanguage.SPARQL, sparqlUpdate);
         u.execute();
-        
+
         String query = "PREFIX  ex:  <http://www.example.org/exampleDocument#>\n" +
                 "PREFIX  voc:  <http://www.example.org/vocabulary#>\n" +
                 "PREFIX  foaf:  <http://xmlns.com/foaf/0.1/>\n" +
@@ -1231,7 +1255,7 @@ public class RdfCloudTripleStoreConnectionTest extends TestCase {
 
         conn.close();
     }
-    
+
     public void testClearGraph() throws Exception {
         RepositoryConnection conn = repository.getConnection();
 
@@ -1263,7 +1287,7 @@ public class RdfCloudTripleStoreConnectionTest extends TestCase {
         CountTupleHandler tupleHandler = new CountTupleHandler();
         tupleQuery.evaluate(tupleHandler);
         assertEquals(4, tupleHandler.getCount());
-        
+
         tupleHandler = new CountTupleHandler();
         conn.clear(new URIImpl("http://example/addresses#G2"));
         tupleQuery.evaluate(tupleHandler);
@@ -1276,7 +1300,7 @@ public class RdfCloudTripleStoreConnectionTest extends TestCase {
 
         conn.close();
     }
-    
+
     public void testClearAllGraph() throws Exception {
         RepositoryConnection conn = repository.getConnection();
 
@@ -1308,7 +1332,7 @@ public class RdfCloudTripleStoreConnectionTest extends TestCase {
         CountTupleHandler tupleHandler = new CountTupleHandler();
         tupleQuery.evaluate(tupleHandler);
         assertEquals(4, tupleHandler.getCount());
-        
+
         tupleHandler = new CountTupleHandler();
         conn.clear();
         tupleQuery.evaluate(tupleHandler);
@@ -1316,7 +1340,7 @@ public class RdfCloudTripleStoreConnectionTest extends TestCase {
 
         conn.close();
     }
-    
+
     public void testDropGraph() throws Exception {
         RepositoryConnection conn = repository.getConnection();
 
@@ -1348,7 +1372,7 @@ public class RdfCloudTripleStoreConnectionTest extends TestCase {
         CountTupleHandler tupleHandler = new CountTupleHandler();
         tupleQuery.evaluate(tupleHandler);
         assertEquals(4, tupleHandler.getCount());
-        
+
         tupleHandler = new CountTupleHandler();
         String drop = "PREFIX ex: <http://example/addresses#>\n" +
                 "DROP GRAPH ex:G2 ";
@@ -1399,7 +1423,7 @@ public class RdfCloudTripleStoreConnectionTest extends TestCase {
     }
 
     private static class PrintTupleHandler implements TupleQueryResultHandler {
-        
+
 
         @Override
         public void startQueryResult(List<String> strings) throws TupleQueryResultHandlerException {
@@ -1430,6 +1454,7 @@ public class RdfCloudTripleStoreConnectionTest extends TestCase {
             Instance instance = new MockInstance();
             try {
                 AccumuloRdfConfiguration conf = new AccumuloRdfConfiguration();
+                conf.setInfer(true);
                 setConf(conf);
                 Connector connector = instance.getConnector("", "");
                 AccumuloRyaDAO cdao = new AccumuloRyaDAO();


### PR DESCRIPTION
Updated config to not use inferencing by default.  Also fixed RyaDirectExample so that it closes all SailRepository and SailRepositoryConnection objects that get created.  