### PR TITLE
RYA-176 Adding DEPENDENCIES to RAT Exclusion

### DIFF
--- a/extras/rya.console/pom.xml
+++ b/extras/rya.console/pom.xml
@@ -97,6 +97,19 @@
     </dependencies>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.rat</groupId>
+                    <artifactId>apache-rat-plugin</artifactId>
+                    <configuration>
+                        <excludes>
+                            <exclude>spring-shell.log</exclude>
+                        </excludes>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <!-- Automatically place Apache 2 license headers at the top of all of the project's Java files.
                  Rat runs during the 'validate' lifecycle step, so it will fail the build before this one 

--- a/extras/rya.merger/pom.xml
+++ b/extras/rya.merger/pom.xml
@@ -176,7 +176,7 @@ under the License.
                     <artifactId>apache-rat-plugin</artifactId>
                     <configuration>
                         <excludes>
-                            Accumulo data Files
+                            <!-- Accumulo data Files -->
                             <exclude>**/*.rf</exclude>
                         </excludes>
                     </configuration>
@@ -184,14 +184,6 @@ under the License.
             </plugins>
         </pluginManagement>
         <plugins>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.0.2</version>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
-            </plugin>
 
             <!--
             <plugin>

--- a/extras/vagrantExample/pom.xml
+++ b/extras/vagrantExample/pom.xml
@@ -30,17 +30,19 @@ under the License.
     <name>Apache Rya Vagrant VM</name>
 
     <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.rat</groupId>
-                <artifactId>apache-rat-plugin</artifactId>
-                <configuration>
-                    <excludes combine.children="append">
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.rat</groupId>
+                    <artifactId>apache-rat-plugin</artifactId>
+                    <configuration>
+                    <excludes>
                         <!--  Vagrant may leave around some files.  These are not checked in -->
                         <exclude>**/src/main/vagrant/.vagrant/**</exclude>
                     </excludes>
-                </configuration>
-            </plugin>
-        </plugins>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 </project>

--- a/pig/accumulo.pig/pom.xml
+++ b/pig/accumulo.pig/pom.xml
@@ -63,18 +63,22 @@ under the License.
         </dependency>
     </dependencies>
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.rat</groupId>
+                    <artifactId>apache-rat-plugin</artifactId>
+                    <configuration>
+                        <excludes>
+                            <exclude>src/test/resources/ResultsFile1.txt</exclude>
+                            <exclude>src/test/resources/testQuery.txt</exclude>
+                            <exclude>src/test/resources/testQuery2.txt</exclude>
+                        </excludes>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
-            <plugin>
-                <groupId>org.apache.rat</groupId>
-                <artifactId>apache-rat-plugin</artifactId>
-                <configuration>
-                    <excludes combine.children="append">
-                        <exclude>src/test/resources/ResultsFile1.txt</exclude>
-                        <exclude>src/test/resources/testQuery.txt</exclude>
-                        <exclude>src/test/resources/testQuery2.txt</exclude>
-                    </excludes>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -718,11 +718,21 @@ under the License.
                                         </goals>
                                     </pluginExecutionFilter>
                                     <action>
-                                        <ignore></ignore>
+                                        <ignore />
                                     </action>
                                 </pluginExecution>
                             </pluginExecutions>
                         </lifecycleMappingMetadata>
+                    </configuration>
+                </plugin>
+               <plugin>
+                    <!-- Apache Release Audit Tool - reports missing license headers and other issues. -->
+                    <groupId>org.apache.rat</groupId>
+                    <artifactId>apache-rat-plugin</artifactId>
+                    <configuration>
+                        <excludes>
+                            <exclude>DEPENDENCIES</exclude>
+                        </excludes>
                     </configuration>
                 </plugin>
             </plugins>
@@ -736,6 +746,7 @@ under the License.
            </plugin>
            <plugin>
                 <!-- Apache Release Audit Tool - reports missing license headers and other issues. -->
+                <!-- Note: Add exclusions to deepest maven submodule/project in the plug-in management section -->
                 <groupId>org.apache.rat</groupId>
                 <artifactId>apache-rat-plugin</artifactId>
                 <executions>


### PR DESCRIPTION
## Description
Updated the POMs to ignore `DEPENDENCIES` file contained in release.  Also some minor updates (`rya.console` had a log file hanging out, updated consistent use of rat exclusions and documented, removed a random java version override)

### Tests

No tests written.  Performed a `mvn clean install` to double check build.

### Links
[Jira](https://issues.apache.org/jira/browse/RYA-176)

### Checklist
- [ ] Code Review
- [x] Squash Commits

#### People To Reivew
@pujav65 