### PR TITLE
Rya-183 Run the example apps when automated tests are run

### DIFF
--- a/extras/indexingExample/src/main/java/RyaDirectExample.java
+++ b/extras/indexingExample/src/main/java/RyaDirectExample.java
@@ -795,7 +795,7 @@ public class RyaDirectExample {
 					queryString2, new String[] { "e", "c", "l", "o" },
 					Optional.<PcjVarOrderFactory> absent());
 		} catch (final RyaDAOException e) {
-			e.printStackTrace();
+			throw new Error("While creating PCJ tables.",e);
 		} finally {
 			closeQuietly(conn);
 			closeQuietly(repository);

--- a/extras/indexingExample/src/test/java/ExamplesTest.java
+++ b/extras/indexingExample/src/test/java/ExamplesTest.java
@@ -1,0 +1,40 @@
+import org.junit.Test;
+/**
+ * Solves the problem of examples getting bugs when tests are passing.
+ * Fixers generally don't run the examples or don't know they are affecting the examples.
+ * Examples generally create and destroy a mock instance of Accumulo, or a test instance of MongoDB.
+ */
+public class ExamplesTest {
+	/**
+	 * Calls main.  Fails if errors are thrown and not caught. parameters are not used.
+	 * @throws Exception
+	 */
+	@Test
+	public void RyaDirectExampleTest() throws Exception {
+		RyaDirectExample.main(new String[] {});
+	}
+	/**
+	 * Calls main.  Fails if errors are thrown and not caught. parameters are not used.
+	 * @throws Exception
+	 */
+	@Test
+	public void RyaClientExampleTest() throws Exception {
+		 RyaClientExample.main(new String[] {});
+	}
+	/**
+	 * Calls main.  Fails if errors are thrown and not caught. parameters are not used.
+	 * @throws Exception
+	 */
+	@Test
+	public void MongoRyaDirectExampleTest() throws Exception {
+		 MongoRyaDirectExample.main(new String[] {});
+	}
+	/**
+	 * Calls main.  Fails if errors are thrown and not caught. parameters are not used.
+	 * @throws Exception
+	 */
+	@Test
+	public void EntityDirectExampleTest() throws Exception {
+		 EntityDirectExample.main(new String[] {});
+	}
+}


### PR DESCRIPTION
## Description
Created ExamplesTest.java in a new test/java folder. it calls main() of four example applications. One of them: RyaDirectExample catches errors that would hide a potential defect.  Now it rethrows as a new Error(). 

### Tests
This work is a JUnit test that tests existing code.

### Links
[Jira RYA-183](https://issues.apache.org/jira/browse/RYA-183)

### Checklist
- [ ] Code Review
- [x] Squash Commits

#### People To Reivew
Anyone.  Aaron has already taken a quick look.
