### PR TITLE
Rya 106 - Ensure users are able to access all or none of a Rya instance's tables.

### DIFF
--- a/common/rya.api/src/main/java/org/apache/rya/api/client/AddUser.java
+++ b/common/rya.api/src/main/java/org/apache/rya/api/client/AddUser.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.api.client;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Grants a user access to an instance of Rya.
+ */
+@DefaultAnnotation(NonNull.class)
+public interface AddUser {
+
+    /**
+     * Grants access to a specific Rya instance to a user of the storage system.
+     *
+     * @param instanceName - Indicates which Rya instance will be granted to the user. (not null)
+     * @param username - The user whose access will be granted. (not null)
+     * @throws InstanceDoesNotExistException No instance of Rya exists for the provided name.
+     * @throws RyaClientException Something caused the command to fail.
+     */
+    public void addUser(String instanceName, String username) throws InstanceDoesNotExistException, RyaClientException;
+}

--- a/common/rya.api/src/main/java/org/apache/rya/api/client/RemoveUser.java
+++ b/common/rya.api/src/main/java/org/apache/rya/api/client/RemoveUser.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.api.client;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Revokes a user's access to an instance of Rya.
+ */
+@DefaultAnnotation(NonNull.class)
+public interface RemoveUser {
+
+    /**
+     * Revokes access to a specific Rya instance from a user of the storage system.
+     *
+     * @param instanceName - Indicates which Rya instance will be revoked from the user. (not null)
+     * @param username - The user whose access will be revoked. (not null)
+     * @throws InstanceDoesNotExistException No instance of Rya exists for the provided name.
+     * @throws RyaClientException Something caused the command to fail.
+     */
+    public void removeUser(String instanceName, String username) throws InstanceDoesNotExistException, RyaClientException;
+}

--- a/common/rya.api/src/main/java/org/apache/rya/api/client/RyaClient.java
+++ b/common/rya.api/src/main/java/org/apache/rya/api/client/RyaClient.java
@@ -34,10 +34,12 @@ public class RyaClient {
     private final Install install;
     private final CreatePCJ createPcj;
     private final DeletePCJ deletePcj;
-    private final BatchUpdatePCJ batchUpdatePcj;
+    private final BatchUpdatePCJ bactchUpdatePCJ;
     private final GetInstanceDetails getInstanceDetails;
     private final InstanceExists instanceExists;
     private final ListInstances listInstances;
+    private final AddUser addUser;
+    private final RemoveUser removeUser;
 
     /**
      * Constructs an instance of {@link RyaClient}.
@@ -49,14 +51,18 @@ public class RyaClient {
             final BatchUpdatePCJ batchUpdatePcj,
             final GetInstanceDetails getInstanceDetails,
             final InstanceExists instanceExists,
-            final ListInstances listInstances) {
+            final ListInstances listInstances,
+            final AddUser addUser,
+            final RemoveUser removeUser) {
         this.install = requireNonNull(install);
         this.createPcj = requireNonNull(createPcj);
         this.deletePcj = requireNonNull(deletePcj);
-        this.batchUpdatePcj = requireNonNull(batchUpdatePcj);
+        bactchUpdatePCJ = requireNonNull(batchUpdatePcj);
         this.getInstanceDetails = requireNonNull(getInstanceDetails);
         this.instanceExists = requireNonNull(instanceExists);
         this.listInstances = requireNonNull(listInstances);
+        this.addUser = requireNonNull(addUser);
+        this.removeUser = requireNonNull(removeUser);
     }
 
     /**
@@ -83,11 +89,11 @@ public class RyaClient {
     }
 
     /**
-     * @return An instnace of {@link BatchUpdatePCJ} that is connected to a Rya storage
+     * @return An instance of {@link BatchUpdatePCJ} that is connect to a Rya storage
      *   if the Rya instance supports PCJ indexing.
      */
     public BatchUpdatePCJ getBatchUpdatePCJ() {
-        return batchUpdatePcj;
+        return bactchUpdatePCJ;
     }
 
     /**
@@ -109,5 +115,19 @@ public class RyaClient {
      */
     public InstanceExists getInstanceExists() {
         return instanceExists;
+    }
+
+    /**
+     * @return An instance of {@link AddUser} that is connected to a Rya storage.
+     */
+    public AddUser getAddUser() {
+        return addUser;
+    }
+
+    /**
+     * @return An instance of {@link DeleteUser} that is connected to a Rya storage.
+     */
+    public RemoveUser getRemoveUser() {
+        return removeUser;
     }
 }

--- a/common/rya.api/src/main/java/org/apache/rya/api/instance/RyaDetails.java
+++ b/common/rya.api/src/main/java/org/apache/rya/api/instance/RyaDetails.java
@@ -1,6 +1,4 @@
-package org.apache.rya.api.instance;
-
-/*
+/**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -9,7 +7,7 @@ package org.apache.rya.api.instance;
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -18,12 +16,15 @@ package org.apache.rya.api.instance;
  * specific language governing permissions and limitations
  * under the License.
  */
+package org.apache.rya.api.instance;
 
 import static java.util.Objects.requireNonNull;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -33,7 +34,11 @@ import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import net.jcip.annotations.Immutable;
 
+import org.apache.rya.api.instance.RyaDetails.PCJIndexDetails;
+import org.apache.rya.api.instance.RyaDetails.PCJIndexDetails.PCJDetails;
+
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 /**
@@ -47,10 +52,14 @@ public class RyaDetails implements Serializable {
     // General metadata about the instance.
     private final String instanceName;
     private final String version;
+    private final ImmutableList<String> users;
 
     // Secondary Index Details.
     private final EntityCentricIndexDetails entityCentricDetails;
-    private final GeoIndexDetails geoDetails;
+    /**
+     * RYA- 215
+     * private final GeoIndexDetails geoDetails;
+     */
     private final PCJIndexDetails pcjDetails;
     private final TemporalIndexDetails temporalDetails;
     private final FreeTextIndexDetails freeTextDetails;
@@ -66,8 +75,9 @@ public class RyaDetails implements Serializable {
     private RyaDetails(
             final String instanceName,
             final String version,
+            final ImmutableList<String> users,
             final EntityCentricIndexDetails entityCentricDetails,
-            final GeoIndexDetails geoDetails,
+//RYA-215            final GeoIndexDetails geoDetails,
             final PCJIndexDetails pcjDetails,
             final TemporalIndexDetails temporalDetails,
             final FreeTextIndexDetails freeTextDetails,
@@ -75,8 +85,9 @@ public class RyaDetails implements Serializable {
             final JoinSelectivityDetails joinSelectivityDetails) {
         this.instanceName = requireNonNull(instanceName);
         this.version = requireNonNull(version);
+        this.users = requireNonNull(users);
         this.entityCentricDetails = requireNonNull(entityCentricDetails);
-        this.geoDetails = requireNonNull(geoDetails);
+      //RYA-215        this.geoDetails = requireNonNull(geoDetails);
         this.pcjDetails = requireNonNull(pcjDetails);
         this.temporalDetails = requireNonNull(temporalDetails);
         this.freeTextDetails = requireNonNull(freeTextDetails);
@@ -100,6 +111,13 @@ public class RyaDetails implements Serializable {
     }
 
     /**
+     * @return The users who have been granted access to the Rya instance.
+     */
+    public ImmutableList<String> getUsers() {
+        return users;
+    }
+
+    /**
      * @return Information about the instance's Entity Centric Index.
      */
     public EntityCentricIndexDetails getEntityCentricIndexDetails() {
@@ -108,10 +126,12 @@ public class RyaDetails implements Serializable {
 
     /**
      * @return Information about the instance's Geospatial Index.
+     *
+     * RYA-215
      */
-    public GeoIndexDetails getGeoIndexDetails() {
+/*    public GeoIndexDetails getGeoIndexDetails() {
         return geoDetails;
-    }
+    }*/
 
     /**
      * @return Information about the instance's Precomputed Join Index.
@@ -154,7 +174,7 @@ public class RyaDetails implements Serializable {
                 instanceName,
                 version,
                 entityCentricDetails,
-                geoDetails,
+              //RYA-215                geoDetails,
                 pcjDetails,
                 temporalDetails,
                 freeTextDetails,
@@ -172,7 +192,7 @@ public class RyaDetails implements Serializable {
             return Objects.equals(instanceName, details.instanceName) &&
                     Objects.equals(version, details.version) &&
                     Objects.equals(entityCentricDetails, details.entityCentricDetails) &&
-                    Objects.equals(geoDetails, details.geoDetails) &&
+                  //RYA-215                    Objects.equals(geoDetails, details.geoDetails) &&
                     Objects.equals(pcjDetails, details.pcjDetails) &&
                     Objects.equals(temporalDetails, details.temporalDetails) &&
                     Objects.equals(freeTextDetails, details.freeTextDetails) &&
@@ -206,6 +226,7 @@ public class RyaDetails implements Serializable {
         // General metadata about the instance.
         private String instanceName;
         private String version;
+        private final List<String> users = new ArrayList<>();
 
         // Secondary Index Details.
         private EntityCentricIndexDetails entityCentricDetails;
@@ -233,8 +254,9 @@ public class RyaDetails implements Serializable {
             requireNonNull(details);
             instanceName = details.instanceName;
             version = details.version;
+            users.addAll( details.users );
             entityCentricDetails = details.entityCentricDetails;
-            geoDetails = details.geoDetails;
+          //RYA-215            geoDetails = details.geoDetails;
             pcjIndexDetailsBuilder = PCJIndexDetails.builder( details.pcjDetails );
             temporalDetails = details.temporalDetails;
             freeTextDetails = details.freeTextDetails;
@@ -262,6 +284,24 @@ public class RyaDetails implements Serializable {
         }
 
         /**
+         * @param user - A user who is granted access to the Rya instance.
+         * @return This {@link Builder} so that method invocations may be chained.
+         */
+        public Builder addUser(final String user) {
+            users.add( user );
+            return this;
+        }
+
+        /**
+         * @param user - A user who is revoked access to the Rya isntance.
+         * @return This {@link Builder} so that method invocations may be chained.
+         */
+        public Builder removeUser(final String user) {
+            users.remove( user );
+            return this;
+        }
+
+        /**
          * @param entityCentricDetails - Information about the instance's Entity Centric Index.
          * @return This {@link Builder} so that method invocations may be chained.
          */
@@ -275,10 +315,11 @@ public class RyaDetails implements Serializable {
          * @param geoDetails - Information about the instance's Geospatial Index.
          * @return This {@link Builder} so that method invocations may be chained.
          */
-        public Builder setGeoIndexDetails(@Nullable final GeoIndexDetails geoDetails) {
+        /*//RYA-215
+         * public Builder setGeoIndexDetails(@Nullable final GeoIndexDetails geoDetails) {
             this.geoDetails = geoDetails;
             return this;
-        }
+        }*/
 
         /**
          * @param temporalDetails - Information about the instance's Temporal Index.
@@ -303,7 +344,7 @@ public class RyaDetails implements Serializable {
          * @return This {@link Builder} so that method invocations may be chained.
          */
         public Builder setPCJIndexDetails(@Nullable final PCJIndexDetails.Builder pcjDetailsBuilder) {
-            this.pcjIndexDetailsBuilder = pcjDetailsBuilder;
+            pcjIndexDetailsBuilder = pcjDetailsBuilder;
             return this;
         }
 
@@ -341,8 +382,9 @@ public class RyaDetails implements Serializable {
             return new RyaDetails(
                     instanceName,
                     version,
+                    ImmutableList.copyOf( users ),
                     entityCentricDetails,
-                    geoDetails,
+                  //RYA-215                    geoDetails,
                     pcjIndexDetailsBuilder.build(),
                     temporalDetails,
                     freeTextDetails,
@@ -640,8 +682,8 @@ public class RyaDetails implements Serializable {
              */
             public Builder(final PCJIndexDetails pcjIndexDetails) {
                 requireNonNull(pcjIndexDetails);
-                this.enabled = pcjIndexDetails.enabled;
-                this.fluoDetails = pcjIndexDetails.fluoDetails.orNull();
+                enabled = pcjIndexDetails.enabled;
+                fluoDetails = pcjIndexDetails.fluoDetails.orNull();
 
                 for(final PCJDetails pcjDetails : pcjIndexDetails.pcjDetails.values()) {
                     pcjDetailsBuilders.put(pcjDetails.getId(), PCJDetails.builder(pcjDetails));
@@ -673,7 +715,7 @@ public class RyaDetails implements Serializable {
              */
             public Builder addPCJDetails(@Nullable final PCJDetails.Builder pcjDetailsBuilder) {
                 if(pcjDetailsBuilder != null) {
-                    this.pcjDetailsBuilders.put(pcjDetailsBuilder.getId(), pcjDetailsBuilder);
+                    pcjDetailsBuilders.put(pcjDetailsBuilder.getId(), pcjDetailsBuilder);
                 }
                 return this;
             }
@@ -684,7 +726,7 @@ public class RyaDetails implements Serializable {
              */
             public Builder removePCJDetails(@Nullable final String pcjId) {
                 requireNonNull(pcjId);
-                this.pcjDetailsBuilders.remove(pcjId);
+                pcjDetailsBuilders.remove(pcjId);
                 return this;
             }
 
@@ -859,9 +901,9 @@ public class RyaDetails implements Serializable {
                  */
                 public Builder(final PCJDetails details) {
                     requireNonNull(details);
-                    this.id = details.id;
-                    this.updateStrategy = details.updateStrategy.orNull();
-                    this.lastUpdateTime = details.lastUpdateTime.orNull();
+                    id = details.id;
+                    updateStrategy = details.updateStrategy.orNull();
+                    lastUpdateTime = details.lastUpdateTime.orNull();
                 }
 
                 /**

--- a/common/rya.api/src/main/java/org/apache/rya/api/instance/RyaDetailsToConfiguration.java
+++ b/common/rya.api/src/main/java/org/apache/rya/api/instance/RyaDetailsToConfiguration.java
@@ -50,7 +50,7 @@ public class RyaDetailsToConfiguration {
 
         checkAndSet(conf, ConfigurationFields.USE_ENTITY, details.getEntityCentricIndexDetails().isEnabled());
         checkAndSet(conf, ConfigurationFields.USE_FREETEXT, details.getFreeTextIndexDetails().isEnabled());
-        checkAndSet(conf, ConfigurationFields.USE_GEO, details.getGeoIndexDetails().isEnabled());
+      //RYA-215        checkAndSet(conf, ConfigurationFields.USE_GEO, details.getGeoIndexDetails().isEnabled());
         checkAndSet(conf, ConfigurationFields.USE_TEMPORAL, details.getTemporalIndexDetails().isEnabled());
         checkAndSet(conf, ConfigurationFields.USE_PCJ, details.getPCJIndexDetails().isEnabled());
     }

--- a/common/rya.api/src/test/java/org/apache/rya/api/instance/RyaDetailsTest.java
+++ b/common/rya.api/src/test/java/org/apache/rya/api/instance/RyaDetailsTest.java
@@ -23,13 +23,8 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.Date;
 
-import org.junit.Test;
-
-import com.google.common.base.Optional;
-
 import org.apache.rya.api.instance.RyaDetails.EntityCentricIndexDetails;
 import org.apache.rya.api.instance.RyaDetails.FreeTextIndexDetails;
-import org.apache.rya.api.instance.RyaDetails.GeoIndexDetails;
 import org.apache.rya.api.instance.RyaDetails.JoinSelectivityDetails;
 import org.apache.rya.api.instance.RyaDetails.PCJIndexDetails;
 import org.apache.rya.api.instance.RyaDetails.PCJIndexDetails.FluoDetails;
@@ -37,6 +32,9 @@ import org.apache.rya.api.instance.RyaDetails.PCJIndexDetails.PCJDetails;
 import org.apache.rya.api.instance.RyaDetails.PCJIndexDetails.PCJDetails.PCJUpdateStrategy;
 import org.apache.rya.api.instance.RyaDetails.ProspectorDetails;
 import org.apache.rya.api.instance.RyaDetails.TemporalIndexDetails;
+import org.junit.Test;
+
+import com.google.common.base.Optional;
 
 /**
  * Tests the methods of {@link RyaDetails}.
@@ -50,7 +48,7 @@ public class RyaDetailsTest {
         builder.setRyaInstanceName("test_instance")
             .setRyaVersion("1.2.3.4")
             .setEntityCentricIndexDetails( new EntityCentricIndexDetails(true) )
-            .setGeoIndexDetails( new GeoIndexDetails(true) )
+          //RYA-215            .setGeoIndexDetails( new GeoIndexDetails(true) )
             .setTemporalIndexDetails( new TemporalIndexDetails(true) )
             .setFreeTextDetails( new FreeTextIndexDetails(true) )
             .setPCJIndexDetails(
@@ -81,7 +79,7 @@ public class RyaDetailsTest {
         builder.setRyaInstanceName("test_instance")
             .setRyaVersion("1.2.3.4")
             .setEntityCentricIndexDetails( new EntityCentricIndexDetails(true) )
-            .setGeoIndexDetails( new GeoIndexDetails(true) )
+          //RYA-215            .setGeoIndexDetails( new GeoIndexDetails(true) )
             .setTemporalIndexDetails( new TemporalIndexDetails(true) )
             .setFreeTextDetails( new FreeTextIndexDetails(true) )
             .setPCJIndexDetails(
@@ -111,7 +109,7 @@ public class RyaDetailsTest {
             .setRyaInstanceName("test_instance")
             .setRyaVersion("1.2.3.4")
             .setEntityCentricIndexDetails( new EntityCentricIndexDetails(true) )
-            .setGeoIndexDetails( new GeoIndexDetails(true) )
+          //RYA-215            .setGeoIndexDetails( new GeoIndexDetails(true) )
             .setTemporalIndexDetails( new TemporalIndexDetails(true) )
             .setFreeTextDetails( new FreeTextIndexDetails(true) )
             .setPCJIndexDetails(

--- a/common/rya.api/src/test/java/org/apache/rya/api/instance/RyaDetailsToConfigurationTest.java
+++ b/common/rya.api/src/test/java/org/apache/rya/api/instance/RyaDetailsToConfigurationTest.java
@@ -21,7 +21,6 @@ package org.apache.rya.api.instance;
 
 import static org.apache.rya.api.instance.ConfigurationFields.USE_ENTITY;
 import static org.apache.rya.api.instance.ConfigurationFields.USE_FREETEXT;
-import static org.apache.rya.api.instance.ConfigurationFields.USE_GEO;
 import static org.apache.rya.api.instance.ConfigurationFields.USE_PCJ;
 import static org.apache.rya.api.instance.ConfigurationFields.USE_TEMPORAL;
 import static org.junit.Assert.assertFalse;
@@ -30,13 +29,8 @@ import static org.junit.Assert.assertTrue;
 import java.util.Date;
 
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Test;
-
-import com.google.common.base.Optional;
-
 import org.apache.rya.api.instance.RyaDetails.EntityCentricIndexDetails;
 import org.apache.rya.api.instance.RyaDetails.FreeTextIndexDetails;
-import org.apache.rya.api.instance.RyaDetails.GeoIndexDetails;
 import org.apache.rya.api.instance.RyaDetails.JoinSelectivityDetails;
 import org.apache.rya.api.instance.RyaDetails.PCJIndexDetails;
 import org.apache.rya.api.instance.RyaDetails.PCJIndexDetails.FluoDetails;
@@ -44,6 +38,9 @@ import org.apache.rya.api.instance.RyaDetails.PCJIndexDetails.PCJDetails;
 import org.apache.rya.api.instance.RyaDetails.PCJIndexDetails.PCJDetails.PCJUpdateStrategy;
 import org.apache.rya.api.instance.RyaDetails.ProspectorDetails;
 import org.apache.rya.api.instance.RyaDetails.TemporalIndexDetails;
+import org.junit.Test;
+
+import com.google.common.base.Optional;
 
 public class RyaDetailsToConfigurationTest {
     @Test
@@ -53,7 +50,7 @@ public class RyaDetailsToConfigurationTest {
         builder.setRyaInstanceName("test_instance")
             .setRyaVersion("1.2.3.4")
             .setEntityCentricIndexDetails( new EntityCentricIndexDetails(true) )
-            .setGeoIndexDetails( new GeoIndexDetails(true) )
+          //RYA-215            .setGeoIndexDetails( new GeoIndexDetails(true) )
             .setTemporalIndexDetails( new TemporalIndexDetails(true) )
             .setFreeTextDetails( new FreeTextIndexDetails(false) )
             .setPCJIndexDetails(
@@ -77,7 +74,7 @@ public class RyaDetailsToConfigurationTest {
         //defaults are set to cause the assert to fail
         assertTrue(conf.getBoolean(USE_ENTITY, false));
         assertFalse(conf.getBoolean(USE_FREETEXT, true));
-        assertTrue(conf.getBoolean(USE_GEO, false));
+      //RYA-215assertTrue(conf.getBoolean(USE_GEO, false));
         assertTrue(conf.getBoolean(USE_TEMPORAL, false));
         assertTrue(conf.getBoolean(USE_PCJ, false));
     }

--- a/common/rya.api/src/test/java/org/apache/rya/api/instance/RyaDetailsUpdaterTest.java
+++ b/common/rya.api/src/test/java/org/apache/rya/api/instance/RyaDetailsUpdaterTest.java
@@ -28,13 +28,8 @@ import static org.mockito.Mockito.when;
 
 import java.util.Date;
 
-import org.junit.Test;
-
-import com.google.common.base.Optional;
-
 import org.apache.rya.api.instance.RyaDetails.EntityCentricIndexDetails;
 import org.apache.rya.api.instance.RyaDetails.FreeTextIndexDetails;
-import org.apache.rya.api.instance.RyaDetails.GeoIndexDetails;
 import org.apache.rya.api.instance.RyaDetails.JoinSelectivityDetails;
 import org.apache.rya.api.instance.RyaDetails.PCJIndexDetails;
 import org.apache.rya.api.instance.RyaDetails.ProspectorDetails;
@@ -44,6 +39,9 @@ import org.apache.rya.api.instance.RyaDetailsRepository.NotInitializedException;
 import org.apache.rya.api.instance.RyaDetailsRepository.RyaDetailsRepositoryException;
 import org.apache.rya.api.instance.RyaDetailsUpdater.RyaDetailsMutator;
 import org.apache.rya.api.instance.RyaDetailsUpdater.RyaDetailsMutator.CouldNotApplyMutationException;
+import org.junit.Test;
+
+import com.google.common.base.Optional;
 
 /**
  * Tests the methods of {@link RyaDetailsUpdater}.
@@ -58,7 +56,7 @@ public class RyaDetailsUpdaterTest {
                 .setRyaVersion("0.0.0.0")
                 .setFreeTextDetails( new FreeTextIndexDetails(true) )
                 .setEntityCentricIndexDetails( new EntityCentricIndexDetails(true) )
-                .setGeoIndexDetails( new GeoIndexDetails(true) )
+              //RYA-215                .setGeoIndexDetails( new GeoIndexDetails(true) )
                 .setTemporalIndexDetails( new TemporalIndexDetails(true) )
                 .setPCJIndexDetails(
                         PCJIndexDetails.builder()
@@ -95,7 +93,7 @@ public class RyaDetailsUpdaterTest {
                 .setRyaVersion("0.0.0.0")
                 .setFreeTextDetails( new FreeTextIndexDetails(true) )
                 .setEntityCentricIndexDetails( new EntityCentricIndexDetails(true) )
-                .setGeoIndexDetails( new GeoIndexDetails(true) )
+              //RYA-215                .setGeoIndexDetails( new GeoIndexDetails(true) )
                 .setTemporalIndexDetails( new TemporalIndexDetails(true) )
                 .setPCJIndexDetails(
                         PCJIndexDetails.builder()

--- a/dao/accumulo.rya/src/main/java/org/apache/rya/accumulo/instance/AccumuloRyaInstanceDetailsRepository.java
+++ b/dao/accumulo.rya/src/main/java/org/apache/rya/accumulo/instance/AccumuloRyaInstanceDetailsRepository.java
@@ -1,6 +1,4 @@
-package org.apache.rya.accumulo.instance;
-
-/*
+/**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -9,7 +7,7 @@ package org.apache.rya.accumulo.instance;
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -18,6 +16,7 @@ package org.apache.rya.accumulo.instance;
  * specific language governing permissions and limitations
  * under the License.
  */
+package org.apache.rya.accumulo.instance;
 
 import static java.util.Objects.requireNonNull;
 
@@ -46,7 +45,6 @@ import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.hadoop.io.Text;
-
 import org.apache.rya.api.instance.RyaDetails;
 import org.apache.rya.api.instance.RyaDetailsRepository;
 
@@ -86,7 +84,7 @@ public class AccumuloRyaInstanceDetailsRepository implements RyaDetailsRepositor
     public AccumuloRyaInstanceDetailsRepository(final Connector connector, final String instanceName) {
         this.connector = requireNonNull( connector );
         this.instanceName = requireNonNull( instanceName );
-        this.detailsTableName = instanceName + INSTANCE_DETAILS_TABLE_NAME;
+        detailsTableName = instanceName + INSTANCE_DETAILS_TABLE_NAME;
     }
 
     @Override
@@ -226,5 +224,16 @@ public class AccumuloRyaInstanceDetailsRepository implements RyaDetailsRepositor
                 writer.close();
             }
         }
+    }
+
+    /**
+     * Make the Accumulo table name used by this repository for a specific instance of Rya.
+     *
+     * @param ryaInstanceName - The name of the Rya instance the table name is for. (not null)
+     * @return The Accumulo table name used by this repository for a specific instance of Rya.
+     */
+    public static String makeTableName(final String ryaInstanceName) {
+        requireNonNull(ryaInstanceName);
+        return ryaInstanceName + INSTANCE_DETAILS_TABLE_NAME;
     }
 }

--- a/dao/accumulo.rya/src/main/java/org/apache/rya/accumulo/utils/TablePermissions.java
+++ b/dao/accumulo.rya/src/main/java/org/apache/rya/accumulo/utils/TablePermissions.java
@@ -1,0 +1,102 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.accumulo.utils;
+
+import static java.util.Objects.requireNonNull;
+
+import org.apache.accumulo.core.client.AccumuloException;
+import org.apache.accumulo.core.client.AccumuloSecurityException;
+import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.client.admin.SecurityOperations;
+import org.apache.accumulo.core.security.TablePermission;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * A utility that makes it easier to grant and revoke table permissions within
+ * an instance of Accumulo.
+ */
+@DefaultAnnotation(NonNull.class)
+public class TablePermissions {
+
+    /**
+     * Grants the following Table Permissions for an Accumulo user to an Accumulo table.
+     * <ul>
+     *   <li>ALTER_TABLE</li>
+     *   <li>BULK_IMPORT</li>
+     *   <li>DROP_TABLE</li>
+     *   <li>GRANT</li>
+     *   <li>READ</li>
+     *   <li>WRITE</li>
+     * </ul>
+     *
+     * @param user - The user who will be granted the permissions. (not null)
+     * @param table - The Accumulo table the permissions are granted to. (not null)
+     * @param conn - The connector that is used to access the Accumulo instance
+     *   that hosts the the {@code user} and {@code table}. (not null)
+     * @throws AccumuloSecurityException If a general error occurs.
+     * @throws AccumuloException If the user does not have permission to grant a user permissions.
+     */
+    public void grantAllPermissions(final String user, final String table, final Connector conn) throws AccumuloException, AccumuloSecurityException {
+        requireNonNull(user);
+        requireNonNull(table);
+        requireNonNull(conn);
+
+        final SecurityOperations secOps = conn.securityOperations();
+        secOps.grantTablePermission(user, table, TablePermission.ALTER_TABLE);
+        secOps.grantTablePermission(user, table, TablePermission.BULK_IMPORT);
+        secOps.grantTablePermission(user, table, TablePermission.DROP_TABLE);
+        secOps.grantTablePermission(user, table, TablePermission.GRANT);
+        secOps.grantTablePermission(user, table, TablePermission.READ);
+        secOps.grantTablePermission(user, table, TablePermission.WRITE);
+    }
+
+    /**
+     * Revokes the following Table Permissions for an Accumulo user from an Accumulo table.
+     * <ul>
+     *   <li>ALTER_TABLE</li>
+     *   <li>BULK_IMPORT</li>
+     *   <li>DROP_TABLE</li>
+     *   <li>GRANT</li>
+     *   <li>READ</li>
+     *   <li>WRITE</li>
+     * </ul>
+     *
+     * @param user - The user whose permissions will be revoked. (not null)
+     * @param table - The Accumulo table the permissions are revoked from. (not null)
+     * @param conn - The connector that is used to access the Accumulo instance
+     *   that hosts the the {@code user} and {@code table}. (not null)
+     * @throws AccumuloException If a general error occurs.
+     * @throws AccumuloSecurityException If the user does not have permission to revoke a user's permissions.
+     */
+    public void revokeAllPermissions(final String user, final String table, final Connector conn) throws AccumuloException, AccumuloSecurityException {
+        requireNonNull(user);
+        requireNonNull(table);
+        requireNonNull(conn);
+
+        final SecurityOperations secOps = conn.securityOperations();
+        secOps.revokeTablePermission(user, table, TablePermission.ALTER_TABLE);
+        secOps.revokeTablePermission(user, table, TablePermission.BULK_IMPORT);
+        secOps.revokeTablePermission(user, table, TablePermission.DROP_TABLE);
+        secOps.revokeTablePermission(user, table, TablePermission.GRANT);
+        secOps.revokeTablePermission(user, table, TablePermission.READ);
+        secOps.revokeTablePermission(user, table, TablePermission.WRITE);
+    }
+}

--- a/dao/accumulo.rya/src/test/java/org/apache/rya/accumulo/AccumuloRyaITBase.java
+++ b/dao/accumulo.rya/src/test/java/org/apache/rya/accumulo/AccumuloRyaITBase.java
@@ -76,7 +76,7 @@ public class AccumuloRyaITBase {
                 .setRyaVersion("0.0.0.0")
                 .setFreeTextDetails( new FreeTextIndexDetails(true) )
                 .setEntityCentricIndexDetails( new EntityCentricIndexDetails(true) )
-                .setGeoIndexDetails( new GeoIndexDetails(true) )
+              //RYA-215                .setGeoIndexDetails( new GeoIndexDetails(true) )
                 .setTemporalIndexDetails( new TemporalIndexDetails(true) )
                 .setPCJIndexDetails(
                         PCJIndexDetails.builder()

--- a/dao/accumulo.rya/src/test/java/org/apache/rya/accumulo/MiniAccumuloClusterInstance.java
+++ b/dao/accumulo.rya/src/test/java/org/apache/rya/accumulo/MiniAccumuloClusterInstance.java
@@ -83,7 +83,7 @@ public class MiniAccumuloClusterInstance {
     }
 
     /**
-     * @return An accumulo connector that is connected to the mini cluster.
+     * @return An Accumulo connector that is connected to the mini cluster's root account.
      */
     public Connector getConnector() throws AccumuloException, AccumuloSecurityException {
         return cluster.getConnector(USERNAME, PASSWORD);

--- a/dao/accumulo.rya/src/test/java/org/apache/rya/accumulo/instance/AccumuloRyaDetailsRepositoryIT.java
+++ b/dao/accumulo.rya/src/test/java/org/apache/rya/accumulo/instance/AccumuloRyaDetailsRepositoryIT.java
@@ -22,35 +22,17 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
 import java.util.Date;
 
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.Connector;
-import org.apache.accumulo.core.client.Instance;
-import org.apache.accumulo.core.client.ZooKeeperInstance;
-import org.apache.accumulo.core.client.mock.MockInstance;
-import org.apache.accumulo.core.client.security.tokens.PasswordToken;
 import org.apache.accumulo.minicluster.MiniAccumuloCluster;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
-import org.apache.zookeeper.ClientCnxn;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
-import com.google.common.base.Optional;
-
 import org.apache.rya.accumulo.AccumuloITBase;
 import org.apache.rya.accumulo.MiniAccumuloClusterInstance;
 import org.apache.rya.api.instance.RyaDetails;
 import org.apache.rya.api.instance.RyaDetails.EntityCentricIndexDetails;
 import org.apache.rya.api.instance.RyaDetails.FreeTextIndexDetails;
-import org.apache.rya.api.instance.RyaDetails.GeoIndexDetails;
 import org.apache.rya.api.instance.RyaDetails.JoinSelectivityDetails;
 import org.apache.rya.api.instance.RyaDetails.PCJIndexDetails;
 import org.apache.rya.api.instance.RyaDetails.PCJIndexDetails.FluoDetails;
@@ -63,6 +45,9 @@ import org.apache.rya.api.instance.RyaDetailsRepository.AlreadyInitializedExcept
 import org.apache.rya.api.instance.RyaDetailsRepository.ConcurrentUpdateException;
 import org.apache.rya.api.instance.RyaDetailsRepository.NotInitializedException;
 import org.apache.rya.api.instance.RyaDetailsRepository.RyaDetailsRepositoryException;
+import org.junit.Test;
+
+import com.google.common.base.Optional;
 
 /**
  * Tests the methods of {@link AccumuloRyaDetailsRepository} by using a {@link MiniAccumuloCluster}.
@@ -78,7 +63,7 @@ public class AccumuloRyaDetailsRepositoryIT extends AccumuloITBase {
             .setRyaInstanceName(instanceName)
             .setRyaVersion("1.2.3.4")
             .setEntityCentricIndexDetails( new EntityCentricIndexDetails(true) )
-            .setGeoIndexDetails( new GeoIndexDetails(true) )
+          //RYA-215            .setGeoIndexDetails( new GeoIndexDetails(true) )
             .setTemporalIndexDetails( new TemporalIndexDetails(true) )
             .setFreeTextDetails( new FreeTextIndexDetails(true) )
             .setPCJIndexDetails(
@@ -120,7 +105,7 @@ public class AccumuloRyaDetailsRepositoryIT extends AccumuloITBase {
             .setRyaInstanceName(instanceName)
             .setRyaVersion("1.2.3.4")
             .setEntityCentricIndexDetails( new EntityCentricIndexDetails(true) )
-            .setGeoIndexDetails( new GeoIndexDetails(true) )
+          //RYA-215            .setGeoIndexDetails( new GeoIndexDetails(true) )
             .setTemporalIndexDetails( new TemporalIndexDetails(true) )
             .setFreeTextDetails( new FreeTextIndexDetails(true) )
             .setPCJIndexDetails(
@@ -169,7 +154,7 @@ public class AccumuloRyaDetailsRepositoryIT extends AccumuloITBase {
             .setRyaInstanceName(instanceName)
             .setRyaVersion("1.2.3.4")
             .setEntityCentricIndexDetails( new EntityCentricIndexDetails(true) )
-            .setGeoIndexDetails( new GeoIndexDetails(true) )
+          //RYA-215            .setGeoIndexDetails( new GeoIndexDetails(true) )
             .setTemporalIndexDetails( new TemporalIndexDetails(true) )
             .setFreeTextDetails( new FreeTextIndexDetails(true) )
             .setPCJIndexDetails(
@@ -219,7 +204,7 @@ public class AccumuloRyaDetailsRepositoryIT extends AccumuloITBase {
             .setRyaInstanceName(instanceName)
             .setRyaVersion("1.2.3.4")
             .setEntityCentricIndexDetails( new EntityCentricIndexDetails(true) )
-            .setGeoIndexDetails( new GeoIndexDetails(true) )
+          //RYA-215            .setGeoIndexDetails( new GeoIndexDetails(true) )
             .setTemporalIndexDetails( new TemporalIndexDetails(true) )
             .setFreeTextDetails( new FreeTextIndexDetails(true) )
             .setPCJIndexDetails(
@@ -247,7 +232,7 @@ public class AccumuloRyaDetailsRepositoryIT extends AccumuloITBase {
 
         // Create a new state for the details.
         final RyaDetails updated = new RyaDetails.Builder( details )
-                .setGeoIndexDetails( new GeoIndexDetails(false) )
+                .setEntityCentricIndexDetails(new EntityCentricIndexDetails(false) )
                 .build();
 
         // Execute the update.
@@ -267,7 +252,7 @@ public class AccumuloRyaDetailsRepositoryIT extends AccumuloITBase {
             .setRyaInstanceName(instanceName)
             .setRyaVersion("1.2.3.4")
             .setEntityCentricIndexDetails( new EntityCentricIndexDetails(true) )
-            .setGeoIndexDetails( new GeoIndexDetails(true) )
+          //RYA-215            .setGeoIndexDetails( new GeoIndexDetails(true) )
             .setTemporalIndexDetails( new TemporalIndexDetails(true) )
             .setFreeTextDetails( new FreeTextIndexDetails(true) )
             .setPCJIndexDetails(
@@ -295,7 +280,7 @@ public class AccumuloRyaDetailsRepositoryIT extends AccumuloITBase {
 
         // Create a new state for the details.
         final RyaDetails updated = new RyaDetails.Builder( details )
-                .setGeoIndexDetails( new GeoIndexDetails(false) )
+                .setEntityCentricIndexDetails(new EntityCentricIndexDetails(false) )
                 .build();
 
         // Try to execute the update where the old state is not the currently stored state.

--- a/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/instance/MongoDetailsAdapter.java
+++ b/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/instance/MongoDetailsAdapter.java
@@ -23,22 +23,13 @@ import static java.util.Objects.requireNonNull;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.Map.Entry;
 
 import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
-import com.google.common.base.Optional;
-import com.google.common.base.Preconditions;
-import com.mongodb.BasicDBList;
-import com.mongodb.BasicDBObject;
-import com.mongodb.BasicDBObjectBuilder;
-import com.mongodb.DBObject;
-
 import org.apache.rya.api.instance.RyaDetails;
 import org.apache.rya.api.instance.RyaDetails.EntityCentricIndexDetails;
 import org.apache.rya.api.instance.RyaDetails.FreeTextIndexDetails;
-import org.apache.rya.api.instance.RyaDetails.GeoIndexDetails;
 import org.apache.rya.api.instance.RyaDetails.JoinSelectivityDetails;
 import org.apache.rya.api.instance.RyaDetails.PCJIndexDetails;
 import org.apache.rya.api.instance.RyaDetails.PCJIndexDetails.FluoDetails;
@@ -46,6 +37,13 @@ import org.apache.rya.api.instance.RyaDetails.PCJIndexDetails.PCJDetails;
 import org.apache.rya.api.instance.RyaDetails.PCJIndexDetails.PCJDetails.PCJUpdateStrategy;
 import org.apache.rya.api.instance.RyaDetails.ProspectorDetails;
 import org.apache.rya.api.instance.RyaDetails.TemporalIndexDetails;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+import com.mongodb.BasicDBList;
+import com.mongodb.BasicDBObject;
+import com.mongodb.BasicDBObjectBuilder;
+import com.mongodb.DBObject;
 
 /**
  * Serializes configuration details for use in Mongo.
@@ -105,7 +103,7 @@ public class MongoDetailsAdapter {
             .add(INSTANCE_KEY, details.getRyaInstanceName())
             .add(VERSION_KEY, details.getRyaVersion())
             .add(ENTITY_DETAILS_KEY, details.getEntityCentricIndexDetails().isEnabled())
-            .add(GEO_DETAILS_KEY, details.getGeoIndexDetails().isEnabled())
+          //RYA-215            .add(GEO_DETAILS_KEY, details.getGeoIndexDetails().isEnabled())
             .add(PCJ_DETAILS_KEY, toDBObject(details.getPCJIndexDetails()))
             .add(TEMPORAL_DETAILS_KEY, details.getTemporalIndexDetails().isEnabled())
             .add(FREETEXT_DETAILS_KEY, details.getFreeTextIndexDetails().isEnabled());
@@ -169,7 +167,7 @@ public class MongoDetailsAdapter {
             .setRyaInstanceName(basicObj.getString(INSTANCE_KEY))
             .setRyaVersion(basicObj.getString(VERSION_KEY))
             .setEntityCentricIndexDetails(new EntityCentricIndexDetails(basicObj.getBoolean(ENTITY_DETAILS_KEY)))
-            .setGeoIndexDetails(new GeoIndexDetails(basicObj.getBoolean(GEO_DETAILS_KEY)))
+          //RYA-215            .setGeoIndexDetails(new GeoIndexDetails(basicObj.getBoolean(GEO_DETAILS_KEY)))
             .setPCJIndexDetails(getPCJIndexDetails(basicObj))
             .setTemporalIndexDetails(new TemporalIndexDetails(basicObj.getBoolean(TEMPORAL_DETAILS_KEY)))
             .setFreeTextDetails(new FreeTextIndexDetails(basicObj.getBoolean(FREETEXT_DETAILS_KEY)))

--- a/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/instance/MongoDetailsAdapterTest.java
+++ b/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/instance/MongoDetailsAdapterTest.java
@@ -23,17 +23,9 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.Date;
 
-import org.junit.Test;
-
-import com.google.common.base.Optional;
-import com.mongodb.BasicDBObject;
-import com.mongodb.DBObject;
-import com.mongodb.util.JSON;
-
 import org.apache.rya.api.instance.RyaDetails;
 import org.apache.rya.api.instance.RyaDetails.EntityCentricIndexDetails;
 import org.apache.rya.api.instance.RyaDetails.FreeTextIndexDetails;
-import org.apache.rya.api.instance.RyaDetails.GeoIndexDetails;
 import org.apache.rya.api.instance.RyaDetails.JoinSelectivityDetails;
 import org.apache.rya.api.instance.RyaDetails.PCJIndexDetails;
 import org.apache.rya.api.instance.RyaDetails.PCJIndexDetails.FluoDetails;
@@ -42,6 +34,12 @@ import org.apache.rya.api.instance.RyaDetails.PCJIndexDetails.PCJDetails.PCJUpda
 import org.apache.rya.api.instance.RyaDetails.ProspectorDetails;
 import org.apache.rya.api.instance.RyaDetails.TemporalIndexDetails;
 import org.apache.rya.mongodb.instance.MongoDetailsAdapter.MalformedRyaDetailsException;
+import org.junit.Test;
+
+import com.google.common.base.Optional;
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBObject;
+import com.mongodb.util.JSON;
 
 /**
  * Tests the methods of {@link MongoDetailsAdapter}.
@@ -55,7 +53,7 @@ public class MongoDetailsAdapterTest {
             .setRyaInstanceName("test")
             .setRyaVersion("1")
             .setEntityCentricIndexDetails(new EntityCentricIndexDetails(true))
-            .setGeoIndexDetails(new GeoIndexDetails(true))
+          //RYA-215            .setGeoIndexDetails(new GeoIndexDetails(true))
             .setPCJIndexDetails(
                 PCJIndexDetails.builder()
                 .setEnabled(true)
@@ -84,7 +82,7 @@ public class MongoDetailsAdapterTest {
             + "instanceName : \"test\","
             + "version : \"1\","
             + "entityCentricDetails : true,"
-            + "geoDetails : true,"
+          //RYA-215            + "geoDetails : true,"
             + "pcjDetails : {"
             +    "enabled : true ,"
             +    "fluoName : \"fluo\","
@@ -118,7 +116,7 @@ public class MongoDetailsAdapterTest {
             + "instanceName : \"test\","
             + "version : \"1\","
             + "entityCentricDetails : true,"
-            + "geoDetails : true,"
+          //RYA-215            + "geoDetails : true,"
             + "pcjDetails : {"
             +    "enabled : true ,"
             +    "fluoName : \"fluo\","
@@ -148,7 +146,7 @@ public class MongoDetailsAdapterTest {
             .setRyaInstanceName("test")
             .setRyaVersion("1")
             .setEntityCentricIndexDetails(new EntityCentricIndexDetails(true))
-            .setGeoIndexDetails(new GeoIndexDetails(true))
+          //RYA-215            .setGeoIndexDetails(new GeoIndexDetails(true))
             .setPCJIndexDetails(
                 PCJIndexDetails.builder()
                     .setEnabled(true)
@@ -180,7 +178,7 @@ public class MongoDetailsAdapterTest {
                 + "instanceName : \"test\","
                 + "version : \"1\","
                 + "entityCentricDetails : true,"
-                + "geoDetails : false,"
+              //RYA-215                + "geoDetails : false,"
                 + "pcjDetails : {"
                 +    "enabled : false,"
                 +    "fluoName : \"fluo\","
@@ -203,7 +201,7 @@ public class MongoDetailsAdapterTest {
             .setRyaInstanceName("test")
             .setRyaVersion("1")
             .setEntityCentricIndexDetails(new EntityCentricIndexDetails(true))
-            .setGeoIndexDetails(new GeoIndexDetails(false))
+          //RYA-215            .setGeoIndexDetails(new GeoIndexDetails(false))
             .setPCJIndexDetails(
                     PCJIndexDetails.builder()
                     .setEnabled(false)
@@ -228,7 +226,7 @@ public class MongoDetailsAdapterTest {
             .setRyaInstanceName("test")
             .setRyaVersion("1")
             .setEntityCentricIndexDetails(new EntityCentricIndexDetails(true))
-            .setGeoIndexDetails(new GeoIndexDetails(false))
+          //RYA-215            .setGeoIndexDetails(new GeoIndexDetails(false))
             .setPCJIndexDetails(
                 PCJIndexDetails.builder()
                     .setEnabled(true)
@@ -247,7 +245,7 @@ public class MongoDetailsAdapterTest {
                 + "instanceName : \"test\","
                 + "version : \"1\","
                 + "entityCentricDetails : true,"
-                + "geoDetails : false,"
+              //RYA-215                + "geoDetails : false,"
                 + "pcjDetails : {"
                 +    "enabled : true,"
                 +    "fluoName : \"fluo\","

--- a/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/instance/MongoRyaDetailsRepositoryIT.java
+++ b/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/instance/MongoRyaDetailsRepositoryIT.java
@@ -23,12 +23,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.io.IOException;
 import java.util.Date;
 
 import org.apache.rya.api.instance.RyaDetails;
 import org.apache.rya.api.instance.RyaDetails.EntityCentricIndexDetails;
 import org.apache.rya.api.instance.RyaDetails.FreeTextIndexDetails;
-import org.apache.rya.api.instance.RyaDetails.GeoIndexDetails;
 import org.apache.rya.api.instance.RyaDetails.JoinSelectivityDetails;
 import org.apache.rya.api.instance.RyaDetails.PCJIndexDetails;
 import org.apache.rya.api.instance.RyaDetails.PCJIndexDetails.FluoDetails;
@@ -41,16 +41,39 @@ import org.apache.rya.api.instance.RyaDetailsRepository.AlreadyInitializedExcept
 import org.apache.rya.api.instance.RyaDetailsRepository.ConcurrentUpdateException;
 import org.apache.rya.api.instance.RyaDetailsRepository.NotInitializedException;
 import org.apache.rya.api.instance.RyaDetailsRepository.RyaDetailsRepositoryException;
-import org.apache.rya.mongodb.MongoRyaTestBase;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.common.base.Optional;
+import com.mongodb.MongoClient;
+import com.mongodb.MongoException;
+
+import de.flapdoodle.embed.mongo.tests.MongodForTestsFactory;
 
 /**
  * Tests the methods of {@link AccumuloRyaDetailsRepository} by using a {@link MiniAccumuloCluster}.
  */
-public class MongoRyaDetailsRepositoryIT extends MongoRyaTestBase {
+public class MongoRyaDetailsRepositoryIT {
 
+    private static MongoClient client = null;
+
+    @BeforeClass
+    public static void startMiniAccumulo() throws MongoException, IOException {
+        final MongodForTestsFactory mongoFactory = new MongodForTestsFactory();
+        client = mongoFactory.newMongo();
+    }
+
+    @Before
+    public void clearLastTest() {
+        client.dropDatabase("testInstance");
+    }
+
+    @AfterClass
+    public static void stopMiniAccumulo() throws IOException, InterruptedException {
+        client.close();
+    }
 
     @Test
     public void initializeAndGet() throws AlreadyInitializedException, RyaDetailsRepositoryException {
@@ -61,7 +84,7 @@ public class MongoRyaDetailsRepositoryIT extends MongoRyaTestBase {
             .setRyaInstanceName(instanceName)
             .setRyaVersion("1.2.3.4")
             .setEntityCentricIndexDetails( new EntityCentricIndexDetails(true) )
-            .setGeoIndexDetails( new GeoIndexDetails(true) )
+          //RYA-215            .setGeoIndexDetails( new GeoIndexDetails(true) )
             .setTemporalIndexDetails( new TemporalIndexDetails(true) )
             .setFreeTextDetails( new FreeTextIndexDetails(true) )
             .setPCJIndexDetails(
@@ -81,7 +104,7 @@ public class MongoRyaDetailsRepositoryIT extends MongoRyaTestBase {
             .build();
 
         // Setup the repository that will be tested using a mock instance of MongoDB.
-        final RyaDetailsRepository repo = new MongoRyaInstanceDetailsRepository(mongoClient, instanceName);
+        final RyaDetailsRepository repo = new MongoRyaInstanceDetailsRepository(client, instanceName);
 
         // Initialize the repository
         repo.initialize(details);
@@ -102,7 +125,7 @@ public class MongoRyaDetailsRepositoryIT extends MongoRyaTestBase {
             .setRyaInstanceName(instanceName)
             .setRyaVersion("1.2.3.4")
             .setEntityCentricIndexDetails( new EntityCentricIndexDetails(true) )
-            .setGeoIndexDetails( new GeoIndexDetails(true) )
+          //RYA-215            .setGeoIndexDetails( new GeoIndexDetails(true) )
             .setTemporalIndexDetails( new TemporalIndexDetails(true) )
             .setFreeTextDetails( new FreeTextIndexDetails(true) )
             .setPCJIndexDetails(
@@ -122,7 +145,7 @@ public class MongoRyaDetailsRepositoryIT extends MongoRyaTestBase {
             .build();
 
         // Setup the repository that will be tested using a mock instance of MongoDB.
-        final RyaDetailsRepository repo = new MongoRyaInstanceDetailsRepository(mongoClient, instanceName);
+        final RyaDetailsRepository repo = new MongoRyaInstanceDetailsRepository(client, instanceName);
 
         // Initialize the repository
         repo.initialize(details);
@@ -134,7 +157,7 @@ public class MongoRyaDetailsRepositoryIT extends MongoRyaTestBase {
     @Test(expected = NotInitializedException.class)
     public void getRyaInstance_notInitialized() throws NotInitializedException, RyaDetailsRepositoryException {
         // Setup the repository that will be tested using a mock instance of Accumulo.
-        final RyaDetailsRepository repo = new MongoRyaInstanceDetailsRepository(mongoClient, "testInstance");
+        final RyaDetailsRepository repo = new MongoRyaInstanceDetailsRepository(client, "testInstance");
 
         // Try to fetch the details from the uninitialized repository.
         repo.getRyaInstanceDetails();
@@ -149,7 +172,7 @@ public class MongoRyaDetailsRepositoryIT extends MongoRyaTestBase {
             .setRyaInstanceName(instanceName)
             .setRyaVersion("1.2.3.4")
             .setEntityCentricIndexDetails( new EntityCentricIndexDetails(true) )
-            .setGeoIndexDetails( new GeoIndexDetails(true) )
+          //RYA-215            .setGeoIndexDetails( new GeoIndexDetails(true) )
             .setTemporalIndexDetails( new TemporalIndexDetails(true) )
             .setFreeTextDetails( new FreeTextIndexDetails(true) )
             .setPCJIndexDetails(
@@ -169,7 +192,7 @@ public class MongoRyaDetailsRepositoryIT extends MongoRyaTestBase {
             .build();
 
         // Setup the repository that will be tested using a mock instance of MongoDB.
-        final RyaDetailsRepository repo = new MongoRyaInstanceDetailsRepository(mongoClient, "testInstance");
+        final RyaDetailsRepository repo = new MongoRyaInstanceDetailsRepository(client, "testInstance");
 
         // Initialize the repository
         repo.initialize(details);
@@ -181,7 +204,7 @@ public class MongoRyaDetailsRepositoryIT extends MongoRyaTestBase {
     @Test
     public void isInitialized_false() throws RyaDetailsRepositoryException {
         // Setup the repository that will be tested using a mock instance of MongoDB.
-        final RyaDetailsRepository repo = new MongoRyaInstanceDetailsRepository(mongoClient, "testInstance");
+        final RyaDetailsRepository repo = new MongoRyaInstanceDetailsRepository(client, "testInstance");
 
         // Ensure the repository reports that is has not been initialized.
         assertFalse( repo.isInitialized() );
@@ -196,7 +219,7 @@ public class MongoRyaDetailsRepositoryIT extends MongoRyaTestBase {
             .setRyaInstanceName(instanceName)
             .setRyaVersion("1.2.3.4")
             .setEntityCentricIndexDetails( new EntityCentricIndexDetails(true) )
-            .setGeoIndexDetails( new GeoIndexDetails(true) )
+          //RYA-215            .setGeoIndexDetails( new GeoIndexDetails(true) )
             .setTemporalIndexDetails( new TemporalIndexDetails(true) )
             .setFreeTextDetails( new FreeTextIndexDetails(true) )
             .setPCJIndexDetails(
@@ -216,14 +239,14 @@ public class MongoRyaDetailsRepositoryIT extends MongoRyaTestBase {
             .build();
 
         // Setup the repository that will be tested using a mock instance of MongoDB.
-        final RyaDetailsRepository repo = new MongoRyaInstanceDetailsRepository(mongoClient, "testInstance");
+        final RyaDetailsRepository repo = new MongoRyaInstanceDetailsRepository(client, "testInstance");
 
         // Initialize the repository
         repo.initialize(details);
 
         // Create a new state for the details.
         final RyaDetails updated = new RyaDetails.Builder( details )
-                .setGeoIndexDetails( new GeoIndexDetails(false) )
+                .setEntityCentricIndexDetails(new EntityCentricIndexDetails(false) )
                 .build();
 
         // Execute the update.
@@ -243,7 +266,7 @@ public class MongoRyaDetailsRepositoryIT extends MongoRyaTestBase {
             .setRyaInstanceName(instanceName)
             .setRyaVersion("1.2.3.4")
             .setEntityCentricIndexDetails( new EntityCentricIndexDetails(true) )
-            .setGeoIndexDetails( new GeoIndexDetails(true) )
+          //RYA-215            .setGeoIndexDetails( new GeoIndexDetails(true) )
             .setTemporalIndexDetails( new TemporalIndexDetails(true) )
             .setFreeTextDetails( new FreeTextIndexDetails(true) )
             .setPCJIndexDetails(
@@ -263,7 +286,7 @@ public class MongoRyaDetailsRepositoryIT extends MongoRyaTestBase {
             .build();
 
         // Setup the repository that will be tested using a mock instance of MongoDB.
-        final RyaDetailsRepository repo = new MongoRyaInstanceDetailsRepository(mongoClient, "testInstance");
+        final RyaDetailsRepository repo = new MongoRyaInstanceDetailsRepository(client, "testInstance");
 
         // Initialize the repository
         repo.initialize(details);
@@ -274,7 +297,7 @@ public class MongoRyaDetailsRepositoryIT extends MongoRyaTestBase {
                 .build();
 
         final RyaDetails updated = new RyaDetails.Builder( details )
-                .setGeoIndexDetails( new GeoIndexDetails(false) )
+                .setEntityCentricIndexDetails(new EntityCentricIndexDetails(false) )
                 .build();
 
         // Try to execute the update where the old state is not the currently stored state.

--- a/extras/indexing/src/main/java/org/apache/rya/accumulo/utils/RyaTableNames.java
+++ b/extras/indexing/src/main/java/org/apache/rya/accumulo/utils/RyaTableNames.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.accumulo.utils;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.client.admin.TableOperations;
+import org.apache.rya.accumulo.instance.AccumuloRyaInstanceDetailsRepository;
+import org.apache.rya.api.instance.RyaDetails;
+import org.apache.rya.api.instance.RyaDetailsRepository;
+import org.apache.rya.api.instance.RyaDetailsRepository.NotInitializedException;
+import org.apache.rya.api.instance.RyaDetailsRepository.RyaDetailsRepositoryException;
+import org.apache.rya.api.layout.TableLayoutStrategy;
+import org.apache.rya.api.layout.TablePrefixLayoutStrategy;
+import org.apache.rya.indexing.accumulo.entity.EntityCentricIndex;
+import org.apache.rya.indexing.accumulo.freetext.AccumuloFreeTextIndexer;
+import org.apache.rya.indexing.accumulo.temporal.AccumuloTemporalIndexer;
+import org.apache.rya.indexing.pcj.storage.PrecomputedJoinStorage.PCJStorageException;
+import org.apache.rya.indexing.pcj.storage.accumulo.AccumuloPcjStorage;
+import org.apache.rya.indexing.pcj.storage.accumulo.PcjTableNameFactory;
+
+/**
+ * A utility that may be used to determine which Accumulo tables are part of  a Rya instance.
+ */
+public class RyaTableNames {
+
+    /**
+     * Get the the Accumulo table names that are used by an instance of Rya.
+     *
+     * @param ryaInstanceName - The name of the Rya instance. (not null)
+     * @param conn - A connector to the host Accumulo instance. (not null)
+     * @return The Accumulo table names that are used by the Rya instance.
+     * @throws NotInitializedException The instance's Rya Details have not been initialized.
+     * @throws RyaDetailsRepositoryException General problem with the Rya Details repository.
+     * @throws PCJStorageException General problem with the PCJ storage.
+     */
+    public List<String> getTableNames(final String ryaInstanceName, final Connector conn) throws NotInitializedException, RyaDetailsRepositoryException, PCJStorageException {
+        // Build the list of tables that may be present within the Rya instance.
+        final List<String> tables = new ArrayList<>();
+
+        // Core Rya tables.
+        final TableLayoutStrategy coreTableNames = new TablePrefixLayoutStrategy(ryaInstanceName);
+        tables.add( coreTableNames.getSpo() );
+        tables.add( coreTableNames.getPo() );
+        tables.add( coreTableNames.getOsp() );
+        tables.add( coreTableNames.getEval() );
+        tables.add( coreTableNames.getNs() );
+        tables.add( coreTableNames.getProspects() );
+        tables.add( coreTableNames.getSelectivity() );
+
+        // Rya Details table.
+        tables.add( AccumuloRyaInstanceDetailsRepository.makeTableName(ryaInstanceName) );
+
+        // Secondary Indexer Tables.
+        final RyaDetailsRepository detailsRepo = new AccumuloRyaInstanceDetailsRepository(conn, ryaInstanceName);
+        final RyaDetails details = detailsRepo.getRyaInstanceDetails();
+
+        if(details.getEntityCentricIndexDetails().isEnabled()) {
+            tables.add( EntityCentricIndex.makeTableName(ryaInstanceName) );
+        }
+
+        if(details.getFreeTextIndexDetails().isEnabled()) {
+            tables.addAll( AccumuloFreeTextIndexer.makeTableNames(ryaInstanceName) );
+        }
+
+        if(details.getTemporalIndexDetails().isEnabled()) {
+            tables.add( AccumuloTemporalIndexer.makeTableName(ryaInstanceName) );
+        }
+
+/**
+ *         if(details.getGeoIndexDetails().isEnabled()) {
+ *             tables.add( GeoMesaGeoIndexer.makeTableName(ryaInstanceName) );
+ *         }
+ */
+
+        if(details.getPCJIndexDetails().isEnabled()) {
+            final List<String> pcjIds = new AccumuloPcjStorage(conn, ryaInstanceName).listPcjs();
+
+            final PcjTableNameFactory tableNameFactory = new PcjTableNameFactory();
+            for(final String pcjId : pcjIds) {
+                tables.add( tableNameFactory.makeTableName(ryaInstanceName, pcjId) );
+            }
+        }
+
+        // Verify they actually exist. If any don't, remove them from the list.
+        final TableOperations tableOps = conn.tableOperations();
+
+        final Iterator<String> tablesIt = tables.iterator();
+        while(tablesIt.hasNext()) {
+            final String table = tablesIt.next();
+            if(!tableOps.exists(table)) {
+                tablesIt.remove();
+            }
+        }
+
+        return tables;
+    }
+}

--- a/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/AccumuloAddUser.java
+++ b/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/AccumuloAddUser.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.api.client.accumulo;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import org.apache.accumulo.core.client.AccumuloException;
+import org.apache.accumulo.core.client.AccumuloSecurityException;
+import org.apache.accumulo.core.client.Connector;
+import org.apache.rya.accumulo.instance.AccumuloRyaInstanceDetailsRepository;
+import org.apache.rya.accumulo.utils.RyaTableNames;
+import org.apache.rya.accumulo.utils.TablePermissions;
+import org.apache.rya.api.client.AddUser;
+import org.apache.rya.api.client.InstanceDoesNotExistException;
+import org.apache.rya.api.client.RyaClientException;
+import org.apache.rya.api.instance.RyaDetails;
+import org.apache.rya.api.instance.RyaDetailsRepository.RyaDetailsRepositoryException;
+import org.apache.rya.api.instance.RyaDetailsUpdater;
+import org.apache.rya.api.instance.RyaDetailsUpdater.RyaDetailsMutator.CouldNotApplyMutationException;
+import org.apache.rya.indexing.pcj.storage.PrecomputedJoinStorage.PCJStorageException;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * An Accumulo implementation of the {@link AddUser} command.
+ */
+@DefaultAnnotation(NonNull.class)
+public class AccumuloAddUser extends AccumuloCommand implements AddUser {
+
+    private static final TablePermissions TABLE_PERMISSIONS = new TablePermissions();
+
+    /**
+     * Constructs an instance of {@link AccumuloAddUser}.
+     *
+     * @param connectionDetails - Details about the values that were used to create
+     *   the connector to the cluster. (not null)
+     * @param connector - Provides programmatic access to the instance of Accumulo
+     *   that hosts Rya instance. (not null)
+     */
+    public AccumuloAddUser(
+            final AccumuloConnectionDetails connectionDetails,
+            final Connector connector) {
+        super(connectionDetails, connector);
+    }
+
+    @Override
+    public void addUser(final String instanceName, final String username) throws InstanceDoesNotExistException, RyaClientException {
+        requireNonNull(instanceName);
+        requireNonNull(username);
+
+        // If the user has already been added, then return immediately.
+        try {
+            final RyaDetails details = new AccumuloRyaInstanceDetailsRepository(getConnector(), instanceName).getRyaInstanceDetails();
+            final List<String> users = details.getUsers();
+            if(users.contains(username)) {
+                return;
+            }
+        } catch (final RyaDetailsRepositoryException e) {
+            throw new RyaClientException("Could not fetch the RyaDetails for Rya instance named '" + instanceName + ".", e);
+        }
+
+        // Update the instance details
+        final RyaDetailsUpdater updater = new RyaDetailsUpdater( new AccumuloRyaInstanceDetailsRepository(getConnector(), instanceName) );
+        try {
+            updater.update(originalDetails -> RyaDetails.builder( originalDetails ).addUser(username).build());
+        } catch (RyaDetailsRepositoryException | CouldNotApplyMutationException e) {
+            throw new RyaClientException("Could not add the user '" + username + "' to the Rya instance's details.", e);
+        }
+
+        // Grant all access to all the instance's tables.
+        try {
+            // Build the list of tables that are present within the Rya instance.
+            final List<String> tables = new RyaTableNames().getTableNames(instanceName, getConnector());
+
+            // Update the user permissions for those tables.
+            for(final String table : tables) {
+                try {
+                    TABLE_PERMISSIONS.grantAllPermissions(username, table, getConnector());
+                } catch (AccumuloException | AccumuloSecurityException e) {
+                    throw new RyaClientException("Could not grant access to table '" + table + "' for user '" + username + "'.", e);
+                }
+            }
+        } catch (PCJStorageException | RyaDetailsRepositoryException e) {
+            throw new RyaClientException("Could not determine which tables exist for the '" + instanceName + "' instance of Rya.", e);
+        }
+    }
+}

--- a/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/AccumuloCommand.java
+++ b/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/AccumuloCommand.java
@@ -38,8 +38,9 @@ public abstract class AccumuloCommand {
     /**
      * Constructs an instance of {@link AccumuloCommand}.
      *
-     * Details about the values that were used to create the connector to the cluster. (not null)
-     * @param connector - Provides programatic access to the instance of Accumulo
+     * @param connectionDetails - Details about the values that were used to create
+     *   the connector to the cluster. (not null)
+     * @param connector - Provides programmatic access to the instance of Accumulo
      *   that hosts Rya instance. (not null)
      */
     public AccumuloCommand(

--- a/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/AccumuloRemoveUser.java
+++ b/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/AccumuloRemoveUser.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.api.client.accumulo;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import org.apache.accumulo.core.client.AccumuloException;
+import org.apache.accumulo.core.client.AccumuloSecurityException;
+import org.apache.accumulo.core.client.Connector;
+import org.apache.rya.accumulo.instance.AccumuloRyaInstanceDetailsRepository;
+import org.apache.rya.accumulo.utils.RyaTableNames;
+import org.apache.rya.accumulo.utils.TablePermissions;
+import org.apache.rya.api.client.InstanceDoesNotExistException;
+import org.apache.rya.api.client.RemoveUser;
+import org.apache.rya.api.client.RyaClientException;
+import org.apache.rya.api.instance.RyaDetails;
+import org.apache.rya.api.instance.RyaDetailsRepository.RyaDetailsRepositoryException;
+import org.apache.rya.api.instance.RyaDetailsUpdater;
+import org.apache.rya.api.instance.RyaDetailsUpdater.RyaDetailsMutator.CouldNotApplyMutationException;
+import org.apache.rya.indexing.pcj.storage.PrecomputedJoinStorage.PCJStorageException;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * An Accumulo implementation of the {@link DeleteUser} command.
+ */
+@DefaultAnnotation(NonNull.class)
+public class AccumuloRemoveUser extends AccumuloCommand implements RemoveUser {
+
+    private static final TablePermissions TABLE_PERMISSIONS = new TablePermissions();
+
+    /**
+     * Constructs an instance of {@link AccumuloDeleteUser}.
+     *
+     * @param connectionDetails - Details about the values that were used to create
+     *   the connector to the cluster. (not null)
+     * @param connector - Provides programmatic access to the instance of Accumulo
+     *   that hosts Rya instance. (not null)
+     */
+    public AccumuloRemoveUser(
+            final AccumuloConnectionDetails connectionDetails,
+            final Connector connector) {
+        super(connectionDetails, connector);
+    }
+
+    @Override
+    public void removeUser(final String instanceName, final String username) throws InstanceDoesNotExistException, RyaClientException {
+        requireNonNull(instanceName);
+        requireNonNull(username);
+
+        // Update the instance details.
+        final RyaDetailsUpdater updater = new RyaDetailsUpdater( new AccumuloRyaInstanceDetailsRepository(getConnector(), instanceName) );
+        try {
+            updater.update(originalDetails -> RyaDetails.builder( originalDetails ).removeUser(username).build());
+        } catch (RyaDetailsRepositoryException | CouldNotApplyMutationException e) {
+            throw new RyaClientException("Could not remove the user '" + username + "' from the Rya instance's details.", e);
+        }
+
+        // Revoke all access to all the instance's tables.
+        try {
+            // Build the list of tables that are present within the Rya instance.
+            final List<String> tables = new RyaTableNames().getTableNames(instanceName, getConnector());
+
+            // Update the user permissions for those tables.
+            for(final String table : tables) {
+                try {
+                    TABLE_PERMISSIONS.revokeAllPermissions(username, table, getConnector());
+                } catch (AccumuloException | AccumuloSecurityException e) {
+                    throw new RyaClientException("Could not revoke access to table '" + table + "' from user '" + username + "'.", e);
+                }
+            }
+        } catch (PCJStorageException | RyaDetailsRepositoryException e) {
+            throw new RyaClientException("Could not determine which tables exist for the '" + instanceName + "' instance of Rya.", e);
+        }
+    }
+}

--- a/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/AccumuloRyaClientFactory.java
+++ b/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/AccumuloRyaClientFactory.java
@@ -24,7 +24,6 @@ import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.apache.accumulo.core.client.Connector;
-
 import org.apache.rya.api.client.RyaClient;
 
 /**
@@ -56,6 +55,8 @@ public class AccumuloRyaClientFactory {
                 new AccumuloBatchUpdatePCJ(connectionDetails, connector),
                 new AccumuloGetInstanceDetails(connectionDetails, connector),
                 new AccumuloInstanceExists(connectionDetails, connector),
-                new AccumuloListInstances(connectionDetails, connector));
+                new AccumuloListInstances(connectionDetails, connector),
+                new AccumuloAddUser(connectionDetails, connector),
+                new AccumuloRemoveUser(connectionDetails, connector));
     }
 }

--- a/extras/indexing/src/main/java/org/apache/rya/indexing/accumulo/temporal/AccumuloTemporalIndexer.java
+++ b/extras/indexing/src/main/java/org/apache/rya/indexing/accumulo/temporal/AccumuloTemporalIndexer.java
@@ -18,8 +18,11 @@
  */
 package org.apache.rya.indexing.accumulo.temporal;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.IOException;
 import java.nio.charset.CharacterCodingException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -51,15 +54,6 @@ import org.apache.commons.codec.binary.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
 import org.apache.log4j.Logger;
-import org.joda.time.DateTime;
-import org.openrdf.model.Literal;
-import org.openrdf.model.Resource;
-import org.openrdf.model.Statement;
-import org.openrdf.model.URI;
-import org.openrdf.query.QueryEvaluationException;
-
-import java.util.Arrays;
-import info.aduna.iteration.CloseableIteration;
 import org.apache.rya.accumulo.experimental.AbstractAccumuloIndexer;
 import org.apache.rya.api.RdfCloudTripleStoreConfiguration;
 import org.apache.rya.api.domain.RyaStatement;
@@ -72,6 +66,14 @@ import org.apache.rya.indexing.TemporalInstant;
 import org.apache.rya.indexing.TemporalInstantRfc3339;
 import org.apache.rya.indexing.TemporalInterval;
 import org.apache.rya.indexing.accumulo.ConfigUtils;
+import org.joda.time.DateTime;
+import org.openrdf.model.Literal;
+import org.openrdf.model.Resource;
+import org.openrdf.model.Statement;
+import org.openrdf.model.URI;
+import org.openrdf.query.QueryEvaluationException;
+
+import info.aduna.iteration.CloseableIteration;
 
 public class AccumuloTemporalIndexer extends AbstractAccumuloIndexer implements TemporalIndexer {
 
@@ -878,7 +880,18 @@ public class AccumuloTemporalIndexer extends AbstractAccumuloIndexer implements 
 
     @Override
     public String getTableName() {
-       return ConfigUtils.getTablePrefix(conf)  + TABLE_SUFFIX;
+       return makeTableName( ConfigUtils.getTablePrefix(conf) );
+    }
+
+    /**
+     * Make the Accumulo table name used by this indexer for a specific instance of Rya.
+     *
+     * @param ryaInstanceName -  The name of the Rya instance the table name is for. (not null)
+     * @return The Accumulo table name used by this indexer for a specific instance of Rya.
+     */
+    public static String makeTableName(final String ryaInstanceName) {
+        requireNonNull(ryaInstanceName);
+        return ryaInstanceName + TABLE_SUFFIX;
     }
 
     private void deleteStatement(final Statement statement) throws IOException, IllegalArgumentException {

--- a/extras/indexing/src/test/java/org/apache/rya/api/client/accumulo/AccumuloAddUserIT.java
+++ b/extras/indexing/src/test/java/org/apache/rya/api/client/accumulo/AccumuloAddUserIT.java
@@ -1,0 +1,267 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.api.client.accumulo;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.accumulo.core.client.AccumuloSecurityException;
+import org.apache.accumulo.core.client.admin.SecurityOperations;
+import org.apache.accumulo.core.client.security.tokens.PasswordToken;
+import org.apache.accumulo.core.security.SystemPermission;
+import org.apache.rya.accumulo.AccumuloITBase;
+import org.apache.rya.accumulo.AccumuloRdfConfiguration;
+import org.apache.rya.api.client.Install.InstallConfiguration;
+import org.apache.rya.api.client.RyaClient;
+import org.apache.rya.api.instance.RyaDetails;
+import org.apache.rya.indexing.accumulo.ConfigUtils;
+import org.apache.rya.sail.config.RyaSailFactory;
+import org.junit.Test;
+import org.openrdf.model.ValueFactory;
+import org.openrdf.sail.Sail;
+import org.openrdf.sail.SailConnection;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * Integration tests the methods of {@link AccumuloAddUser}.
+ */
+public class AccumuloAddUserIT extends AccumuloITBase {
+
+    /**
+     * Ensure that the user who installs the instance of Rya is reported as being a user who can access it.
+     */
+    @Test
+    public void ryaDetailsIncludesOriginalUser() throws Exception {
+        final SecurityOperations secOps = super.getConnector().securityOperations();
+
+        // Create the user that will install the instance of Rya.
+        secOps.createLocalUser("userA", new PasswordToken("userA"));
+        secOps.grantSystemPermission("userA", SystemPermission.CREATE_TABLE);
+
+        // Create a Rya Client for that user.
+        final RyaClient userAClient = AccumuloRyaClientFactory.build(
+                new AccumuloConnectionDetails("userA", "userA".toCharArray(), getInstanceName(), getZookeepers()),
+                super.getClusterInstance().getCluster().getConnector("userA", "userA"));
+
+        // Install the instance of Rya.
+        userAClient.getInstall().install("testInstance_", InstallConfiguration.builder().build());
+
+        // Ensure the Rya instance's details only contain the username of the user who installed the instance.
+        final ImmutableList<String> expectedUsers = ImmutableList.<String>builder()
+                .add("userA")
+                .build();
+
+        final RyaDetails details = userAClient.getGetInstanceDetails().getDetails("testInstance_").get();
+        assertEquals(expectedUsers, details.getUsers());
+    }
+
+    /**
+     * Ensure that when a user is added to a Rya instance that its details are updated to include the new user.
+     */
+    @Test
+    public void userAddedAlsoAddedToRyaDetails() throws Exception {
+        final SecurityOperations secOps = super.getConnector().securityOperations();
+
+        // Create the user that will install the instance of Rya.
+        secOps.createLocalUser("userA", new PasswordToken("userA"));
+        secOps.grantSystemPermission("userA", SystemPermission.CREATE_TABLE);
+
+        final RyaClient userAClient = AccumuloRyaClientFactory.build(
+                new AccumuloConnectionDetails("userA", "userA".toCharArray(), getInstanceName(), getZookeepers()),
+                super.getClusterInstance().getCluster().getConnector("userA", "userA"));
+
+        // Create the user that will be added to the instance of Rya.
+        secOps.createLocalUser("userB", new PasswordToken("userB"));
+
+        // Install the instance of Rya.
+        userAClient.getInstall().install("testInstance_", InstallConfiguration.builder().build());
+
+        // Add the user.
+        userAClient.getAddUser().addUser("testInstance_", "userB");
+
+        // Ensure the Rya instance's details have been updated to include the added user.
+        final ImmutableList<String> expectedUsers = ImmutableList.<String>builder()
+                .add("userA")
+                .add("userB")
+                .build();
+
+        final RyaDetails details = userAClient.getGetInstanceDetails().getDetails("testInstance_").get();
+        assertEquals(expectedUsers, details.getUsers());
+    }
+
+    /**
+     * Ensure a user that has not been added to the Rya instance can not interact with it.
+     */
+    @Test
+    public void userNotAddedCanNotInsert() throws Exception {
+        final SecurityOperations secOps = super.getConnector().securityOperations();
+
+        // Create the user that will install the instance of Rya.
+        secOps.createLocalUser("userA", new PasswordToken("userA"));
+        secOps.grantSystemPermission("userA", SystemPermission.CREATE_TABLE);
+
+        final RyaClient userAClient = AccumuloRyaClientFactory.build(
+                new AccumuloConnectionDetails("userA", "userA".toCharArray(), getInstanceName(), getZookeepers()),
+                super.getClusterInstance().getCluster().getConnector("userA", "userA"));
+
+        // Install the instance of Rya.
+        userAClient.getInstall().install("testInstance_", InstallConfiguration.builder().build());
+
+        // Create the user that will not be added to the instance of Rya, but will try to scan it.
+        secOps.createLocalUser("userB", new PasswordToken("userB"));
+
+        //Try to add a statement the Rya instance with the unauthorized user. This should fail.
+        boolean securityExceptionThrown = false;
+
+        Sail sail = null;
+        SailConnection sailConn = null;
+        try {
+            final AccumuloRdfConfiguration userBConf = makeRyaConfig("testInstance_", "userB", "userB", getInstanceName(), getZookeepers());
+            sail = RyaSailFactory.getInstance(userBConf);
+            sailConn = sail.getConnection();
+
+            final ValueFactory vf = sail.getValueFactory();
+            sailConn.addStatement(vf.createURI("urn:Alice"), vf.createURI("urn:talksTo"), vf.createURI("urn:Bob"));
+
+        } catch(final RuntimeException e) {
+            final Throwable cause = e.getCause();
+            if(cause instanceof AccumuloSecurityException) {
+                securityExceptionThrown = true;
+            }
+        } finally {
+            if(sailConn != null) {
+                try {
+                    sailConn.close();
+                } finally { }
+            }
+            if(sail != null) {
+                try {
+                    sail.shutDown();
+                } finally { }
+            }
+        }
+
+        assertTrue(securityExceptionThrown);
+    }
+
+    /**
+     * Ensure a user that has been added to the Rya instance can interact with it.
+     */
+    @Test
+    public void userAddedCanInsert() throws Exception {
+        final SecurityOperations secOps = super.getConnector().securityOperations();
+
+        // Create the user that will install the instance of Rya.
+        secOps.createLocalUser("userA", new PasswordToken("userA"));
+        secOps.grantSystemPermission("userA", SystemPermission.CREATE_TABLE);
+
+        final RyaClient userAClient = AccumuloRyaClientFactory.build(
+                new AccumuloConnectionDetails("userA", "userA".toCharArray(), getInstanceName(), getZookeepers()),
+                super.getClusterInstance().getCluster().getConnector("userA", "userA"));
+
+        // Create the user that will not be added to the instance of Rya, but will try to scan it.
+        secOps.createLocalUser("userB", new PasswordToken("userB"));
+
+        // Install the instance of Rya.
+        userAClient.getInstall().install("testInstance_", InstallConfiguration.builder().build());
+
+        // Add the user.
+        userAClient.getAddUser().addUser("testInstance_", "userB");
+
+        // Try to add a statement to the Rya instance. This should succeed.
+        Sail sail = null;
+        SailConnection sailConn = null;
+
+        try {
+            final AccumuloRdfConfiguration userBConf = makeRyaConfig("testInstance_", "userB", "userB", getInstanceName(), getZookeepers());
+            sail = RyaSailFactory.getInstance(userBConf);
+            sailConn = sail.getConnection();
+
+            final ValueFactory vf = sail.getValueFactory();
+            sailConn.begin();
+            sailConn.addStatement(vf.createURI("urn:Alice"), vf.createURI("urn:talksTo"), vf.createURI("urn:Bob"));
+            sailConn.close();
+
+        } finally {
+            if(sailConn != null) {
+                try {
+                    sailConn.close();
+                } finally { }
+            }
+            if(sail != null) {
+                try {
+                    sail.shutDown();
+                } finally { }
+            }
+        }
+    }
+
+    /**
+     * Ensure nothing happens if you try to add a user that is already there.
+     */
+    @Test
+    public void addUserTwice() throws Exception {
+        final SecurityOperations secOps = super.getConnector().securityOperations();
+
+        // Create the user that will install the instance of Rya.
+        secOps.createLocalUser("userA", new PasswordToken("userA"));
+        secOps.grantSystemPermission("userA", SystemPermission.CREATE_TABLE);
+
+        final RyaClient userAClient = AccumuloRyaClientFactory.build(
+                new AccumuloConnectionDetails("userA", "userA".toCharArray(), getInstanceName(), getZookeepers()),
+                super.getClusterInstance().getCluster().getConnector("userA", "userA"));
+
+        // Create the user that will not be added to the instance of Rya, but will try to scan it.
+        secOps.createLocalUser("userB", new PasswordToken("userB"));
+
+        // Install the instance of Rya.
+        userAClient.getInstall().install("testInstance_", InstallConfiguration.builder().build());
+
+        // Add the user.
+        userAClient.getAddUser().addUser("testInstance_", "userB");
+        userAClient.getAddUser().addUser("testInstance_", "userB");
+
+        // Ensure the Rya instance's details only contain the username of the user who installed the instance.
+        final ImmutableList<String> expectedUsers = ImmutableList.<String>builder()
+                .add("userA")
+                .add("userB")
+                .build();
+
+        final RyaDetails details = userAClient.getGetInstanceDetails().getDetails("testInstance_").get();
+        assertEquals(expectedUsers, details.getUsers());
+    }
+
+    private static AccumuloRdfConfiguration makeRyaConfig(
+            final String ryaInstanceName,
+            final String username,
+            final String password,
+            final String instanceName,
+            final String zookeepers) {
+        final AccumuloRdfConfiguration conf = new AccumuloRdfConfiguration();
+        conf.setTablePrefix(ryaInstanceName);
+        // Accumulo connection information.
+        conf.set(ConfigUtils.CLOUDBASE_USER, username);
+        conf.set(ConfigUtils.CLOUDBASE_PASSWORD, password);
+        conf.set(ConfigUtils.CLOUDBASE_INSTANCE, instanceName);
+        conf.set(ConfigUtils.CLOUDBASE_ZOOKEEPERS, zookeepers);
+        conf.set(ConfigUtils.CLOUDBASE_AUTHS, "");
+        return conf;
+    }
+}

--- a/extras/indexing/src/test/java/org/apache/rya/api/client/accumulo/AccumuloBatchUpdatePCJIT.java
+++ b/extras/indexing/src/test/java/org/apache/rya/api/client/accumulo/AccumuloBatchUpdatePCJIT.java
@@ -23,15 +23,6 @@ import static org.junit.Assert.assertEquals;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.rya.indexing.pcj.storage.PrecomputedJoinStorage;
-import org.apache.rya.indexing.pcj.storage.accumulo.AccumuloPcjStorage;
-import org.junit.Test;
-import org.openrdf.model.ValueFactory;
-import org.openrdf.query.BindingSet;
-import org.openrdf.query.impl.MapBindingSet;
-import org.openrdf.sail.Sail;
-import org.openrdf.sail.SailConnection;
-
 import org.apache.rya.accumulo.AccumuloITBase;
 import org.apache.rya.accumulo.AccumuloRdfConfiguration;
 import org.apache.rya.api.client.Install.InstallConfiguration;
@@ -39,7 +30,15 @@ import org.apache.rya.api.client.RyaClient;
 import org.apache.rya.indexing.accumulo.ConfigUtils;
 import org.apache.rya.indexing.external.PrecomputedJoinIndexerConfig.PrecomputedJoinStorageType;
 import org.apache.rya.indexing.external.PrecomputedJoinIndexerConfig.PrecomputedJoinUpdaterType;
+import org.apache.rya.indexing.pcj.storage.PrecomputedJoinStorage;
+import org.apache.rya.indexing.pcj.storage.accumulo.AccumuloPcjStorage;
 import org.apache.rya.sail.config.RyaSailFactory;
+import org.junit.Test;
+import org.openrdf.model.ValueFactory;
+import org.openrdf.query.BindingSet;
+import org.openrdf.query.impl.MapBindingSet;
+import org.openrdf.sail.Sail;
+import org.openrdf.sail.SailConnection;
 
 /**
  * Integration tests the methods of {@link AccumuloBatchUpdatePCJ}.

--- a/extras/indexing/src/test/java/org/apache/rya/api/client/accumulo/AccumuloGetInstanceDetailsIT.java
+++ b/extras/indexing/src/test/java/org/apache/rya/api/client/accumulo/AccumuloGetInstanceDetailsIT.java
@@ -27,10 +27,6 @@ import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.TableExistsException;
 import org.apache.accumulo.core.client.admin.TableOperations;
-import org.junit.Test;
-
-import com.google.common.base.Optional;
-
 import org.apache.rya.accumulo.AccumuloITBase;
 import org.apache.rya.api.RdfCloudTripleStoreConstants;
 import org.apache.rya.api.client.GetInstanceDetails;
@@ -42,12 +38,14 @@ import org.apache.rya.api.client.RyaClientException;
 import org.apache.rya.api.instance.RyaDetails;
 import org.apache.rya.api.instance.RyaDetails.EntityCentricIndexDetails;
 import org.apache.rya.api.instance.RyaDetails.FreeTextIndexDetails;
-import org.apache.rya.api.instance.RyaDetails.GeoIndexDetails;
 import org.apache.rya.api.instance.RyaDetails.JoinSelectivityDetails;
 import org.apache.rya.api.instance.RyaDetails.PCJIndexDetails;
 import org.apache.rya.api.instance.RyaDetails.PCJIndexDetails.FluoDetails;
 import org.apache.rya.api.instance.RyaDetails.ProspectorDetails;
 import org.apache.rya.api.instance.RyaDetails.TemporalIndexDetails;
+import org.junit.Test;
+
+import com.google.common.base.Optional;
 
 /**
  * Tests the methods of {@link AccumuloGetInstanceDetails}.
@@ -87,7 +85,7 @@ public class AccumuloGetInstanceDetailsIT extends AccumuloITBase {
                 // The version depends on how the test is packaged, so just grab whatever was stored.
                 .setRyaVersion( details.get().getRyaVersion() )
 
-                .setGeoIndexDetails( new GeoIndexDetails(true) )
+              //RYA-215                .setGeoIndexDetails( new GeoIndexDetails(true) )
                 .setTemporalIndexDetails(new TemporalIndexDetails(true) )
                 .setFreeTextDetails( new FreeTextIndexDetails(true) )
                 .setEntityCentricIndexDetails( new EntityCentricIndexDetails(true) )

--- a/extras/indexing/src/test/java/org/apache/rya/api/client/accumulo/AccumuloRemoveUserIT.java
+++ b/extras/indexing/src/test/java/org/apache/rya/api/client/accumulo/AccumuloRemoveUserIT.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.api.client.accumulo;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.accumulo.core.client.AccumuloSecurityException;
+import org.apache.accumulo.core.client.admin.SecurityOperations;
+import org.apache.accumulo.core.client.security.tokens.PasswordToken;
+import org.apache.accumulo.core.security.SystemPermission;
+import org.apache.rya.accumulo.AccumuloITBase;
+import org.apache.rya.accumulo.AccumuloRdfConfiguration;
+import org.apache.rya.api.client.Install.InstallConfiguration;
+import org.apache.rya.api.client.RyaClient;
+import org.apache.rya.api.instance.RyaDetails;
+import org.apache.rya.indexing.accumulo.ConfigUtils;
+import org.apache.rya.sail.config.RyaSailFactory;
+import org.junit.Test;
+import org.openrdf.model.ValueFactory;
+import org.openrdf.sail.Sail;
+import org.openrdf.sail.SailConnection;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * Integration tests the methods of {@link AccumuloRemoveUser}.
+ */
+public class AccumuloRemoveUserIT extends AccumuloITBase {
+
+    /**
+     * Ensure that when a user is removed from a Rya instance that its details are updated to no longer include the user.
+     */
+    @Test
+    public void removedUserNotInDetails() throws Exception {
+        final SecurityOperations secOps = super.getConnector().securityOperations();
+
+        // Create the user that will install the instance of Rya.
+        secOps.createLocalUser("userA", new PasswordToken("userA"));
+        secOps.grantSystemPermission("userA", SystemPermission.CREATE_TABLE);
+
+        final RyaClient userAClient = AccumuloRyaClientFactory.build(
+                new AccumuloConnectionDetails("userA", "userA".toCharArray(), getInstanceName(), getZookeepers()),
+                super.getClusterInstance().getCluster().getConnector("userA", "userA"));
+
+        // Create the user that will be added to the instance of Rya.
+        secOps.createLocalUser("userB", new PasswordToken("userB"));
+
+        final RyaClient userBClient = AccumuloRyaClientFactory.build(
+                new AccumuloConnectionDetails("userB", "userB".toCharArray(), getInstanceName(), getZookeepers()),
+                super.getClusterInstance().getCluster().getConnector("userB", "userB"));
+
+        // Install the instance of Rya.
+        userAClient.getInstall().install("testInstance_", InstallConfiguration.builder().build());
+
+        // Add userB.
+        userAClient.getAddUser().addUser("testInstance_", "userB");
+
+        // Remove userA.
+        userBClient.getRemoveUser().removeUser("testInstance_", "userA");
+
+        // Ensure the Rya instance's details have been updated to include the added user.
+        final ImmutableList<String> expectedUsers = ImmutableList.<String>builder()
+                .add("userB")
+                .build();
+
+        final RyaDetails details = userBClient.getGetInstanceDetails().getDetails("testInstance_").get();
+        assertEquals(expectedUsers, details.getUsers());
+    }
+
+    /**
+     * Ensure a user that has been removed from the Rya instance can not interact with it.
+     */
+    @Test
+    public void removedUserCanNotInsert() throws Exception {
+        final SecurityOperations secOps = super.getConnector().securityOperations();
+
+        // Create the user that will install the instance of Rya.
+        secOps.createLocalUser("userA", new PasswordToken("userA"));
+        secOps.grantSystemPermission("userA", SystemPermission.CREATE_TABLE);
+
+        final RyaClient userAClient = AccumuloRyaClientFactory.build(
+                new AccumuloConnectionDetails("userA", "userA".toCharArray(), getInstanceName(), getZookeepers()),
+                super.getClusterInstance().getCluster().getConnector("userA", "userA"));
+
+        // Create the user that will be added to the instance of Rya.
+        secOps.createLocalUser("userB", new PasswordToken("userB"));
+
+        final RyaClient userBClient = AccumuloRyaClientFactory.build(
+                new AccumuloConnectionDetails("userB", "userB".toCharArray(), getInstanceName(), getZookeepers()),
+                super.getClusterInstance().getCluster().getConnector("userB", "userB"));
+
+        // Install the instance of Rya.
+        userAClient.getInstall().install("testInstance_", InstallConfiguration.builder().build());
+
+        // Add userB.
+        userAClient.getAddUser().addUser("testInstance_", "userB");
+
+        // Remove userA.
+        userBClient.getRemoveUser().removeUser("testInstance_", "userA");
+
+        // Show that userA can not insert anything.
+        boolean securityExceptionThrown = false;
+
+        Sail sail = null;
+        SailConnection sailConn = null;
+        try {
+            final AccumuloRdfConfiguration userAConf = makeRyaConfig("testInstance_", "userA", "userA", getInstanceName(), getZookeepers());
+            sail = RyaSailFactory.getInstance(userAConf);
+            sailConn = sail.getConnection();
+
+            final ValueFactory vf = sail.getValueFactory();
+            sailConn.addStatement(vf.createURI("urn:Alice"), vf.createURI("urn:talksTo"), vf.createURI("urn:Bob"));
+
+        } catch(final RuntimeException e) {
+            final Throwable cause = e.getCause();
+            if(cause instanceof AccumuloSecurityException) {
+                securityExceptionThrown = true;
+            }
+        } finally {
+            if(sailConn != null) {
+                try {
+                    sailConn.close();
+                } finally { }
+            }
+            if(sail != null) {
+                try {
+                    sail.shutDown();
+                } finally { }
+            }
+        }
+
+        assertTrue(securityExceptionThrown);
+    }
+
+    private static AccumuloRdfConfiguration makeRyaConfig(
+            final String ryaInstanceName,
+            final String username,
+            final String password,
+            final String instanceName,
+            final String zookeepers) {
+        final AccumuloRdfConfiguration conf = new AccumuloRdfConfiguration();
+        conf.setTablePrefix(ryaInstanceName);
+        // Accumulo connection information.
+        conf.set(ConfigUtils.CLOUDBASE_USER, username);
+        conf.set(ConfigUtils.CLOUDBASE_PASSWORD, password);
+        conf.set(ConfigUtils.CLOUDBASE_INSTANCE, instanceName);
+        conf.set(ConfigUtils.CLOUDBASE_ZOOKEEPERS, zookeepers);
+        conf.set(ConfigUtils.CLOUDBASE_AUTHS, "");
+        return conf;
+    }
+}

--- a/extras/indexing/src/test/java/org/apache/rya/indexing/external/tupleSet/AccumuloIndexSetColumnVisibilityTest.java
+++ b/extras/indexing/src/test/java/org/apache/rya/indexing/external/tupleSet/AccumuloIndexSetColumnVisibilityTest.java
@@ -38,13 +38,26 @@ import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.minicluster.MiniAccumuloCluster;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.log4j.Logger;
+import org.apache.rya.accumulo.AccumuloRdfConfiguration;
+import org.apache.rya.accumulo.instance.AccumuloRyaInstanceDetailsRepository;
+import org.apache.rya.api.RdfCloudTripleStoreConfiguration;
+import org.apache.rya.api.instance.RyaDetails;
+import org.apache.rya.api.instance.RyaDetails.EntityCentricIndexDetails;
+import org.apache.rya.api.instance.RyaDetails.FreeTextIndexDetails;
+import org.apache.rya.api.instance.RyaDetails.JoinSelectivityDetails;
+import org.apache.rya.api.instance.RyaDetails.PCJIndexDetails;
+import org.apache.rya.api.instance.RyaDetails.ProspectorDetails;
+import org.apache.rya.api.instance.RyaDetails.TemporalIndexDetails;
+import org.apache.rya.api.instance.RyaDetailsRepository;
+import org.apache.rya.api.instance.RyaDetailsRepository.AlreadyInitializedException;
+import org.apache.rya.api.instance.RyaDetailsRepository.RyaDetailsRepositoryException;
+import org.apache.rya.indexing.accumulo.ConfigUtils;
 import org.apache.rya.indexing.pcj.storage.PrecomputedJoinStorage.PCJStorageException;
 import org.apache.rya.indexing.pcj.storage.accumulo.AccumuloPcjStorage;
 import org.apache.rya.indexing.pcj.storage.accumulo.PcjTableNameFactory;
 import org.apache.rya.indexing.pcj.storage.accumulo.VisibilityBindingSet;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.openrdf.model.impl.NumericLiteralImpl;
 import org.openrdf.model.impl.URIImpl;
@@ -59,21 +72,6 @@ import com.google.common.collect.Sets;
 import com.google.common.io.Files;
 
 import info.aduna.iteration.CloseableIteration;
-import org.apache.rya.accumulo.AccumuloRdfConfiguration;
-import org.apache.rya.accumulo.instance.AccumuloRyaInstanceDetailsRepository;
-import org.apache.rya.api.RdfCloudTripleStoreConfiguration;
-import org.apache.rya.api.instance.RyaDetails;
-import org.apache.rya.api.instance.RyaDetails.EntityCentricIndexDetails;
-import org.apache.rya.api.instance.RyaDetails.FreeTextIndexDetails;
-import org.apache.rya.api.instance.RyaDetails.GeoIndexDetails;
-import org.apache.rya.api.instance.RyaDetails.JoinSelectivityDetails;
-import org.apache.rya.api.instance.RyaDetails.PCJIndexDetails;
-import org.apache.rya.api.instance.RyaDetails.ProspectorDetails;
-import org.apache.rya.api.instance.RyaDetails.TemporalIndexDetails;
-import org.apache.rya.api.instance.RyaDetailsRepository;
-import org.apache.rya.api.instance.RyaDetailsRepository.AlreadyInitializedException;
-import org.apache.rya.api.instance.RyaDetailsRepository.RyaDetailsRepositoryException;
-import org.apache.rya.indexing.accumulo.ConfigUtils;
 
 /**
  * Tests the evaluation of {@link AccumuloIndexSet}.
@@ -176,7 +174,7 @@ public class AccumuloIndexSetColumnVisibilityTest {
                 .setRyaVersion("0.0.0.0")
                 .setFreeTextDetails( new FreeTextIndexDetails(true) )
                 .setEntityCentricIndexDetails( new EntityCentricIndexDetails(true) )
-                .setGeoIndexDetails( new GeoIndexDetails(true) )
+//RYA-215                .setGeoIndexDetails( new GeoIndexDetails(true) )
                 .setTemporalIndexDetails( new TemporalIndexDetails(true) )
                 .setPCJIndexDetails(
                         PCJIndexDetails.builder()

--- a/extras/rya.console/src/main/java/org/apache/rya/shell/RyaAdminCommands.java
+++ b/extras/rya.console/src/main/java/org/apache/rya/shell/RyaAdminCommands.java
@@ -24,20 +24,10 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.shell.core.CommandMarker;
-import org.springframework.shell.core.annotation.CliAvailabilityIndicator;
-import org.springframework.shell.core.annotation.CliCommand;
-import org.springframework.shell.core.annotation.CliOption;
-import org.springframework.stereotype.Component;
-
-import com.google.common.base.Optional;
-
 import org.apache.rya.api.client.GetInstanceDetails;
 import org.apache.rya.api.client.Install.DuplicateInstanceNameException;
 import org.apache.rya.api.client.Install.InstallConfiguration;
 import org.apache.rya.api.client.InstanceDoesNotExistException;
-import org.apache.rya.api.client.PCJDoesNotExistException;
 import org.apache.rya.api.client.RyaClient;
 import org.apache.rya.api.client.RyaClientException;
 import org.apache.rya.api.instance.RyaDetails;
@@ -47,6 +37,14 @@ import org.apache.rya.shell.util.InstallPrompt;
 import org.apache.rya.shell.util.InstanceNamesFormatter;
 import org.apache.rya.shell.util.RyaDetailsFormatter;
 import org.apache.rya.shell.util.SparqlPrompt;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.shell.core.CommandMarker;
+import org.springframework.shell.core.annotation.CliAvailabilityIndicator;
+import org.springframework.shell.core.annotation.CliCommand;
+import org.springframework.shell.core.annotation.CliOption;
+import org.springframework.stereotype.Component;
+
+import com.google.common.base.Optional;
 
 /**
  * Rya Shell commands that have to do with administrative tasks.
@@ -56,11 +54,12 @@ public class RyaAdminCommands implements CommandMarker {
 
     public static final String CREATE_PCJ_CMD = "create-pcj";
     public static final String DELETE_PCJ_CMD = "delete-pcj";
-    public static final String BATCH_UPDATE_PCJ_CMD = "batch-update-pcj";
     public static final String GET_INSTANCE_DETAILS_CMD = "get-instance-details";
     public static final String INSTALL_CMD = "install";
     public static final String LIST_INSTANCES_CMD = "list-instances";
     public static final String UNINSTALL_CMD = "uninstall";
+    public static final String ADD_USER_CMD = "add-user";
+    public static final String REMOVE_USER_CMD = "remove-user";
 
     private final SharedShellState state;
     private final InstallPrompt installPrompt;
@@ -71,7 +70,7 @@ public class RyaAdminCommands implements CommandMarker {
      *
      * @param state - Holds shared state between all of the command classes. (not null)
      * @param installPrompt - Prompts a user for installation details. (not null)
-     * @param sparqlPrompt - Prompts a user for create PCJ details. (not null)
+     * @param sparqlPrompt - Prompts a user for a SPARQL query. (not null)
      */
     @Autowired
     public RyaAdminCommands(final SharedShellState state, final InstallPrompt installPrompt, final SparqlPrompt sparqlPrompt) {
@@ -101,7 +100,9 @@ public class RyaAdminCommands implements CommandMarker {
      */
     @CliAvailabilityIndicator({
         GET_INSTANCE_DETAILS_CMD,
-        UNINSTALL_CMD })
+        UNINSTALL_CMD,
+        ADD_USER_CMD,
+        REMOVE_USER_CMD})
     public boolean areInstanceCommandsAvailable() {
         switch(state.getShellState().getConnectionState()) {
             case CONNECTED_TO_INSTANCE:
@@ -116,8 +117,7 @@ public class RyaAdminCommands implements CommandMarker {
      */
     @CliAvailabilityIndicator({
         CREATE_PCJ_CMD,
-        DELETE_PCJ_CMD,
-        BATCH_UPDATE_PCJ_CMD})
+        DELETE_PCJ_CMD })
     public boolean arePCJCommandsAvailable() {
         // The PCJ commands are only available if the Shell is connected to an instance of Rya
         // that is new enough to use the RyaDetailsRepository and is configured to maintain PCJs.
@@ -141,18 +141,18 @@ public class RyaAdminCommands implements CommandMarker {
     public String listInstances() {
         // Fetch the command that is connected to the store.
         final ShellState shellState = state.getShellState();
-        final RyaClient ryaClient = shellState.getConnectedCommands().get();
-        final Optional<String> ryaInstanceName = shellState.getRyaInstanceName();
+        final RyaClient commands = shellState.getConnectedCommands().get();
+        final Optional<String> ryaInstance = shellState.getRyaInstanceName();
 
         try {
             // Sort the names alphabetically.
-            final List<String> instanceNames = ryaClient.getListInstances().listInstances();
+            final List<String> instanceNames = commands.getListInstances().listInstances();
             Collections.sort( instanceNames );
 
             final String report;
             final InstanceNamesFormatter formatter = new InstanceNamesFormatter();
-            if(ryaInstanceName.isPresent()) {
-                report = formatter.format(instanceNames, ryaInstanceName.get());
+            if(ryaInstance.isPresent()) {
+                report = formatter.format(instanceNames, ryaInstance.get());
             } else {
                 report = formatter.format(instanceNames);
             }
@@ -166,7 +166,7 @@ public class RyaAdminCommands implements CommandMarker {
     @CliCommand(value = INSTALL_CMD, help = "Create a new instance of Rya.")
     public String install() {
         // Fetch the commands that are connected to the store.
-        final RyaClient ryaClient = state.getShellState().getConnectedCommands().get();
+        final RyaClient commands = state.getShellState().getConnectedCommands().get();
 
         String instanceName = null;
         InstallConfiguration installConfig = null;
@@ -182,7 +182,7 @@ public class RyaAdminCommands implements CommandMarker {
             }
 
             // Execute the command.
-            ryaClient.getInstall().install(instanceName, installConfig);
+            commands.getInstall().install(instanceName, installConfig);
             return String.format("The Rya instance named '%s' has been installed.", instanceName);
 
         } catch(final DuplicateInstanceNameException e) {
@@ -196,18 +196,18 @@ public class RyaAdminCommands implements CommandMarker {
     public String getInstanceDetails() {
         // Fetch the command that is connected to the store.
         final ShellState shellState = state.getShellState();
-        final RyaClient ryaClient = shellState.getConnectedCommands().get();
-        final String ryaInstanceName = shellState.getRyaInstanceName().get();
+        final RyaClient commands = shellState.getConnectedCommands().get();
+        final String ryaInstance = shellState.getRyaInstanceName().get();
 
         try {
-            final Optional<RyaDetails> details = ryaClient.getGetInstanceDetails().getDetails(ryaInstanceName);
+            final Optional<RyaDetails> details = commands.getGetInstanceDetails().getDetails(ryaInstance);
             if(details.isPresent()) {
                 return new RyaDetailsFormatter().format(details.get());
             } else {
                 return "This instance of Rya does not have a Rya Details table. Consider migrating to a newer version of Rya.";
             }
         } catch(final InstanceDoesNotExistException e) {
-            throw new RuntimeException(String.format("A Rya instance named '%s' does not exist.", ryaInstanceName), e);
+            throw new RuntimeException(String.format("A Rya instance named '%s' does not exist.", ryaInstance), e);
         } catch (final RyaClientException e) {
             throw new RuntimeException("Could not get the instance details. Reason: " + e.getMessage(), e);
         }
@@ -217,18 +217,18 @@ public class RyaAdminCommands implements CommandMarker {
     public String createPcj() {
         // Fetch the command that is connected to the store.
         final ShellState shellState = state.getShellState();
-        final RyaClient ryaClient = shellState.getConnectedCommands().get();
-        final String ryaInstanceName = shellState.getRyaInstanceName().get();
+        final RyaClient commands = shellState.getConnectedCommands().get();
+        final String ryaInstance = shellState.getRyaInstanceName().get();
 
         try {
             // Prompt the user for the SPARQL.
             final String sparql = sparqlPrompt.getSparql();
             // Execute the command.
-            final String pcjId = ryaClient.getCreatePCJ().createPCJ(ryaInstanceName, sparql);
+            final String pcjId = commands.getCreatePCJ().createPCJ(ryaInstance, sparql);
             // Return a message that indicates the ID of the newly created ID.
             return String.format("The PCJ has been created. Its ID is '%s'.", pcjId);
         } catch (final InstanceDoesNotExistException e) {
-            throw new RuntimeException(String.format("A Rya instance named '%s' does not exist.", ryaInstanceName), e);
+            throw new RuntimeException(String.format("A Rya instance named '%s' does not exist.", ryaInstance), e);
         } catch (final IOException | RyaClientException e) {
             throw new RuntimeException("Could not create the PCJ. Provided reasons: " + e.getMessage(), e);
         }
@@ -240,39 +240,54 @@ public class RyaAdminCommands implements CommandMarker {
             final String pcjId) {
         // Fetch the command that is connected to the store.
         final ShellState shellState = state.getShellState();
-        final RyaClient ryaClient = shellState.getConnectedCommands().get();
-        final String ryaInstanceName = shellState.getRyaInstanceName().get();
+        final RyaClient commands = shellState.getConnectedCommands().get();
+        final String ryaInstance = shellState.getRyaInstanceName().get();
 
         try {
             // Execute the command.
-            ryaClient.getDeletePCJ().deletePCJ(ryaInstanceName, pcjId);
+            commands.getDeletePCJ().deletePCJ(ryaInstance, pcjId);
             return "The PCJ has been deleted.";
 
         } catch (final InstanceDoesNotExistException e) {
-            throw new RuntimeException(String.format("A Rya instance named '%s' does not exist.", ryaInstanceName), e);
+            throw new RuntimeException(String.format("A Rya instance named '%s' does not exist.", ryaInstance), e);
         } catch (final RyaClientException e) {
             throw new RuntimeException("The PCJ could not be deleted. Provided reason: " + e.getMessage(), e);
         }
     }
 
-    @CliCommand(value = BATCH_UPDATE_PCJ_CMD, help = "Batch update a PCJ index using this client. This operation may take a long time.")
-    public String batchUpdatePcj(
-            @CliOption(key={"pcjId"}, mandatory = true, help = "The ID of the PCJ that will be updated.")
-            final String pcjId) {
-        // Fetch the command that is connected to the store.
+    @CliCommand(value = ADD_USER_CMD, help = "Adds an authorized user to the Rya instance.")
+    public void addUser(
+            @CliOption(key = {"username"}, mandatory = true, help = "The username of the user that will be granted access.")
+            final String username) {
+        // Fetch the Rya client that is connected to the store.
         final ShellState shellState = state.getShellState();
         final RyaClient ryaClient = shellState.getConnectedCommands().get();
-        final String ryaInstanceName = shellState.getRyaInstanceName().get();
+        final String ryaInstance = shellState.getRyaInstanceName().get();
 
         try {
-            ryaClient.getBatchUpdatePCJ().batchUpdate(ryaInstanceName, pcjId);
-            return "The PCJ's results have been updated.";
-        } catch(final InstanceDoesNotExistException e) {
-            throw new RuntimeException(String.format("A Rya instance named '%s' does not exist.", ryaInstanceName), e);
-        } catch(final PCJDoesNotExistException e) {
-            throw new RuntimeException(String.format("A PCJ with ID '%s' does not exist.", pcjId), e);
-        } catch(final RyaClientException e) {
-            throw new RuntimeException("The PCJ could not be deleted. Provided reason: " + e.getMessage(), e);
+            ryaClient.getAddUser().addUser(ryaInstance, username);
+        } catch (final InstanceDoesNotExistException e) {
+            throw new RuntimeException(String.format("A Rya instance named '%s' does not exist.", ryaInstance), e);
+        } catch (final RyaClientException e) {
+            throw new RuntimeException("The user's access could not be granted. Provided reason: " + e.getMessage(), e);
+        }
+    }
+
+    @CliCommand(value = REMOVE_USER_CMD, help = "Removes an authorized user from the Rya instance.")
+    public void removeUser(
+            @CliOption(key = {"username"}, mandatory = true, help = "The username of the user whose access will be revoked.")
+            final String username) {
+        // Fetch the Rya client that is connected to the store.
+        final ShellState shellState = state.getShellState();
+        final RyaClient ryaClient = shellState.getConnectedCommands().get();
+        final String ryaInstance = shellState.getRyaInstanceName().get();
+
+        try {
+            ryaClient.getRemoveUser().removeUser(ryaInstance, username);
+        } catch (final InstanceDoesNotExistException e) {
+            throw new RuntimeException(String.format("A Rya instance named '%s' does not exist.", ryaInstance), e);
+        } catch (final RyaClientException e) {
+            throw new RuntimeException("The user's access could not be revoked. Provided reason: " + e.getMessage(), e);
         }
     }
 }

--- a/extras/rya.console/src/main/java/org/apache/rya/shell/util/RyaDetailsFormatter.java
+++ b/extras/rya.console/src/main/java/org/apache/rya/shell/util/RyaDetailsFormatter.java
@@ -23,12 +23,13 @@ import static java.util.Objects.requireNonNull;
 import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
-import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableMap;
-
 import org.apache.rya.api.instance.RyaDetails;
 import org.apache.rya.api.instance.RyaDetails.PCJIndexDetails;
 import org.apache.rya.api.instance.RyaDetails.PCJIndexDetails.PCJDetails;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
 
 /**
  * Formats an instance of {@link RyaDetails}.
@@ -50,12 +51,13 @@ public class RyaDetailsFormatter {
         report.append("General Metadata:\n");
         report.append("  Instance Name: ").append(details.getRyaInstanceName()).append("\n");
         report.append("  RYA Version: ").append( details.getRyaVersion() ).append("\n");
+        report.append("  Users: ").append( Joiner.on(", ").join(details.getUsers()) ).append("\n");
 
         report.append("Secondary Indicies:\n");
         report.append("  Entity Centric Index:\n");
         report.append("    Enabled: ").append( details.getEntityCentricIndexDetails().isEnabled() ).append("\n");
-        report.append("  Geospatial Index:\n");
-        report.append("    Enabled: ").append( details.getGeoIndexDetails().isEnabled() ).append("\n");
+      //RYA-215        report.append("  Geospatial Index:\n");
+      //RYA-215        report.append("    Enabled: ").append( details.getGeoIndexDetails().isEnabled() ).append("\n");
         report.append("  Free Text Index:\n");
         report.append("    Enabled: ").append( details.getFreeTextIndexDetails().isEnabled() ).append("\n");
         report.append("  Temporal Index:\n");

--- a/extras/rya.console/src/test/java/org/apache/rya/shell/util/RyaDetailsFormatterTest.java
+++ b/extras/rya.console/src/test/java/org/apache/rya/shell/util/RyaDetailsFormatterTest.java
@@ -23,14 +23,9 @@ import static org.junit.Assert.assertEquals;
 import java.util.Date;
 import java.util.TimeZone;
 
-import org.junit.Test;
-
-import com.google.common.base.Optional;
-
 import org.apache.rya.api.instance.RyaDetails;
 import org.apache.rya.api.instance.RyaDetails.EntityCentricIndexDetails;
 import org.apache.rya.api.instance.RyaDetails.FreeTextIndexDetails;
-import org.apache.rya.api.instance.RyaDetails.GeoIndexDetails;
 import org.apache.rya.api.instance.RyaDetails.JoinSelectivityDetails;
 import org.apache.rya.api.instance.RyaDetails.PCJIndexDetails;
 import org.apache.rya.api.instance.RyaDetails.PCJIndexDetails.FluoDetails;
@@ -38,6 +33,9 @@ import org.apache.rya.api.instance.RyaDetails.PCJIndexDetails.PCJDetails;
 import org.apache.rya.api.instance.RyaDetails.PCJIndexDetails.PCJDetails.PCJUpdateStrategy;
 import org.apache.rya.api.instance.RyaDetails.ProspectorDetails;
 import org.apache.rya.api.instance.RyaDetails.TemporalIndexDetails;
+import org.junit.Test;
+
+import com.google.common.base.Optional;
 
 /**
  * Tests the methods of {@link RyaDetailsFormatter}.
@@ -51,8 +49,11 @@ public class RyaDetailsFormatterTest {
         // Create the object that will be formatted.
         final RyaDetails details = RyaDetails.builder().setRyaInstanceName("test_instance")
             .setRyaVersion("1.2.3.4")
+            .addUser("alice")
+            .addUser("bob")
+            .addUser("charlie")
             .setEntityCentricIndexDetails( new EntityCentricIndexDetails(true) )
-            .setGeoIndexDetails( new GeoIndexDetails(true) )
+          //RYA-215            .setGeoIndexDetails( new GeoIndexDetails(true) )
             .setTemporalIndexDetails( new TemporalIndexDetails(true) )
             .setFreeTextDetails( new FreeTextIndexDetails(true) )
             .setPCJIndexDetails(
@@ -79,11 +80,12 @@ public class RyaDetailsFormatterTest {
                 "General Metadata:\n" +
                 "  Instance Name: test_instance\n" +
                 "  RYA Version: 1.2.3.4\n" +
+                "  Users: alice, bob, charlie\n" +
                 "Secondary Indicies:\n" +
                 "  Entity Centric Index:\n" +
                 "    Enabled: true\n" +
-                "  Geospatial Index:\n" +
-                "    Enabled: true\n" +
+              //RYA-215                "  Geospatial Index:\n" +
+            //RYA-215                "    Enabled: true\n" +
                 "  Free Text Index:\n" +
                 "    Enabled: true\n" +
                 "  Temporal Index:\n" +

--- a/extras/rya.pcj.fluo/pcj.fluo.demo/src/main/java/org/apache/rya/indexing/pcj/fluo/demo/DemoDriver.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.demo/src/main/java/org/apache/rya/indexing/pcj/fluo/demo/DemoDriver.java
@@ -34,29 +34,16 @@ import org.apache.accumulo.core.client.Instance;
 import org.apache.accumulo.core.client.ZooKeeperInstance;
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
 import org.apache.accumulo.minicluster.MiniAccumuloCluster;
-import org.apache.log4j.ConsoleAppender;
-import org.apache.log4j.Level;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
-import org.apache.log4j.PatternLayout;
-import org.apache.rya.indexing.pcj.fluo.app.export.rya.RyaExportParameters;
-import org.apache.rya.indexing.pcj.fluo.app.observers.FilterObserver;
-import org.apache.rya.indexing.pcj.fluo.app.observers.JoinObserver;
-import org.apache.rya.indexing.pcj.fluo.app.observers.QueryResultObserver;
-import org.apache.rya.indexing.pcj.fluo.app.observers.StatementPatternObserver;
-import org.apache.rya.indexing.pcj.fluo.app.observers.TripleObserver;
-import org.apache.rya.indexing.pcj.fluo.demo.Demo.DemoExecutionException;
-import org.openrdf.repository.RepositoryConnection;
-import org.openrdf.repository.RepositoryException;
-
-import com.google.common.base.Optional;
-import com.google.common.io.Files;
-
 import org.apache.fluo.api.client.FluoClient;
 import org.apache.fluo.api.client.FluoFactory;
 import org.apache.fluo.api.config.FluoConfiguration;
 import org.apache.fluo.api.config.ObserverSpecification;
 import org.apache.fluo.api.mini.MiniFluo;
+import org.apache.log4j.ConsoleAppender;
+import org.apache.log4j.Level;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.apache.log4j.PatternLayout;
 import org.apache.rya.accumulo.AccumuloRdfConfiguration;
 import org.apache.rya.accumulo.AccumuloRyaDAO;
 import org.apache.rya.accumulo.instance.AccumuloRyaInstanceDetailsRepository;
@@ -64,7 +51,6 @@ import org.apache.rya.api.RdfCloudTripleStoreConfiguration;
 import org.apache.rya.api.instance.RyaDetails;
 import org.apache.rya.api.instance.RyaDetails.EntityCentricIndexDetails;
 import org.apache.rya.api.instance.RyaDetails.FreeTextIndexDetails;
-import org.apache.rya.api.instance.RyaDetails.GeoIndexDetails;
 import org.apache.rya.api.instance.RyaDetails.JoinSelectivityDetails;
 import org.apache.rya.api.instance.RyaDetails.PCJIndexDetails;
 import org.apache.rya.api.instance.RyaDetails.ProspectorDetails;
@@ -72,8 +58,20 @@ import org.apache.rya.api.instance.RyaDetails.TemporalIndexDetails;
 import org.apache.rya.api.instance.RyaDetailsRepository;
 import org.apache.rya.api.instance.RyaDetailsRepository.AlreadyInitializedException;
 import org.apache.rya.api.instance.RyaDetailsRepository.RyaDetailsRepositoryException;
+import org.apache.rya.indexing.pcj.fluo.app.export.rya.RyaExportParameters;
+import org.apache.rya.indexing.pcj.fluo.app.observers.FilterObserver;
+import org.apache.rya.indexing.pcj.fluo.app.observers.JoinObserver;
+import org.apache.rya.indexing.pcj.fluo.app.observers.QueryResultObserver;
+import org.apache.rya.indexing.pcj.fluo.app.observers.StatementPatternObserver;
+import org.apache.rya.indexing.pcj.fluo.app.observers.TripleObserver;
+import org.apache.rya.indexing.pcj.fluo.demo.Demo.DemoExecutionException;
 import org.apache.rya.rdftriplestore.RdfCloudTripleStore;
 import org.apache.rya.rdftriplestore.RyaSailRepository;
+import org.openrdf.repository.RepositoryConnection;
+import org.openrdf.repository.RepositoryException;
+
+import com.google.common.base.Optional;
+import com.google.common.io.Files;
 
 /**
  * Runs {@link Demo}s that require Rya and Fluo.
@@ -274,7 +272,7 @@ public class DemoDriver {
                 .setRyaVersion("0.0.0.0")
                 .setFreeTextDetails( new FreeTextIndexDetails(true) )
                 .setEntityCentricIndexDetails( new EntityCentricIndexDetails(true) )
-                .setGeoIndexDetails( new GeoIndexDetails(true) )
+              //RYA-215                .setGeoIndexDetails( new GeoIndexDetails(true) )
                 .setTemporalIndexDetails( new TemporalIndexDetails(true) )
                 .setPCJIndexDetails(
                         PCJIndexDetails.builder()


### PR DESCRIPTION
Added two new commands to the RyaClient class. AddUser and RemoveUser. Users that have been added to the Rya instance are tracked within the RyaDetails for the instance and they are granted full table permissions. When you revoke a user from the instance, they also have all table permissions revoked.
