### PR TITLE
rya-177 WIP; indexing and mapreduce are now optional profiles in Mave…

### DIFF
--- a/extras/indexing/pom.xml
+++ b/extras/indexing/pom.xml
@@ -26,6 +26,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <geotools.version>14.3</geotools.version>
+        <geomesa.version>1.2.0</geomesa.version> <!-- Newest: 1.2.0 -->
     </properties>
     <repositories>
         <repository>
@@ -87,6 +88,17 @@
 			<groupId>org.locationtech.geomesa</groupId>
 			<artifactId>geomesa-accumulo-datastore</artifactId>
 		</dependency>
+            <!-- Geo Indexing -->
+            <dependency>
+                <groupId>org.locationtech.geomesa</groupId>
+                <artifactId>geomesa-accumulo-datastore</artifactId>
+                <version>${geomesa.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.locationtech.geomesa</groupId>
+                <artifactId>geomesa-accumulo-distributed-runtime</artifactId>
+                <version>${geomesa.version}</version>
+            </dependency>
 
 		<!-- PCJ Indexing -->
 		<dependency>

--- a/extras/pom.xml
+++ b/extras/pom.xml
@@ -35,13 +35,21 @@ under the License.
         <module>rya.manual</module>
         <module>tinkerpop.rya</module>
         <module>rya.console</module>
-        <module>indexing</module>
-        <module>rya.indexing.pcj</module>
-        <module>indexingExample</module>
         <module>rya.reasoning</module>
         <module>vagrantExample</module>
-        <module>rya.pcj.fluo</module>
         <module>rya.merger</module>
         <module>rya.benchmark</module>
     </modules>
+    <profiles>
+        <profile>
+            <id>indexing</id>
+            <modules>
+                <module>indexing</module>
+                <module>rya.indexing.pcj</module>
+                <module>indexingExample</module>
+                <module>rya.pcj.fluo</module>
+                <module>indexing</module>
+            </modules>
+        </profile>
+    </profiles>
 </project>

--- a/extras/rya.console/pom.xml
+++ b/extras/rya.console/pom.xml
@@ -111,28 +111,6 @@
             </plugins>
         </pluginManagement>
         <plugins>
-            <!-- Automatically place Apache 2 license headers at the top of all of the project's Java files.
-                 Rat runs during the 'validate' lifecycle step, so it will fail the build before this one 
-                 executes if any of the headers are missing. Run the build with rat turned off to add
-                 missing headers to the Java files. -->
-            <plugin>
-                <groupId>com.mycila</groupId>
-                <artifactId>license-maven-plugin</artifactId>
-                <version>2.6</version>
-                <configuration>
-                    <!-- We use a custome Apache 2.0 license because we do not include a copywrite section. -->                
-                    <header>src/main/resources/LICENSE.txt</header>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>process-sources</phase>
-                        <goals>
-                            <goal>format</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            
             <!-- Create an executable jar file for the shell. -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -60,12 +60,21 @@ under the License.
         <module>common</module>
         <module>dao</module>
         <module>extras</module>
-        <module>mapreduce</module>
         <module>osgi</module>
         <module>pig</module>
         <module>sail</module>
         <module>web</module>
     </modules>
+    <profiles>
+        <profile>
+            <id>mapreduce</id>
+            <modules>
+                <module>mapreduce</module>
+                <module>indexing</module>
+                <module>indexingSailExample</module>
+            </modules>
+        </profile>
+    </profiles>
     <properties>
         <openrdf.sesame.version>2.7.6</openrdf.sesame.version> <!-- Newest: 4.0.0 -->
         <!--Cannot upgrade to openrdf.sesame 2.7.6 until RYA-9 is resolved -->
@@ -77,7 +86,8 @@ under the License.
         <zookeeper.version>3.4.6</zookeeper.version>
 
         <pig.version>0.9.2</pig.version> <!-- Newest: 0.15.0 -->
-
+        
+        <!-- Can we move geomesa to indexing? -->
         <geomesa.version>1.2.0</geomesa.version> <!-- Newest: 1.2.0 -->
         <lucene.version>3.6.2</lucene.version> <!-- Newest: 5.3.1 -->
         <joda-time.version>2.1</joda-time.version> <!-- Newest: 2.9.1 -->
@@ -462,6 +472,7 @@ under the License.
             </dependency>
 
             <!-- Geo Indexing -->
+            <!-- Can we move geomesa to extras/indexing? -->
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
                 <artifactId>geomesa-accumulo-datastore</artifactId>


### PR DESCRIPTION
Closing this un-pulled because of a better effort that only removed geo dependencies.
## Description
>What Changed?

Made indexing and mapreduce modules part of profiles that are not built unless using one of these:
    mvn ... -P indexing 
    mvn ... -P mapreduce 

The purpose is to make geotools related features optional since it has an LGPL license.
Also under RYA-177 are removing several other less difficult dependencies.

TODO: remove Geo dependencies from top level POM.xml and find dependencies.  They are marked with comments.  Also remove other dependencies that have incompatible licenses.

### Tests
>Coverage?

No additional junit tests are needed.  A good test is to run exactly this in the project root:
    mvn license:aggregate-add-third-party

GeoTools should be missing.  Also look for GPL and LGPL and some other incompatible licensed libraries.  look on the rya dev list where I posted the subset of bad ones.  It subject has the wrong issue number, here it is:

subject: RYA-179 Review License / Copyright notices on Rya Artifacts
found here: https://www.mail-archive.com/dev@rya.incubator.apache.org/msg00969.html

### Links
[Jira](https://issues.apache.org/jira/browse/RYA-177)

### Checklist
- [ ] Code Review
- [ ] Squash Commits

#### People To Reivew
