### PR TITLE
Rya 189 mongo arch dependant

### DIFF
--- a/dao/mongodb.rya/pom.xml
+++ b/dao/mongodb.rya/pom.xml
@@ -44,6 +44,29 @@ under the License.
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <configuration>
+                    <rules>
+                        <!-- Flapdoodle (for testing MongoDB) was failing for 32 bit architecture -->
+                        <requireOS>
+                            <message>Flapdoodle (for testing MongoDB) was failing for 32 bit architecture </message>
+                            <!--  <arch>!x86</arch>  -->
+                            <arch>amd64</arch>
+                        </requireOS>
+                        <requireOS>
+                            <message>Flapdoodle (for testing MongoDB) was failing for 32 bit architecture </message>
+                            <arch>i686_64</arch>
+                        </requireOS>
+                        <requireOS>
+                            <message>Flapdoodle (for testing MongoDB) was failing for 32 bit architecture </message>
+                            <arch>x86_64</arch>
+                        </requireOS>
+                    </rules>
+                    <fail>true</fail>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/dao/mongodb.rya/pom.xml
+++ b/dao/mongodb.rya/pom.xml
@@ -49,19 +49,11 @@ under the License.
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <configuration>
                     <rules>
-                        <!-- Flapdoodle (for testing MongoDB) was failing for 32 bit architecture -->
                         <requireOS>
-                            <message>Flapdoodle (for testing MongoDB) was failing for 32 bit architecture </message>
-                            <!--  <arch>!x86</arch>  -->
-                            <arch>amd64</arch>
-                        </requireOS>
-                        <requireOS>
-                            <message>Flapdoodle (for testing MongoDB) was failing for 32 bit architecture </message>
-                            <arch>i686_64</arch>
-                        </requireOS>
-                        <requireOS>
-                            <message>Flapdoodle (for testing MongoDB) was failing for 32 bit architecture </message>
-                            <arch>x86_64</arch>
+                        <message>Testing MongoDB with Flapdoodle fails for arch=x86, which is 32bit JVM, fix by using a 64bit JDK 
+Tests will fail with the following error when using 32bit JVM on either Linux or Windows:
+                        java.io.IOException: Could not start process: &lt;EOF&gt;</message>
+                             <arch>!x86</arch> 
                         </requireOS>
                     </rules>
                     <fail>true</fail>


### PR DESCRIPTION
## Description

Made the build fail for module mongodb.rya if using a 32bit JVM/JDK.
When it fails, it provides an explanation and recomendation to use a 64bit JVM.
Currently the tests fail when using a 32bit JVM with output that give little clue to the cause.

### Tests

No unit tests need.
Test manually like this:

#### The usual case:
Run a build using a 64bit JVM installed:

> mvn install   -rf  :mongodb.rya

#### The new case:
Install a 32bit JDK, for example jdk1.8.0_102.
Run this command to cause it to be used (replace the path to the JDK):

In Linux:
> JAVA_HOME='/whatever/Java32bit/jdk1.8.0_102' mvn install   -rf  :mongodb.rya

or in Windows using git bash or MSYS2:

> JAVA_HOME='C:\Program Files (x86)\Java\jdk1.8.0_102' mvn install   -rf  :mongodb.rya

Expect this output:

> [WARNING] Rule 0: org.apache.maven.plugins.enforcer.RequireOS failed with message:
> Testing MongoDB with Flapdoodle fails for arch=x86, which is 32bit JVM, fix by using a 64bit JDK
> Tests will fail with the following error when using 32bit JVM on either Linux or Windows:
>                         java.io.IOException: Could not start process: <EOF>

Followed by an enforcer error.

### Links
[Jira](https://issues.apache.org/jira/browse/RYA-189)

### Checklist
- [x] Code Review
- [ ] Squash Commits

#### People To Reivew
Caleb has a linux based 32bit SDK.  I did not test that.
or Aaron, anyone.
