### PR TITLE
RYA-154 Decoupled Updater Configuration from PCJ Configuration

### DIFF
--- a/extras/indexing/src/main/java/mvm/rya/indexing/accumulo/ConfigUtils.java
+++ b/extras/indexing/src/main/java/mvm/rya/indexing/accumulo/ConfigUtils.java
@@ -97,6 +97,7 @@ public class ConfigUtils {
     public static final String USE_ENTITY = "sc.use_entity";
     public static final String USE_PCJ = "sc.use_pcj";
     public static final String USE_OPTIMAL_PCJ = "sc.use.optimal.pcj";
+    public static final String USE_PCJ_UPDATER_INDEX = "sc.use.updater";
 
     public static final String FLUO_APP_NAME = "rya.indexing.pcj.fluo.fluoAppName";
     public static final String USE_PCJ_FLUO_UPDATER = "rya.indexing.pcj.updater.fluo";
@@ -373,6 +374,10 @@ public class ConfigUtils {
     public static boolean getUseOptimalPCJ(final Configuration conf) {
         return conf.getBoolean(USE_OPTIMAL_PCJ, false);
     }
+    
+    public static boolean getUsePcjUpdaterIndex(final Configuration conf) {
+        return conf.getBoolean(USE_PCJ_UPDATER_INDEX, false);
+    }
 
 
     /**
@@ -408,10 +413,13 @@ public class ConfigUtils {
             }
         } else {
 
-            if (getUsePCJ(conf) || getUseOptimalPCJ(conf)) {
-                conf.setPcjOptimizer(PCJOptimizer.class);
-                indexList.add(PrecomputedJoinIndexer.class.getName());
-            }
+        	 if (getUsePCJ(conf) || getUseOptimalPCJ(conf)) {
+                 conf.setPcjOptimizer(PCJOptimizer.class);
+             }
+             
+             if(getUsePcjUpdaterIndex(conf)) {
+             	indexList.add(PrecomputedJoinIndexer.class.getName());
+             }
 
             if (getUseGeo(conf)) {
                 indexList.add(GeoMesaGeoIndexer.class.getName());

--- a/extras/rya.pcj.fluo/pcj.fluo.integration/src/test/java/org/apache/rya/indexing/pcj/fluo/ITBase.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.integration/src/test/java/org/apache/rya/indexing/pcj/fluo/ITBase.java
@@ -371,6 +371,7 @@ public abstract class ITBase {
         conf.set(ConfigUtils.CLOUDBASE_INSTANCE, instanceName);
         conf.set(ConfigUtils.CLOUDBASE_ZOOKEEPERS, zookeepers);
         conf.set(ConfigUtils.USE_PCJ, "true");
+        conf.set(ConfigUtils.USE_PCJ_UPDATER_INDEX, "true");
         conf.set(ConfigUtils.USE_PCJ_FLUO_UPDATER, "true");
         conf.set(ConfigUtils.FLUO_APP_NAME, appName);
         conf.set(ConfigUtils.PCJ_STORAGE_TYPE,


### PR DESCRIPTION
Decoupled PrecomputedJoinIndexer configuration from PCJ configuration.  Users who want to use PCJs (which is a query based configuration) should not also be using the PrecomputedJoinIndexer (which affects ingest).