### PR TITLE
RYA-133 Fix broken Mongo Secondary Indexers

### DIFF
--- a/extras/indexing/src/main/java/mvm/rya/indexing/FilterFunctionOptimizer.java
+++ b/extras/indexing/src/main/java/mvm/rya/indexing/FilterFunctionOptimizer.java
@@ -68,6 +68,7 @@ import mvm.rya.indexing.accumulo.freetext.FreeTextTupleSet;
 import mvm.rya.indexing.accumulo.geo.GeoMesaGeoIndexer;
 import mvm.rya.indexing.accumulo.geo.GeoTupleSet;
 import mvm.rya.indexing.accumulo.temporal.AccumuloTemporalIndexer;
+import mvm.rya.indexing.mongodb.AbstractMongoIndexer;
 import mvm.rya.indexing.mongodb.freetext.MongoFreeTextIndexer;
 import mvm.rya.indexing.mongodb.geo.MongoGeoIndexer;
 import mvm.rya.indexing.mongodb.temporal.MongoTemporalIndexer;
@@ -101,23 +102,23 @@ public class FilterFunctionOptimizer implements QueryOptimizer, Configurable {
         init = false;
         try {
             init();
-        } catch (final NumberFormatException | UnknownHostException e) {
+        } catch (final NumberFormatException | IOException e) {
             LOG.error("Unable to update to use new config, falling back to the old config.", e);
             init = true;
         }
     }
 
-    private synchronized void init() throws NumberFormatException, UnknownHostException {
+    private synchronized void init() throws NumberFormatException, IOException {
         if (!init) {
             if (ConfigUtils.getUseMongo(conf)) {
                 try {
                     final MongoClient mongoClient = MongoConnectorFactory.getMongoClient(conf);
-                    geoIndexer = new MongoGeoIndexer(mongoClient);
-                    geoIndexer.setConf(conf);
-                    freeTextIndexer = new MongoFreeTextIndexer(mongoClient);
-                    freeTextIndexer.setConf(conf);
-                    temporalIndexer = new MongoTemporalIndexer(mongoClient);
-                    temporalIndexer.setConf(conf);
+                    geoIndexer = new MongoGeoIndexer();
+                    ((AbstractMongoIndexer) geoIndexer).initIndexer(conf, mongoClient);
+                    freeTextIndexer = new MongoFreeTextIndexer();
+                    ((AbstractMongoIndexer)freeTextIndexer).initIndexer(conf, mongoClient);
+                    temporalIndexer = new MongoTemporalIndexer();
+                    ((AbstractMongoIndexer)temporalIndexer).initIndexer(conf, mongoClient);
                 } catch (NumberFormatException | UnknownHostException e) {
                     LOG.error("Unable to connect to mongo.", e);
                     throw e;

--- a/extras/indexing/src/main/java/mvm/rya/indexing/mongodb/AbstractMongoIndexer.java
+++ b/extras/indexing/src/main/java/mvm/rya/indexing/mongodb/AbstractMongoIndexer.java
@@ -1,7 +1,5 @@
 package mvm.rya.indexing.mongodb;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -46,6 +44,7 @@ import mvm.rya.api.persist.index.RyaSecondaryIndexer;
 import mvm.rya.api.resolver.RyaToRdfConversions;
 import mvm.rya.indexing.StatementConstraints;
 import mvm.rya.mongodb.MongoDBRdfConfiguration;
+import mvm.rya.mongodb.MongoDBRyaDAO;
 
 /**
  * Secondary Indexer using MondoDB
@@ -56,6 +55,7 @@ public abstract class AbstractMongoIndexer<T extends IndexingMongoDBStorageStrat
 
     private boolean isInit = false;
     protected Configuration conf;
+    protected MongoDBRyaDAO dao;
     protected MongoClient mongoClient;
     protected String dbName;
     protected DB db;
@@ -64,23 +64,15 @@ public abstract class AbstractMongoIndexer<T extends IndexingMongoDBStorageStrat
 
     protected T storageStrategy;
 
-    /**
-     * Creates a new {@link AbstractMongoIndexer} with the provided mongo client.
-     * @param mongoClient The {@link MongoClient} to use with this indexer.
-     */
-    public AbstractMongoIndexer(final MongoClient mongoClient) {
-        this.mongoClient = checkNotNull(mongoClient);
-    }
-
     protected void init() throws NumberFormatException, IOException{
         dbName = conf.get(MongoDBRdfConfiguration.MONGO_DB_NAME);
         db = this.mongoClient.getDB(dbName);
         collection = db.getCollection(conf.get(MongoDBRdfConfiguration.MONGO_COLLECTION_PREFIX, "rya") + getCollectionName());
     }
 
-    @Override
-    public void setConf(final Configuration conf) {
-        this.conf = conf;
+    public void initIndexer(final Configuration conf, final MongoClient client) throws NumberFormatException, IOException {
+        this.mongoClient = client;
+        setConf(conf);
         if (!isInit) {
             try {
                 init();
@@ -90,6 +82,11 @@ public abstract class AbstractMongoIndexer<T extends IndexingMongoDBStorageStrat
                 throw new RuntimeException(e);
             }
         }
+    }
+
+    @Override
+    public void setConf(final Configuration conf) {
+        this.conf = conf;
     }
 
     @Override

--- a/extras/indexing/src/main/java/mvm/rya/indexing/mongodb/freetext/MongoFreeTextIndexer.java
+++ b/extras/indexing/src/main/java/mvm/rya/indexing/mongodb/freetext/MongoFreeTextIndexer.java
@@ -24,7 +24,6 @@ import org.apache.log4j.Logger;
 import org.openrdf.model.Statement;
 import org.openrdf.query.QueryEvaluationException;
 
-import com.mongodb.MongoClient;
 import com.mongodb.QueryBuilder;
 
 import info.aduna.iteration.CloseableIteration;
@@ -35,10 +34,6 @@ import mvm.rya.indexing.mongodb.AbstractMongoIndexer;
 
 public class MongoFreeTextIndexer extends AbstractMongoIndexer<TextMongoDBStorageStrategy> implements FreeTextIndexer {
     private static final Logger logger = Logger.getLogger(MongoFreeTextIndexer.class);
-
-    public MongoFreeTextIndexer(final MongoClient mongoClient) {
-        super(mongoClient);
-    }
 
     @Override
     protected void init() throws IOException{

--- a/extras/indexing/src/main/java/mvm/rya/indexing/mongodb/geo/MongoGeoIndexer.java
+++ b/extras/indexing/src/main/java/mvm/rya/indexing/mongodb/geo/MongoGeoIndexer.java
@@ -29,7 +29,6 @@ import org.openrdf.model.Statement;
 import org.openrdf.query.QueryEvaluationException;
 
 import com.mongodb.DBObject;
-import com.mongodb.MongoClient;
 import com.vividsolutions.jts.geom.Geometry;
 
 import info.aduna.iteration.CloseableIteration;
@@ -42,10 +41,6 @@ import mvm.rya.mongodb.MongoDBRdfConfiguration;
 
 public class MongoGeoIndexer extends AbstractMongoIndexer<GeoMongoDBStorageStrategy> implements GeoIndexer {
     private static final Logger logger = Logger.getLogger(MongoGeoIndexer.class);
-
-    public MongoGeoIndexer(final MongoClient mongoClient) {
-        super(mongoClient);
-    }
 
     @Override
     protected void init() throws NumberFormatException, IOException{

--- a/extras/indexing/src/main/java/mvm/rya/indexing/mongodb/temporal/MongoTemporalIndexer.java
+++ b/extras/indexing/src/main/java/mvm/rya/indexing/mongodb/temporal/MongoTemporalIndexer.java
@@ -30,7 +30,6 @@ import org.openrdf.query.QueryEvaluationException;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.mongodb.DBCollection;
-import com.mongodb.MongoClient;
 import com.mongodb.QueryBuilder;
 
 import info.aduna.iteration.CloseableIteration;
@@ -46,14 +45,6 @@ import mvm.rya.indexing.mongodb.AbstractMongoIndexer;
  */
 public class MongoTemporalIndexer extends AbstractMongoIndexer<TemporalMongoDBStorageStrategy> implements TemporalIndexer {
     private static final Logger LOG = Logger.getLogger(MongoTemporalIndexer.class);
-
-    /**
-     * Creates a new {@link MongoTemporalIndexer}
-     * @param mongoClient - The {@link MongoClient} used to interact with MongoDB.
-     */
-    public MongoTemporalIndexer(final MongoClient mongoClient) {
-        super(mongoClient);
-    }
 
     @Override
     protected void init() throws IOException{

--- a/extras/indexing/src/test/java/mvm/rya/indexing/mongo/MongoFreeTextIndexerTest.java
+++ b/extras/indexing/src/test/java/mvm/rya/indexing/mongo/MongoFreeTextIndexerTest.java
@@ -69,8 +69,8 @@ public class MongoFreeTextIndexerTest {
 
      @Test
     public void testSearch() throws Exception {
-        try (MongoFreeTextIndexer f = new MongoFreeTextIndexer(mongoClient)) {
-            f.setConf(conf);
+        try (MongoFreeTextIndexer f = new MongoFreeTextIndexer()) {
+            f.initIndexer(conf, mongoClient);
 
             final ValueFactory vf = new ValueFactoryImpl();
 
@@ -93,8 +93,8 @@ public class MongoFreeTextIndexerTest {
 
     @Test
     public void testDelete() throws Exception {
-        try (MongoFreeTextIndexer f = new MongoFreeTextIndexer(mongoClient)) {
-            f.setConf(conf);
+        try (MongoFreeTextIndexer f = new MongoFreeTextIndexer()) {
+            f.initIndexer(conf, mongoClient);
 
             final ValueFactory vf = new ValueFactoryImpl();
 
@@ -143,8 +143,8 @@ public class MongoFreeTextIndexerTest {
     public void testRestrictPredicatesSearch() throws Exception {
         conf.setStrings(ConfigUtils.FREETEXT_PREDICATES_LIST, "pred:1,pred:2");
 
-        try (MongoFreeTextIndexer f = new MongoFreeTextIndexer(mongoClient)) {
-            f.setConf(conf);
+        try (MongoFreeTextIndexer f = new MongoFreeTextIndexer()) {
+            f.initIndexer(conf, mongoClient);
 
             // These should not be stored because they are not in the predicate list
             f.storeStatement(new RyaStatement(new RyaURI("foo:subj1"), new RyaURI(RDFS.LABEL.toString()), new RyaType("invalid")));
@@ -176,8 +176,8 @@ public class MongoFreeTextIndexerTest {
 
     @Test
     public void testContextSearch() throws Exception {
-        try (MongoFreeTextIndexer f = new MongoFreeTextIndexer(mongoClient)) {
-            f.setConf(conf);
+        try (MongoFreeTextIndexer f = new MongoFreeTextIndexer()) {
+            f.initIndexer(conf, mongoClient);
 
             final ValueFactory vf = new ValueFactoryImpl();
             final URI subject = new URIImpl("foo:subj");

--- a/extras/indexing/src/test/java/mvm/rya/indexing/mongo/MongoGeoIndexerSfTest.java
+++ b/extras/indexing/src/test/java/mvm/rya/indexing/mongo/MongoGeoIndexerSfTest.java
@@ -121,8 +121,8 @@ public class MongoGeoIndexerSfTest {
 
         final MongodForTestsFactory testsFactory = MongodForTestsFactory.with(Version.Main.PRODUCTION);
         final MongoClient mongoClient = testsFactory.newMongo();
-        g = new MongoGeoIndexer(mongoClient);
-        g.setConf(conf);
+        g = new MongoGeoIndexer();
+        g.initIndexer(conf, mongoClient);
         g.storeStatement(statement(A));
         g.storeStatement(statement(B));
         g.storeStatement(statement(C));

--- a/extras/indexing/src/test/java/mvm/rya/indexing/mongo/MongoGeoIndexerTest.java
+++ b/extras/indexing/src/test/java/mvm/rya/indexing/mongo/MongoGeoIndexerTest.java
@@ -87,8 +87,8 @@ public class MongoGeoIndexerTest {
     @Test
     public void testRestrictPredicatesSearch() throws Exception {
         conf.setStrings(ConfigUtils.GEO_PREDICATES_LIST, "pred:1,pred:2");
-        try (MongoGeoIndexer f = new MongoGeoIndexer(mongoClient)) {
-            f.setConf(conf);
+        try (MongoGeoIndexer f = new MongoGeoIndexer()) {
+            f.initIndexer(conf, mongoClient);
 
             final ValueFactory vf = new ValueFactoryImpl();
 
@@ -134,8 +134,8 @@ public class MongoGeoIndexerTest {
 
     @Test
     public void testPrimeMeridianSearch() throws Exception {
-        try (MongoGeoIndexer f = new MongoGeoIndexer(mongoClient)) {
-            f.setConf(conf);
+        try (MongoGeoIndexer f = new MongoGeoIndexer()) {
+            f.initIndexer(conf, mongoClient);
 
             final ValueFactory vf = new ValueFactoryImpl();
             final Resource subject = vf.createURI("foo:subj");
@@ -178,8 +178,8 @@ public class MongoGeoIndexerTest {
     @Test
     public void testDcSearch() throws Exception {
         // test a ring around dc
-        try (MongoGeoIndexer f = new MongoGeoIndexer(mongoClient)) {
-            f.setConf(conf);
+        try (MongoGeoIndexer f = new MongoGeoIndexer()) {
+            f.initIndexer(conf, mongoClient);
 
             final ValueFactory vf = new ValueFactoryImpl();
             final Resource subject = vf.createURI("foo:subj");
@@ -207,8 +207,8 @@ public class MongoGeoIndexerTest {
     @Test
     public void testDeleteSearch() throws Exception {
         // test a ring around dc
-        try (MongoGeoIndexer f = new MongoGeoIndexer(mongoClient)) {
-            f.setConf(conf);
+        try (MongoGeoIndexer f = new MongoGeoIndexer()) {
+            f.initIndexer(conf, mongoClient);
 
             final ValueFactory vf = new ValueFactoryImpl();
             final Resource subject = vf.createURI("foo:subj");
@@ -246,8 +246,8 @@ public class MongoGeoIndexerTest {
     @Test
     public void testDcSearchWithContext() throws Exception {
         // test a ring around dc
-        try (MongoGeoIndexer f = new MongoGeoIndexer(mongoClient)) {
-            f.setConf(conf);
+        try (MongoGeoIndexer f = new MongoGeoIndexer()) {
+            f.initIndexer(conf, mongoClient);
 
             final ValueFactory vf = new ValueFactoryImpl();
             final Resource subject = vf.createURI("foo:subj");
@@ -275,8 +275,8 @@ public class MongoGeoIndexerTest {
     @Test
     public void testDcSearchWithSubject() throws Exception {
         // test a ring around dc
-        try (MongoGeoIndexer f = new MongoGeoIndexer(mongoClient)) {
-            f.setConf(conf);
+        try (MongoGeoIndexer f = new MongoGeoIndexer()) {
+            f.initIndexer(conf, mongoClient);
 
             final ValueFactory vf = new ValueFactoryImpl();
             final Resource subject = vf.createURI("foo:subj");
@@ -303,8 +303,8 @@ public class MongoGeoIndexerTest {
     @Test
     public void testDcSearchWithSubjectAndContext() throws Exception {
         // test a ring around dc
-        try (MongoGeoIndexer f = new MongoGeoIndexer(mongoClient)) {
-            f.setConf(conf);
+        try (MongoGeoIndexer f = new MongoGeoIndexer()) {
+            f.initIndexer(conf, mongoClient);
 
             final ValueFactory vf = new ValueFactoryImpl();
             final Resource subject = vf.createURI("foo:subj");
@@ -336,8 +336,8 @@ public class MongoGeoIndexerTest {
     @Test
     public void testDcSearchWithPredicate() throws Exception {
         // test a ring around dc
-        try (MongoGeoIndexer f = new MongoGeoIndexer(mongoClient)) {
-            f.setConf(conf);
+        try (MongoGeoIndexer f = new MongoGeoIndexer()) {
+            f.initIndexer(conf, mongoClient);
 
             final ValueFactory vf = new ValueFactoryImpl();
             final Resource subject = vf.createURI("foo:subj");
@@ -366,8 +366,8 @@ public class MongoGeoIndexerTest {
     // @Test
     public void testAntiMeridianSearch() throws Exception {
         // verify that a search works if the bounding box crosses the anti meridian
-        try (MongoGeoIndexer f = new MongoGeoIndexer(mongoClient)) {
-            f.setConf(conf);
+        try (MongoGeoIndexer f = new MongoGeoIndexer()) {
+            f.initIndexer(conf, mongoClient);
 
             final ValueFactory vf = new ValueFactoryImpl();
             final Resource context = vf.createURI("foo:context");

--- a/extras/indexing/src/test/java/mvm/rya/indexing/mongo/MongoTemporalIndexerTest.java
+++ b/extras/indexing/src/test/java/mvm/rya/indexing/mongo/MongoTemporalIndexerTest.java
@@ -199,8 +199,8 @@ public final class MongoTemporalIndexerTest {
 
         final MongodForTestsFactory testsFactory = MongodForTestsFactory.with(Version.Main.PRODUCTION);
         final MongoClient mongoClient = testsFactory.newMongo();
-        tIndexer = new MongoTemporalIndexer(mongoClient);
-        tIndexer.setConf(conf);
+        tIndexer = new MongoTemporalIndexer();
+        tIndexer.initIndexer(conf, mongoClient);
 
 
         final String dbName = conf.get(MongoDBRdfConfiguration.MONGO_DB_NAME);


### PR DESCRIPTION
## Description
>What changed?
The secondary indexers need an empty constructor.  Moved back to an init() call instead, leave empty constructor open for the reflexive calls.

### Links
[Jira](https://issues.apache.org/jira/browse/RYA-133)

### Checklist
- [ ] Code Review
- [x] Squash commits

#### People To Review
@dlotts