### PR TITLE
RYA-200 Removing findbugs:jsr305 Dependency

### DIFF
--- a/common/rya.api/pom.xml
+++ b/common/rya.api/pom.xml
@@ -62,6 +62,11 @@ under the License.
             <artifactId>findbugs-annotations</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.github.stephenc.jcip</groupId>
+            <artifactId>jcip-annotations</artifactId>
+        </dependency>
+        
+        <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
         </dependency>

--- a/common/rya.api/pom.xml
+++ b/common/rya.api/pom.xml
@@ -58,6 +58,10 @@ under the License.
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.github.stephenc.findbugs</groupId>
+            <artifactId>findbugs-annotations</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
         </dependency>

--- a/common/rya.api/src/main/java/org/apache/rya/api/client/BatchUpdatePCJ.java
+++ b/common/rya.api/src/main/java/org/apache/rya/api/client/BatchUpdatePCJ.java
@@ -18,12 +18,13 @@
  */
 package org.apache.rya.api.client;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * Batch update a PCJ index.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public interface BatchUpdatePCJ {
 
     /**

--- a/common/rya.api/src/main/java/org/apache/rya/api/client/BatchUpdatePCJ.java
+++ b/common/rya.api/src/main/java/org/apache/rya/api/client/BatchUpdatePCJ.java
@@ -18,12 +18,12 @@
  */
 package org.apache.rya.api.client;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 /**
  * Batch update a PCJ index.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public interface BatchUpdatePCJ {
 
     /**

--- a/common/rya.api/src/main/java/org/apache/rya/api/client/CreatePCJ.java
+++ b/common/rya.api/src/main/java/org/apache/rya/api/client/CreatePCJ.java
@@ -18,12 +18,12 @@
  */
 package org.apache.rya.api.client;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 /**
  * Create a new PCJ within the target instance of Rya.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public interface CreatePCJ {
 
     /**

--- a/common/rya.api/src/main/java/org/apache/rya/api/client/CreatePCJ.java
+++ b/common/rya.api/src/main/java/org/apache/rya/api/client/CreatePCJ.java
@@ -18,12 +18,13 @@
  */
 package org.apache.rya.api.client;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * Create a new PCJ within the target instance of Rya.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public interface CreatePCJ {
 
     /**

--- a/common/rya.api/src/main/java/org/apache/rya/api/client/DeletePCJ.java
+++ b/common/rya.api/src/main/java/org/apache/rya/api/client/DeletePCJ.java
@@ -18,12 +18,13 @@
  */
 package org.apache.rya.api.client;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * Deletes a PCJ from an instance of Rya.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public interface DeletePCJ {
 
     /**

--- a/common/rya.api/src/main/java/org/apache/rya/api/client/DeletePCJ.java
+++ b/common/rya.api/src/main/java/org/apache/rya/api/client/DeletePCJ.java
@@ -18,12 +18,12 @@
  */
 package org.apache.rya.api.client;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 /**
  * Deletes a PCJ from an instance of Rya.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public interface DeletePCJ {
 
     /**

--- a/common/rya.api/src/main/java/org/apache/rya/api/client/GetInstanceDetails.java
+++ b/common/rya.api/src/main/java/org/apache/rya/api/client/GetInstanceDetails.java
@@ -18,7 +18,8 @@
  */
 package org.apache.rya.api.client;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import com.google.common.base.Optional;
 
@@ -27,7 +28,7 @@ import org.apache.rya.api.instance.RyaDetails;
 /**
  * Get configuration and maintenance information about a specific instance of Rya.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public interface GetInstanceDetails {
 
     /**

--- a/common/rya.api/src/main/java/org/apache/rya/api/client/GetInstanceDetails.java
+++ b/common/rya.api/src/main/java/org/apache/rya/api/client/GetInstanceDetails.java
@@ -18,7 +18,7 @@
  */
 package org.apache.rya.api.client;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import com.google.common.base.Optional;
 
@@ -27,7 +27,7 @@ import org.apache.rya.api.instance.RyaDetails;
 /**
  * Get configuration and maintenance information about a specific instance of Rya.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public interface GetInstanceDetails {
 
     /**

--- a/common/rya.api/src/main/java/org/apache/rya/api/client/Install.java
+++ b/common/rya.api/src/main/java/org/apache/rya/api/client/Install.java
@@ -23,15 +23,16 @@ import static java.util.Objects.requireNonNull;
 import java.util.Objects;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
-// SEE RYA-211 import javax.annotation.concurrent.Immutable;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import net.jcip.annotations.Immutable;
 
 import com.google.common.base.Optional;
 
 /**
  * Installs a new instance of Rya.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public interface Install {
 
     /**
@@ -59,8 +60,8 @@ public interface Install {
     /**
      * Configures how an instance of Rya will be configured when it is installed.
      */
-// SEE RYA-211     @Immutable
-// SEE RYA-211     @ParametersAreNonnullByDefault
+    @Immutable
+    @DefaultAnnotation(NonNull.class)
     public static class InstallConfiguration {
 
         private final boolean enableTableHashPrefix;
@@ -181,7 +182,7 @@ public interface Install {
         /**
          * Builds instances of {@link InstallConfiguration}.
          */
-// SEE RYA-211         @ParametersAreNonnullByDefault
+        @DefaultAnnotation(NonNull.class)
         public static class Builder {
             private boolean enableTableHashPrefix = false;
             private boolean enableFreeTextIndex = false;

--- a/common/rya.api/src/main/java/org/apache/rya/api/client/Install.java
+++ b/common/rya.api/src/main/java/org/apache/rya/api/client/Install.java
@@ -22,16 +22,16 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Objects;
 
-import javax.annotation.Nullable;
-import javax.annotation.ParametersAreNonnullByDefault;
-import javax.annotation.concurrent.Immutable;
+import edu.umd.cs.findbugs.annotations.Nullable;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.concurrent.Immutable;
 
 import com.google.common.base.Optional;
 
 /**
  * Installs a new instance of Rya.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public interface Install {
 
     /**
@@ -59,8 +59,8 @@ public interface Install {
     /**
      * Configures how an instance of Rya will be configured when it is installed.
      */
-    @Immutable
-    @ParametersAreNonnullByDefault
+// SEE RYA-211     @Immutable
+// SEE RYA-211     @ParametersAreNonnullByDefault
     public static class InstallConfiguration {
 
         private final boolean enableTableHashPrefix;
@@ -181,7 +181,7 @@ public interface Install {
         /**
          * Builds instances of {@link InstallConfiguration}.
          */
-        @ParametersAreNonnullByDefault
+// SEE RYA-211         @ParametersAreNonnullByDefault
         public static class Builder {
             private boolean enableTableHashPrefix = false;
             private boolean enableFreeTextIndex = false;

--- a/common/rya.api/src/main/java/org/apache/rya/api/client/InstanceDoesNotExistException.java
+++ b/common/rya.api/src/main/java/org/apache/rya/api/client/InstanceDoesNotExistException.java
@@ -18,13 +18,13 @@
  */
 package org.apache.rya.api.client;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 /**
  * One of the {@link RyaClient} commands could not execute because the connected
  * instance of Rya does not exist.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class InstanceDoesNotExistException extends RyaClientException {
     private static final long serialVersionUID = 1L;
 

--- a/common/rya.api/src/main/java/org/apache/rya/api/client/InstanceDoesNotExistException.java
+++ b/common/rya.api/src/main/java/org/apache/rya/api/client/InstanceDoesNotExistException.java
@@ -18,13 +18,14 @@
  */
 package org.apache.rya.api.client;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * One of the {@link RyaClient} commands could not execute because the connected
  * instance of Rya does not exist.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class InstanceDoesNotExistException extends RyaClientException {
     private static final long serialVersionUID = 1L;
 

--- a/common/rya.api/src/main/java/org/apache/rya/api/client/InstanceExists.java
+++ b/common/rya.api/src/main/java/org/apache/rya/api/client/InstanceExists.java
@@ -18,12 +18,13 @@
  */
 package org.apache.rya.api.client;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * Checks if an instance of Rya has been installed.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public interface InstanceExists {
 
     /**

--- a/common/rya.api/src/main/java/org/apache/rya/api/client/InstanceExists.java
+++ b/common/rya.api/src/main/java/org/apache/rya/api/client/InstanceExists.java
@@ -18,12 +18,12 @@
  */
 package org.apache.rya.api.client;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 /**
  * Checks if an instance of Rya has been installed.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public interface InstanceExists {
 
     /**

--- a/common/rya.api/src/main/java/org/apache/rya/api/client/ListInstances.java
+++ b/common/rya.api/src/main/java/org/apache/rya/api/client/ListInstances.java
@@ -20,12 +20,13 @@ package org.apache.rya.api.client;
 
 import java.util.List;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * List the names of the installed Rya instances.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public interface ListInstances {
 
     /**

--- a/common/rya.api/src/main/java/org/apache/rya/api/client/ListInstances.java
+++ b/common/rya.api/src/main/java/org/apache/rya/api/client/ListInstances.java
@@ -20,12 +20,12 @@ package org.apache.rya.api.client;
 
 import java.util.List;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 /**
  * List the names of the installed Rya instances.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public interface ListInstances {
 
     /**

--- a/common/rya.api/src/main/java/org/apache/rya/api/client/PCJDoesNotExistException.java
+++ b/common/rya.api/src/main/java/org/apache/rya/api/client/PCJDoesNotExistException.java
@@ -18,13 +18,13 @@
  */
 package org.apache.rya.api.client;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 /**
  * One of the {@link RyaClient} commands could not execute because the connected
  * instance of Rya does not have a PCJ matching the provided PCJ ID.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class PCJDoesNotExistException extends RyaClientException {
     private static final long serialVersionUID = 1L;
 

--- a/common/rya.api/src/main/java/org/apache/rya/api/client/PCJDoesNotExistException.java
+++ b/common/rya.api/src/main/java/org/apache/rya/api/client/PCJDoesNotExistException.java
@@ -18,13 +18,14 @@
  */
 package org.apache.rya.api.client;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * One of the {@link RyaClient} commands could not execute because the connected
  * instance of Rya does not have a PCJ matching the provided PCJ ID.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class PCJDoesNotExistException extends RyaClientException {
     private static final long serialVersionUID = 1L;
 

--- a/common/rya.api/src/main/java/org/apache/rya/api/client/RyaClient.java
+++ b/common/rya.api/src/main/java/org/apache/rya/api/client/RyaClient.java
@@ -20,14 +20,15 @@ package org.apache.rya.api.client;
 
 import static java.util.Objects.requireNonNull;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
-// SEE RYA-211 import javax.annotation.concurrent.Immutable;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import net.jcip.annotations.Immutable;
 
 /**
  * Provides access to a set of Rya functions.
  */
-// SEE RYA-211 @Immutable
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@Immutable
+@DefaultAnnotation(NonNull.class)
 public class RyaClient {
     // Administrative functions.
     private final Install install;

--- a/common/rya.api/src/main/java/org/apache/rya/api/client/RyaClient.java
+++ b/common/rya.api/src/main/java/org/apache/rya/api/client/RyaClient.java
@@ -20,14 +20,14 @@ package org.apache.rya.api.client;
 
 import static java.util.Objects.requireNonNull;
 
-import javax.annotation.ParametersAreNonnullByDefault;
-import javax.annotation.concurrent.Immutable;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.concurrent.Immutable;
 
 /**
  * Provides access to a set of Rya functions.
  */
-@Immutable
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @Immutable
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class RyaClient {
     // Administrative functions.
     private final Install install;

--- a/common/rya.api/src/main/java/org/apache/rya/api/client/RyaClientException.java
+++ b/common/rya.api/src/main/java/org/apache/rya/api/client/RyaClientException.java
@@ -18,12 +18,13 @@
  */
 package org.apache.rya.api.client;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * One of the {@link RyaClient} functions failed.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class RyaClientException extends Exception {
     private static final long serialVersionUID = 1L;
 

--- a/common/rya.api/src/main/java/org/apache/rya/api/client/RyaClientException.java
+++ b/common/rya.api/src/main/java/org/apache/rya/api/client/RyaClientException.java
@@ -18,12 +18,12 @@
  */
 package org.apache.rya.api.client;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 /**
  * One of the {@link RyaClient} functions failed.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class RyaClientException extends Exception {
     private static final long serialVersionUID = 1L;
 

--- a/common/rya.api/src/main/java/org/apache/rya/api/instance/RyaDetails.java
+++ b/common/rya.api/src/main/java/org/apache/rya/api/instance/RyaDetails.java
@@ -29,8 +29,9 @@ import java.util.Map.Entry;
 import java.util.Objects;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
-// SEE RYA-211 import javax.annotation.concurrent.Immutable;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import net.jcip.annotations.Immutable;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
@@ -38,8 +39,8 @@ import com.google.common.collect.ImmutableMap;
 /**
  * Details about how a Rya instance's state.
  */
-// SEE RYA-211 @Immutable
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@Immutable
+@DefaultAnnotation(NonNull.class)
 public class RyaDetails implements Serializable {
     private static final long serialVersionUID = 1L;
 
@@ -199,7 +200,7 @@ public class RyaDetails implements Serializable {
     /**
      * Builds instances of {@link RyaDetails}.
      */
-// SEE RYA-211     @ParametersAreNonnullByDefault
+    @DefaultAnnotation(NonNull.class)
     public static class Builder {
 
         // General metadata about the instance.
@@ -353,8 +354,8 @@ public class RyaDetails implements Serializable {
     /**
      * Details about a Rya instance's Geospatial Index.
      */
-// SEE RYA-211     @Immutable
-// SEE RYA-211     @ParametersAreNonnullByDefault
+    @Immutable
+    @DefaultAnnotation(NonNull.class)
     public static class GeoIndexDetails implements Serializable {
         private static final long serialVersionUID = 1L;
 
@@ -397,8 +398,8 @@ public class RyaDetails implements Serializable {
     /**
      * Details about a Rya instance's Temporal Index.
      */
-// SEE RYA-211     @Immutable
-// SEE RYA-211     @ParametersAreNonnullByDefault
+    @Immutable
+    @DefaultAnnotation(NonNull.class)
     public static class TemporalIndexDetails implements Serializable {
         private static final long serialVersionUID = 1L;
 
@@ -441,8 +442,8 @@ public class RyaDetails implements Serializable {
     /**
      * Details about a Rya instance's Entity Centric Index.
      */
-// SEE RYA-211     @Immutable
-// SEE RYA-211     @ParametersAreNonnullByDefault
+    @Immutable
+    @DefaultAnnotation(NonNull.class)
     public static class EntityCentricIndexDetails implements Serializable {
         private static final long serialVersionUID = 1L;
 
@@ -485,8 +486,8 @@ public class RyaDetails implements Serializable {
     /**
      * Details about a Rya instance's Free Text Index.
      */
-// SEE RYA-211     @Immutable
-// SEE RYA-211     @ParametersAreNonnullByDefault
+    @Immutable
+    @DefaultAnnotation(NonNull.class)
     public static class FreeTextIndexDetails implements Serializable {
         private static final long serialVersionUID = 1L;
 
@@ -529,8 +530,8 @@ public class RyaDetails implements Serializable {
     /**
      * Details about a Rya instance's PCJ Index.
      */
-// SEE RYA-211     @Immutable
-// SEE RYA-211     @ParametersAreNonnullByDefault
+    @Immutable
+    @DefaultAnnotation(NonNull.class)
     public static class PCJIndexDetails implements Serializable {
         private static final long serialVersionUID = 1L;
 
@@ -618,7 +619,7 @@ public class RyaDetails implements Serializable {
         /**
          * Builds instance of {@link PCJIndexDetails).
          */
-// SEE RYA-211         @ParametersAreNonnullByDefault
+        @DefaultAnnotation(NonNull.class)
         public static class Builder {
 
             private Boolean enabled = null;
@@ -707,8 +708,8 @@ public class RyaDetails implements Serializable {
          * Details about a Fluo Incremental PCJ application that has been installed
          * as part of this Rya instance.
          */
-// SEE RYA-211         @Immutable
-// SEE RYA-211         @ParametersAreNonnullByDefault
+        @Immutable
+        @DefaultAnnotation(NonNull.class)
         public static class FluoDetails implements Serializable {
             private static final long serialVersionUID = 1L;
 
@@ -752,8 +753,8 @@ public class RyaDetails implements Serializable {
         /**
          * Details about a specific PCJ that is being maintained within the Rya instance.
          */
-// SEE RYA-211         @Immutable
-// SEE RYA-211         @ParametersAreNonnullByDefault
+        @Immutable
+        @DefaultAnnotation(NonNull.class)
         public static class PCJDetails implements Serializable {
             private static final long serialVersionUID = 1L;
 
@@ -838,7 +839,7 @@ public class RyaDetails implements Serializable {
             /**
              * Builds instance of {@link PCJDetails}.
              */
-// SEE RYA-211             @ParametersAreNonnullByDefault
+            @DefaultAnnotation(NonNull.class)
             public static class Builder {
 
                 private String id;
@@ -944,8 +945,8 @@ public class RyaDetails implements Serializable {
     /**
      * Details about a Rya instance's Prospector statistics.
      */
-// SEE RYA-211     @Immutable
-// SEE RYA-211     @ParametersAreNonnullByDefault
+    @Immutable
+    @DefaultAnnotation(NonNull.class)
     public static class ProspectorDetails implements Serializable {
         private static final long serialVersionUID = 1L;
 
@@ -988,8 +989,8 @@ public class RyaDetails implements Serializable {
     /**
      * Details about a Rya instance's Join Selectivity statistics.
      */
-// SEE RYA-211     @Immutable
-// SEE RYA-211     @ParametersAreNonnullByDefault
+    @Immutable
+    @DefaultAnnotation(NonNull.class)
     public static class JoinSelectivityDetails implements Serializable {
         private static final long serialVersionUID = 1L;
 

--- a/common/rya.api/src/main/java/org/apache/rya/api/instance/RyaDetails.java
+++ b/common/rya.api/src/main/java/org/apache/rya/api/instance/RyaDetails.java
@@ -28,9 +28,9 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 
-import javax.annotation.Nullable;
-import javax.annotation.ParametersAreNonnullByDefault;
-import javax.annotation.concurrent.Immutable;
+import edu.umd.cs.findbugs.annotations.Nullable;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.concurrent.Immutable;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
@@ -38,8 +38,8 @@ import com.google.common.collect.ImmutableMap;
 /**
  * Details about how a Rya instance's state.
  */
-@Immutable
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @Immutable
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class RyaDetails implements Serializable {
     private static final long serialVersionUID = 1L;
 
@@ -199,7 +199,7 @@ public class RyaDetails implements Serializable {
     /**
      * Builds instances of {@link RyaDetails}.
      */
-    @ParametersAreNonnullByDefault
+// SEE RYA-211     @ParametersAreNonnullByDefault
     public static class Builder {
 
         // General metadata about the instance.
@@ -353,8 +353,8 @@ public class RyaDetails implements Serializable {
     /**
      * Details about a Rya instance's Geospatial Index.
      */
-    @Immutable
-    @ParametersAreNonnullByDefault
+// SEE RYA-211     @Immutable
+// SEE RYA-211     @ParametersAreNonnullByDefault
     public static class GeoIndexDetails implements Serializable {
         private static final long serialVersionUID = 1L;
 
@@ -397,8 +397,8 @@ public class RyaDetails implements Serializable {
     /**
      * Details about a Rya instance's Temporal Index.
      */
-    @Immutable
-    @ParametersAreNonnullByDefault
+// SEE RYA-211     @Immutable
+// SEE RYA-211     @ParametersAreNonnullByDefault
     public static class TemporalIndexDetails implements Serializable {
         private static final long serialVersionUID = 1L;
 
@@ -441,8 +441,8 @@ public class RyaDetails implements Serializable {
     /**
      * Details about a Rya instance's Entity Centric Index.
      */
-    @Immutable
-    @ParametersAreNonnullByDefault
+// SEE RYA-211     @Immutable
+// SEE RYA-211     @ParametersAreNonnullByDefault
     public static class EntityCentricIndexDetails implements Serializable {
         private static final long serialVersionUID = 1L;
 
@@ -485,8 +485,8 @@ public class RyaDetails implements Serializable {
     /**
      * Details about a Rya instance's Free Text Index.
      */
-    @Immutable
-    @ParametersAreNonnullByDefault
+// SEE RYA-211     @Immutable
+// SEE RYA-211     @ParametersAreNonnullByDefault
     public static class FreeTextIndexDetails implements Serializable {
         private static final long serialVersionUID = 1L;
 
@@ -529,8 +529,8 @@ public class RyaDetails implements Serializable {
     /**
      * Details about a Rya instance's PCJ Index.
      */
-    @Immutable
-    @ParametersAreNonnullByDefault
+// SEE RYA-211     @Immutable
+// SEE RYA-211     @ParametersAreNonnullByDefault
     public static class PCJIndexDetails implements Serializable {
         private static final long serialVersionUID = 1L;
 
@@ -618,7 +618,7 @@ public class RyaDetails implements Serializable {
         /**
          * Builds instance of {@link PCJIndexDetails).
          */
-        @ParametersAreNonnullByDefault
+// SEE RYA-211         @ParametersAreNonnullByDefault
         public static class Builder {
 
             private Boolean enabled = null;
@@ -707,8 +707,8 @@ public class RyaDetails implements Serializable {
          * Details about a Fluo Incremental PCJ application that has been installed
          * as part of this Rya instance.
          */
-        @Immutable
-        @ParametersAreNonnullByDefault
+// SEE RYA-211         @Immutable
+// SEE RYA-211         @ParametersAreNonnullByDefault
         public static class FluoDetails implements Serializable {
             private static final long serialVersionUID = 1L;
 
@@ -752,8 +752,8 @@ public class RyaDetails implements Serializable {
         /**
          * Details about a specific PCJ that is being maintained within the Rya instance.
          */
-        @Immutable
-        @ParametersAreNonnullByDefault
+// SEE RYA-211         @Immutable
+// SEE RYA-211         @ParametersAreNonnullByDefault
         public static class PCJDetails implements Serializable {
             private static final long serialVersionUID = 1L;
 
@@ -838,7 +838,7 @@ public class RyaDetails implements Serializable {
             /**
              * Builds instance of {@link PCJDetails}.
              */
-            @ParametersAreNonnullByDefault
+// SEE RYA-211             @ParametersAreNonnullByDefault
             public static class Builder {
 
                 private String id;
@@ -944,8 +944,8 @@ public class RyaDetails implements Serializable {
     /**
      * Details about a Rya instance's Prospector statistics.
      */
-    @Immutable
-    @ParametersAreNonnullByDefault
+// SEE RYA-211     @Immutable
+// SEE RYA-211     @ParametersAreNonnullByDefault
     public static class ProspectorDetails implements Serializable {
         private static final long serialVersionUID = 1L;
 
@@ -988,8 +988,8 @@ public class RyaDetails implements Serializable {
     /**
      * Details about a Rya instance's Join Selectivity statistics.
      */
-    @Immutable
-    @ParametersAreNonnullByDefault
+// SEE RYA-211     @Immutable
+// SEE RYA-211     @ParametersAreNonnullByDefault
     public static class JoinSelectivityDetails implements Serializable {
         private static final long serialVersionUID = 1L;
 

--- a/common/rya.api/src/main/java/org/apache/rya/api/instance/RyaDetailsRepository.java
+++ b/common/rya.api/src/main/java/org/apache/rya/api/instance/RyaDetailsRepository.java
@@ -19,13 +19,13 @@ package org.apache.rya.api.instance;
  * under the License.
  */
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 /**
  * Provides access to the {@link RyaDetails} information that describes
  * an instance of Rya.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public interface RyaDetailsRepository {
 
     /**

--- a/common/rya.api/src/main/java/org/apache/rya/api/instance/RyaDetailsRepository.java
+++ b/common/rya.api/src/main/java/org/apache/rya/api/instance/RyaDetailsRepository.java
@@ -19,13 +19,14 @@ package org.apache.rya.api.instance;
  * under the License.
  */
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * Provides access to the {@link RyaDetails} information that describes
  * an instance of Rya.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public interface RyaDetailsRepository {
 
     /**

--- a/common/rya.api/src/main/java/org/apache/rya/api/instance/RyaDetailsToConfiguration.java
+++ b/common/rya.api/src/main/java/org/apache/rya/api/instance/RyaDetailsToConfiguration.java
@@ -20,7 +20,7 @@ package org.apache.rya.api.instance;
 
 import static java.util.Objects.requireNonNull;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.log4j.Logger;
@@ -31,7 +31,7 @@ import com.google.common.base.Optional;
  * Used to fetch {@link RyaDetails} from a {@link RyaDetailsRepository} and
  * add them to the application's {@link Configuration}.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class RyaDetailsToConfiguration {
     private static final Logger log = Logger.getLogger(RyaDetailsToConfiguration.class);
 

--- a/common/rya.api/src/main/java/org/apache/rya/api/instance/RyaDetailsToConfiguration.java
+++ b/common/rya.api/src/main/java/org/apache/rya/api/instance/RyaDetailsToConfiguration.java
@@ -20,7 +20,8 @@ package org.apache.rya.api.instance;
 
 import static java.util.Objects.requireNonNull;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.log4j.Logger;
@@ -31,7 +32,7 @@ import com.google.common.base.Optional;
  * Used to fetch {@link RyaDetails} from a {@link RyaDetailsRepository} and
  * add them to the application's {@link Configuration}.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class RyaDetailsToConfiguration {
     private static final Logger log = Logger.getLogger(RyaDetailsToConfiguration.class);
 

--- a/common/rya.api/src/main/java/org/apache/rya/api/instance/RyaDetailsUpdater.java
+++ b/common/rya.api/src/main/java/org/apache/rya/api/instance/RyaDetailsUpdater.java
@@ -20,7 +20,7 @@ package org.apache.rya.api.instance;
 
 import static java.util.Objects.requireNonNull;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,14 +35,14 @@ import org.apache.rya.api.instance.RyaDetailsUpdater.RyaDetailsMutator.CouldNotA
  * can be used in place of boilerplate code that handles the concurrent nature
  * of details updates.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class RyaDetailsUpdater {
     private static final Logger log = LoggerFactory.getLogger(RyaDetailsUpdater.class);
 
     /**
      * Applies a mutation to a an instance of {@link RyaDetails}.
      */
-    @ParametersAreNonnullByDefault
+// SEE RYA-211     @ParametersAreNonnullByDefault
     public static interface RyaDetailsMutator {
 
         /**

--- a/common/rya.api/src/main/java/org/apache/rya/api/instance/RyaDetailsUpdater.java
+++ b/common/rya.api/src/main/java/org/apache/rya/api/instance/RyaDetailsUpdater.java
@@ -20,7 +20,8 @@ package org.apache.rya.api.instance;
 
 import static java.util.Objects.requireNonNull;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,14 +36,14 @@ import org.apache.rya.api.instance.RyaDetailsUpdater.RyaDetailsMutator.CouldNotA
  * can be used in place of boilerplate code that handles the concurrent nature
  * of details updates.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class RyaDetailsUpdater {
     private static final Logger log = LoggerFactory.getLogger(RyaDetailsUpdater.class);
 
     /**
      * Applies a mutation to a an instance of {@link RyaDetails}.
      */
-// SEE RYA-211     @ParametersAreNonnullByDefault
+    @DefaultAnnotation(NonNull.class)
     public static interface RyaDetailsMutator {
 
         /**

--- a/dao/accumulo.rya/src/main/java/org/apache/rya/accumulo/instance/AccumuloRyaInstanceDetailsRepository.java
+++ b/dao/accumulo.rya/src/main/java/org/apache/rya/accumulo/instance/AccumuloRyaInstanceDetailsRepository.java
@@ -23,7 +23,8 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Map.Entry;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
@@ -60,7 +61,7 @@ import org.apache.rya.api.instance.RyaDetailsRepository;
  * style operations to synchronize writes to the object. On the downside, only
  * Java clients will work.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class AccumuloRyaInstanceDetailsRepository implements RyaDetailsRepository {
 
     public static final String INSTANCE_DETAILS_TABLE_NAME = "instance_details";

--- a/dao/accumulo.rya/src/main/java/org/apache/rya/accumulo/instance/AccumuloRyaInstanceDetailsRepository.java
+++ b/dao/accumulo.rya/src/main/java/org/apache/rya/accumulo/instance/AccumuloRyaInstanceDetailsRepository.java
@@ -23,7 +23,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Map.Entry;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
@@ -60,7 +60,7 @@ import org.apache.rya.api.instance.RyaDetailsRepository;
  * style operations to synchronize writes to the object. On the downside, only
  * Java clients will work.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class AccumuloRyaInstanceDetailsRepository implements RyaDetailsRepository {
 
     public static final String INSTANCE_DETAILS_TABLE_NAME = "instance_details";

--- a/dao/accumulo.rya/src/main/java/org/apache/rya/accumulo/instance/RyaDetailsSerializer.java
+++ b/dao/accumulo.rya/src/main/java/org/apache/rya/accumulo/instance/RyaDetailsSerializer.java
@@ -27,7 +27,8 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.apache.rya.api.instance.RyaDetails;
 import org.apache.rya.api.instance.RyaDetailsRepository.RyaDetailsRepositoryException;
@@ -35,7 +36,7 @@ import org.apache.rya.api.instance.RyaDetailsRepository.RyaDetailsRepositoryExce
 /**
  * Serializes {@link RyaDetails} instances.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class RyaDetailsSerializer {
 
     /**

--- a/dao/accumulo.rya/src/main/java/org/apache/rya/accumulo/instance/RyaDetailsSerializer.java
+++ b/dao/accumulo.rya/src/main/java/org/apache/rya/accumulo/instance/RyaDetailsSerializer.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.apache.rya.api.instance.RyaDetails;
 import org.apache.rya.api.instance.RyaDetailsRepository.RyaDetailsRepositoryException;
@@ -35,7 +35,7 @@ import org.apache.rya.api.instance.RyaDetailsRepository.RyaDetailsRepositoryExce
 /**
  * Serializes {@link RyaDetails} instances.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class RyaDetailsSerializer {
 
     /**

--- a/dao/accumulo.rya/src/main/java/org/apache/rya/accumulo/utils/VisibilitySimplifier.java
+++ b/dao/accumulo.rya/src/main/java/org/apache/rya/accumulo/utils/VisibilitySimplifier.java
@@ -20,7 +20,8 @@ package org.apache.rya.accumulo.utils;
 
 import static java.util.Objects.requireNonNull;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.apache.accumulo.core.security.ColumnVisibility;
 
@@ -29,7 +30,7 @@ import com.google.common.base.Charsets;
 /**
  * Simplifies Accumulo visibility expressions.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class VisibilitySimplifier {
 
     /**

--- a/dao/accumulo.rya/src/main/java/org/apache/rya/accumulo/utils/VisibilitySimplifier.java
+++ b/dao/accumulo.rya/src/main/java/org/apache/rya/accumulo/utils/VisibilitySimplifier.java
@@ -20,7 +20,7 @@ package org.apache.rya.accumulo.utils;
 
 import static java.util.Objects.requireNonNull;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.apache.accumulo.core.security.ColumnVisibility;
 
@@ -29,7 +29,7 @@ import com.google.common.base.Charsets;
 /**
  * Simplifies Accumulo visibility expressions.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class VisibilitySimplifier {
 
     /**

--- a/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/instance/MongoDetailsAdapter.java
+++ b/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/instance/MongoDetailsAdapter.java
@@ -25,7 +25,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map.Entry;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
@@ -73,7 +73,7 @@ import org.apache.rya.api.instance.RyaDetails.TemporalIndexDetails;
  * }
  * </pre>
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class MongoDetailsAdapter {
     public static final String INSTANCE_KEY = "instanceName";
     public static final String VERSION_KEY = "version";

--- a/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/instance/MongoDetailsAdapter.java
+++ b/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/instance/MongoDetailsAdapter.java
@@ -25,7 +25,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map.Entry;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
@@ -73,7 +74,7 @@ import org.apache.rya.api.instance.RyaDetails.TemporalIndexDetails;
  * }
  * </pre>
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class MongoDetailsAdapter {
     public static final String INSTANCE_KEY = "instanceName";
     public static final String VERSION_KEY = "version";

--- a/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/instance/MongoRyaInstanceDetailsRepository.java
+++ b/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/instance/MongoRyaInstanceDetailsRepository.java
@@ -22,7 +22,8 @@ package org.apache.rya.mongodb.instance;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.Objects.requireNonNull;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import com.mongodb.BasicDBObject;
 import com.mongodb.DB;
@@ -39,7 +40,7 @@ import org.apache.rya.mongodb.instance.MongoDetailsAdapter.MalformedRyaDetailsEx
  * An implementation of {@link RyaDetailsRepository} that stores a Rya
  * instance's {@link RyaDetails} in a Mongo document.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class MongoRyaInstanceDetailsRepository implements RyaDetailsRepository {
     private static final String INSTANCE_DETAILS_COLLECTION_NAME = "instance_details";
 

--- a/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/instance/MongoRyaInstanceDetailsRepository.java
+++ b/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/instance/MongoRyaInstanceDetailsRepository.java
@@ -22,7 +22,7 @@ package org.apache.rya.mongodb.instance;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.Objects.requireNonNull;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import com.mongodb.BasicDBObject;
 import com.mongodb.DB;
@@ -39,7 +39,7 @@ import org.apache.rya.mongodb.instance.MongoDetailsAdapter.MalformedRyaDetailsEx
  * An implementation of {@link RyaDetailsRepository} that stores a Rya
  * instance's {@link RyaDetails} in a Mongo document.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class MongoRyaInstanceDetailsRepository implements RyaDetailsRepository {
     private static final String INSTANCE_DETAILS_COLLECTION_NAME = "instance_details";
 

--- a/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/AccumuloCommand.java
+++ b/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/AccumuloCommand.java
@@ -20,7 +20,8 @@ package org.apache.rya.api.client.accumulo;
 
 import static java.util.Objects.requireNonNull;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.apache.accumulo.core.client.Connector;
 
@@ -28,7 +29,7 @@ import org.apache.accumulo.core.client.Connector;
  * An abstract class that holds onto Accumulo access information. Extend this
  * when implementing a command that interacts with Accumulo.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public abstract class AccumuloCommand {
 
     private final AccumuloConnectionDetails connectionDetails;

--- a/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/AccumuloCommand.java
+++ b/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/AccumuloCommand.java
@@ -20,7 +20,7 @@ package org.apache.rya.api.client.accumulo;
 
 import static java.util.Objects.requireNonNull;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.apache.accumulo.core.client.Connector;
 
@@ -28,7 +28,7 @@ import org.apache.accumulo.core.client.Connector;
  * An abstract class that holds onto Accumulo access information. Extend this
  * when implementing a command that interacts with Accumulo.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public abstract class AccumuloCommand {
 
     private final AccumuloConnectionDetails connectionDetails;

--- a/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/AccumuloConnectionDetails.java
+++ b/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/AccumuloConnectionDetails.java
@@ -20,14 +20,14 @@ package org.apache.rya.api.client.accumulo;
 
 import static java.util.Objects.requireNonNull;
 
-import javax.annotation.ParametersAreNonnullByDefault;
-import javax.annotation.concurrent.Immutable;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.concurrent.Immutable;
 
 /**
  * The information that the shell used to connect to Accumulo.
  */
-@Immutable
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @Immutable
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class AccumuloConnectionDetails {
     private final String username;
     private final char[] password;

--- a/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/AccumuloConnectionDetails.java
+++ b/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/AccumuloConnectionDetails.java
@@ -20,14 +20,15 @@ package org.apache.rya.api.client.accumulo;
 
 import static java.util.Objects.requireNonNull;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
-// SEE RYA-211 import javax.annotation.concurrent.Immutable;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import net.jcip.annotations.Immutable;
 
 /**
  * The information that the shell used to connect to Accumulo.
  */
-// SEE RYA-211 @Immutable
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@Immutable
+@DefaultAnnotation(NonNull.class)
 public class AccumuloConnectionDetails {
     private final String username;
     private final char[] password;

--- a/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/AccumuloCreatePCJ.java
+++ b/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/AccumuloCreatePCJ.java
@@ -21,7 +21,8 @@ package org.apache.rya.api.client.accumulo;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.Objects.requireNonNull;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.apache.accumulo.core.client.Connector;
 import org.apache.rya.indexing.pcj.storage.PcjException;
@@ -59,7 +60,7 @@ import org.apache.rya.rdftriplestore.RyaSailRepository;
 /**
  * An Accumulo implementation of the {@link CreatePCJ} command.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class AccumuloCreatePCJ extends AccumuloCommand implements CreatePCJ {
 
     private final GetInstanceDetails getInstanceDetails;

--- a/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/AccumuloCreatePCJ.java
+++ b/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/AccumuloCreatePCJ.java
@@ -21,7 +21,7 @@ package org.apache.rya.api.client.accumulo;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.Objects.requireNonNull;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.apache.accumulo.core.client.Connector;
 import org.apache.rya.indexing.pcj.storage.PcjException;
@@ -59,7 +59,7 @@ import org.apache.rya.rdftriplestore.RyaSailRepository;
 /**
  * An Accumulo implementation of the {@link CreatePCJ} command.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class AccumuloCreatePCJ extends AccumuloCommand implements CreatePCJ {
 
     private final GetInstanceDetails getInstanceDetails;

--- a/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/AccumuloDeletePCJ.java
+++ b/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/AccumuloDeletePCJ.java
@@ -20,7 +20,8 @@ package org.apache.rya.api.client.accumulo;
 
 import static java.util.Objects.requireNonNull;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.apache.accumulo.core.client.Connector;
 import org.apache.rya.indexing.pcj.fluo.api.DeletePcj;
@@ -46,7 +47,7 @@ import org.apache.rya.api.instance.RyaDetails.PCJIndexDetails.PCJDetails.PCJUpda
 /**
  * An Accumulo implementation of the {@link DeletePCJ} command.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class AccumuloDeletePCJ extends AccumuloCommand implements DeletePCJ {
 
     private static final Logger log = LoggerFactory.getLogger(AccumuloDeletePCJ.class);

--- a/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/AccumuloDeletePCJ.java
+++ b/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/AccumuloDeletePCJ.java
@@ -20,7 +20,7 @@ package org.apache.rya.api.client.accumulo;
 
 import static java.util.Objects.requireNonNull;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.apache.accumulo.core.client.Connector;
 import org.apache.rya.indexing.pcj.fluo.api.DeletePcj;
@@ -46,7 +46,7 @@ import org.apache.rya.api.instance.RyaDetails.PCJIndexDetails.PCJDetails.PCJUpda
 /**
  * An Accumulo implementation of the {@link DeletePCJ} command.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class AccumuloDeletePCJ extends AccumuloCommand implements DeletePCJ {
 
     private static final Logger log = LoggerFactory.getLogger(AccumuloDeletePCJ.class);

--- a/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/AccumuloGetInstanceDetails.java
+++ b/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/AccumuloGetInstanceDetails.java
@@ -20,7 +20,7 @@ package org.apache.rya.api.client.accumulo;
 
 import static java.util.Objects.requireNonNull;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.apache.accumulo.core.client.Connector;
 
@@ -39,7 +39,7 @@ import org.apache.rya.api.instance.RyaDetailsRepository.RyaDetailsRepositoryExce
 /**
  * An Accumulo implementation of the {@link GetInstanceDetails} command.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class AccumuloGetInstanceDetails extends AccumuloCommand implements GetInstanceDetails {
 
     private final InstanceExists instanceExists;

--- a/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/AccumuloGetInstanceDetails.java
+++ b/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/AccumuloGetInstanceDetails.java
@@ -20,7 +20,8 @@ package org.apache.rya.api.client.accumulo;
 
 import static java.util.Objects.requireNonNull;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.apache.accumulo.core.client.Connector;
 
@@ -39,7 +40,7 @@ import org.apache.rya.api.instance.RyaDetailsRepository.RyaDetailsRepositoryExce
 /**
  * An Accumulo implementation of the {@link GetInstanceDetails} command.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class AccumuloGetInstanceDetails extends AccumuloCommand implements GetInstanceDetails {
 
     private final InstanceExists instanceExists;

--- a/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/AccumuloInstall.java
+++ b/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/AccumuloInstall.java
@@ -22,7 +22,8 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Date;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
@@ -60,7 +61,7 @@ import org.apache.rya.sail.config.RyaSailFactory;
  * An Accumulo implementation of the {@link Install} command.
  */
 
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class AccumuloInstall extends AccumuloCommand implements Install {
 
     private final InstanceExists instanceExists;

--- a/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/AccumuloInstall.java
+++ b/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/AccumuloInstall.java
@@ -22,7 +22,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Date;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
@@ -60,7 +60,7 @@ import org.apache.rya.sail.config.RyaSailFactory;
  * An Accumulo implementation of the {@link Install} command.
  */
 
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class AccumuloInstall extends AccumuloCommand implements Install {
 
     private final InstanceExists instanceExists;

--- a/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/AccumuloInstanceExists.java
+++ b/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/AccumuloInstanceExists.java
@@ -20,7 +20,8 @@ package org.apache.rya.api.client.accumulo;
 
 import static java.util.Objects.requireNonNull;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.admin.TableOperations;
@@ -33,7 +34,7 @@ import org.apache.rya.api.client.RyaClientException;
 /**
  * An Accumulo implementation of the {@link InstanceExists} command.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class AccumuloInstanceExists extends AccumuloCommand implements InstanceExists {
 
     /**

--- a/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/AccumuloInstanceExists.java
+++ b/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/AccumuloInstanceExists.java
@@ -20,7 +20,7 @@ package org.apache.rya.api.client.accumulo;
 
 import static java.util.Objects.requireNonNull;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.admin.TableOperations;
@@ -33,7 +33,7 @@ import org.apache.rya.api.client.RyaClientException;
 /**
  * An Accumulo implementation of the {@link InstanceExists} command.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class AccumuloInstanceExists extends AccumuloCommand implements InstanceExists {
 
     /**

--- a/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/AccumuloListInstances.java
+++ b/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/AccumuloListInstances.java
@@ -26,7 +26,8 @@ import java.util.Map.Entry;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.apache.accumulo.core.client.Connector;
 
@@ -37,7 +38,7 @@ import org.apache.rya.api.client.RyaClientException;
 /**
  * An Accumulo implementation of the {@link ListInstances} command.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class AccumuloListInstances extends AccumuloCommand implements ListInstances {
 
     private final Pattern spoPattern = Pattern.compile("(.*)" + RdfCloudTripleStoreConstants.TBL_SPO_SUFFIX);
@@ -104,7 +105,7 @@ public class AccumuloListInstances extends AccumuloCommand implements ListInstan
     /**
      * Flags that are used to determine if a String is a Rya Instance name.
      */
-// SEE RYA-211     @ParametersAreNonnullByDefault
+    @DefaultAnnotation(NonNull.class)
     private static class InstanceTablesFound {
         private boolean spoFound = false;
         private boolean ospFound = false;

--- a/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/AccumuloListInstances.java
+++ b/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/AccumuloListInstances.java
@@ -26,7 +26,7 @@ import java.util.Map.Entry;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.apache.accumulo.core.client.Connector;
 
@@ -37,7 +37,7 @@ import org.apache.rya.api.client.RyaClientException;
 /**
  * An Accumulo implementation of the {@link ListInstances} command.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class AccumuloListInstances extends AccumuloCommand implements ListInstances {
 
     private final Pattern spoPattern = Pattern.compile("(.*)" + RdfCloudTripleStoreConstants.TBL_SPO_SUFFIX);
@@ -104,7 +104,7 @@ public class AccumuloListInstances extends AccumuloCommand implements ListInstan
     /**
      * Flags that are used to determine if a String is a Rya Instance name.
      */
-    @ParametersAreNonnullByDefault
+// SEE RYA-211     @ParametersAreNonnullByDefault
     private static class InstanceTablesFound {
         private boolean spoFound = false;
         private boolean ospFound = false;

--- a/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/AccumuloRyaClientFactory.java
+++ b/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/AccumuloRyaClientFactory.java
@@ -20,7 +20,7 @@ package org.apache.rya.api.client.accumulo;
 
 import static java.util.Objects.requireNonNull;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.apache.accumulo.core.client.Connector;
 
@@ -30,7 +30,7 @@ import org.apache.rya.api.client.RyaClient;
  * Constructs instance of {@link RyaClient} that are connected to instance of
  * Rya hosted by Accumulo clusters.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class AccumuloRyaClientFactory {
 
     /**

--- a/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/AccumuloRyaClientFactory.java
+++ b/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/AccumuloRyaClientFactory.java
@@ -20,7 +20,8 @@ package org.apache.rya.api.client.accumulo;
 
 import static java.util.Objects.requireNonNull;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.apache.accumulo.core.client.Connector;
 
@@ -30,7 +31,7 @@ import org.apache.rya.api.client.RyaClient;
  * Constructs instance of {@link RyaClient} that are connected to instance of
  * Rya hosted by Accumulo clusters.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class AccumuloRyaClientFactory {
 
     /**

--- a/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/FluoClientFactory.java
+++ b/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/FluoClientFactory.java
@@ -20,7 +20,8 @@ package org.apache.rya.api.client.accumulo;
 
 import static java.util.Objects.requireNonNull;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.apache.fluo.api.client.FluoClient;
 import org.apache.fluo.api.client.FluoFactory;
@@ -29,7 +30,7 @@ import org.apache.fluo.api.config.FluoConfiguration;
 /**
  * Creates {@link FluoClient}s that are connected to a specific Fluo Application.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class FluoClientFactory {
 
     /**

--- a/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/FluoClientFactory.java
+++ b/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/FluoClientFactory.java
@@ -20,7 +20,7 @@ package org.apache.rya.api.client.accumulo;
 
 import static java.util.Objects.requireNonNull;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.apache.fluo.api.client.FluoClient;
 import org.apache.fluo.api.client.FluoFactory;
@@ -29,7 +29,7 @@ import org.apache.fluo.api.config.FluoConfiguration;
 /**
  * Creates {@link FluoClient}s that are connected to a specific Fluo Application.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class FluoClientFactory {
 
     /**

--- a/extras/indexing/src/main/java/org/apache/rya/indexing/external/PrecomputedJoinIndexer.java
+++ b/extras/indexing/src/main/java/org/apache/rya/indexing/external/PrecomputedJoinIndexer.java
@@ -26,7 +26,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.MultiTableBatchWriter;
@@ -53,7 +53,7 @@ import org.apache.rya.indexing.external.fluo.PcjUpdaterSupplierFactory;
 /**
  * Updates the state of the Precomputed Join indices that are used by Rya.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class PrecomputedJoinIndexer extends AbstractAccumuloIndexer {
     private static final Logger log = Logger
             .getLogger(PrecomputedJoinIndexer.class);

--- a/extras/indexing/src/main/java/org/apache/rya/indexing/external/PrecomputedJoinIndexer.java
+++ b/extras/indexing/src/main/java/org/apache/rya/indexing/external/PrecomputedJoinIndexer.java
@@ -26,7 +26,8 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.MultiTableBatchWriter;
@@ -53,7 +54,7 @@ import org.apache.rya.indexing.external.fluo.PcjUpdaterSupplierFactory;
 /**
  * Updates the state of the Precomputed Join indices that are used by Rya.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class PrecomputedJoinIndexer extends AbstractAccumuloIndexer {
     private static final Logger log = Logger
             .getLogger(PrecomputedJoinIndexer.class);

--- a/extras/indexing/src/main/java/org/apache/rya/indexing/external/PrecomputedJoinIndexerConfig.java
+++ b/extras/indexing/src/main/java/org/apache/rya/indexing/external/PrecomputedJoinIndexerConfig.java
@@ -20,7 +20,7 @@ package org.apache.rya.indexing.external;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.apache.rya.api.persist.index.RyaSecondaryIndexer;
 import org.apache.rya.indexing.accumulo.ConfigUtils;
@@ -36,7 +36,7 @@ import com.google.common.base.Optional;
  * of {@link RyaSecondaryIndexer} to provide {@link PrecomputedJoinIndexer}
  * specific values.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class PrecomputedJoinIndexerConfig {
 
     /**

--- a/extras/indexing/src/main/java/org/apache/rya/indexing/external/PrecomputedJoinIndexerConfig.java
+++ b/extras/indexing/src/main/java/org/apache/rya/indexing/external/PrecomputedJoinIndexerConfig.java
@@ -20,7 +20,8 @@ package org.apache.rya.indexing.external;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.apache.rya.api.persist.index.RyaSecondaryIndexer;
 import org.apache.rya.indexing.accumulo.ConfigUtils;
@@ -36,7 +37,7 @@ import com.google.common.base.Optional;
  * of {@link RyaSecondaryIndexer} to provide {@link PrecomputedJoinIndexer}
  * specific values.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class PrecomputedJoinIndexerConfig {
 
     /**

--- a/extras/indexing/src/main/java/org/apache/rya/indexing/external/fluo/FluoPcjUpdater.java
+++ b/extras/indexing/src/main/java/org/apache/rya/indexing/external/fluo/FluoPcjUpdater.java
@@ -22,7 +22,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Collection;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.apache.log4j.Logger;
 import org.apache.rya.indexing.pcj.fluo.api.InsertTriples;
@@ -37,7 +37,7 @@ import org.apache.rya.api.domain.RyaStatement;
  * Updates the PCJ indices by forwarding the statement additions/removals to
  * a Fluo application.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class FluoPcjUpdater implements PrecomputedJoinUpdater {
     private static final Logger log = Logger.getLogger(FluoPcjUpdater.class);
 

--- a/extras/indexing/src/main/java/org/apache/rya/indexing/external/fluo/FluoPcjUpdater.java
+++ b/extras/indexing/src/main/java/org/apache/rya/indexing/external/fluo/FluoPcjUpdater.java
@@ -22,7 +22,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Collection;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.apache.log4j.Logger;
 import org.apache.rya.indexing.pcj.fluo.api.InsertTriples;
@@ -37,7 +38,7 @@ import org.apache.rya.api.domain.RyaStatement;
  * Updates the PCJ indices by forwarding the statement additions/removals to
  * a Fluo application.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class FluoPcjUpdater implements PrecomputedJoinUpdater {
     private static final Logger log = Logger.getLogger(FluoPcjUpdater.class);
 

--- a/extras/indexing/src/main/java/org/apache/rya/indexing/external/fluo/FluoPcjUpdaterSupplier.java
+++ b/extras/indexing/src/main/java/org/apache/rya/indexing/external/fluo/FluoPcjUpdaterSupplier.java
@@ -30,7 +30,7 @@ import org.apache.fluo.api.client.FluoClient;
 import org.apache.fluo.api.client.FluoFactory;
 import org.apache.fluo.api.config.FluoConfiguration;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.apache.rya.indexing.external.PrecomputedJoinIndexerConfig;
 import org.apache.rya.indexing.external.PrecomputedJoinIndexerConfig.PrecomputedJoinUpdaterType;
@@ -44,7 +44,7 @@ import com.google.common.base.Supplier;
 /**
  * Creates instances of {@link FluoPcjUpdater} using the values found in a {@link Configuration}.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class FluoPcjUpdaterSupplier implements Supplier<PrecomputedJoinUpdater> {
 
     private final Supplier<Configuration> configSupplier;

--- a/extras/indexing/src/main/java/org/apache/rya/indexing/external/fluo/FluoPcjUpdaterSupplier.java
+++ b/extras/indexing/src/main/java/org/apache/rya/indexing/external/fluo/FluoPcjUpdaterSupplier.java
@@ -30,7 +30,8 @@ import org.apache.fluo.api.client.FluoClient;
 import org.apache.fluo.api.client.FluoFactory;
 import org.apache.fluo.api.config.FluoConfiguration;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.apache.rya.indexing.external.PrecomputedJoinIndexerConfig;
 import org.apache.rya.indexing.external.PrecomputedJoinIndexerConfig.PrecomputedJoinUpdaterType;
@@ -44,7 +45,7 @@ import com.google.common.base.Supplier;
 /**
  * Creates instances of {@link FluoPcjUpdater} using the values found in a {@link Configuration}.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class FluoPcjUpdaterSupplier implements Supplier<PrecomputedJoinUpdater> {
 
     private final Supplier<Configuration> configSupplier;

--- a/extras/indexing/src/main/java/org/apache/rya/indexing/external/tupleSet/ParsedQueryUtil.java
+++ b/extras/indexing/src/main/java/org/apache/rya/indexing/external/tupleSet/ParsedQueryUtil.java
@@ -22,7 +22,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.openrdf.query.algebra.Projection;
 import org.openrdf.query.algebra.helpers.QueryModelVisitorBase;
@@ -33,7 +33,7 @@ import com.google.common.base.Optional;
 /**
  * Utilities that help applications inspect {@link ParsedQuery} objects.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class ParsedQueryUtil {
 
     /**

--- a/extras/indexing/src/main/java/org/apache/rya/indexing/external/tupleSet/ParsedQueryUtil.java
+++ b/extras/indexing/src/main/java/org/apache/rya/indexing/external/tupleSet/ParsedQueryUtil.java
@@ -22,7 +22,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.openrdf.query.algebra.Projection;
 import org.openrdf.query.algebra.helpers.QueryModelVisitorBase;
@@ -33,7 +34,7 @@ import com.google.common.base.Optional;
 /**
  * Utilities that help applications inspect {@link ParsedQuery} objects.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class ParsedQueryUtil {
 
     /**

--- a/extras/rya.benchmark/pom.xml
+++ b/extras/rya.benchmark/pom.xml
@@ -54,11 +54,6 @@
         
         <!-- Utils -->
         <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-        </dependency>
-        
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/extras/rya.benchmark/src/main/java/org/apache/rya/benchmark/query/PCJOptimizerBenchmark.java
+++ b/extras/rya.benchmark/src/main/java/org/apache/rya/benchmark/query/PCJOptimizerBenchmark.java
@@ -28,7 +28,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Queue;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Param;
@@ -71,7 +72,7 @@ import org.apache.rya.indexing.pcj.matching.PCJOptimizer;
  * </pre>
  */
 @State(Scope.Thread)
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class PCJOptimizerBenchmark {
 
     /**
@@ -305,7 +306,7 @@ public class PCJOptimizerBenchmark {
     /**
      * The parameter values used by the benchmark. Used to lookup a benchmark' {@link BenchmarkValues}.
      */
-// SEE RYA-211     @ParametersAreNonnullByDefault
+    @DefaultAnnotation(NonNull.class)
     public static class BenchmarkParams {
         private final int numPCJs;
         private final int pcjSPCount;
@@ -369,7 +370,7 @@ public class PCJOptimizerBenchmark {
      * Holds onto the SPARQL query that will be optimized as well as the optimizers
      * that will be used to optimize the query.
      */
-// SEE RYA-211     @ParametersAreNonnullByDefault
+    @DefaultAnnotation(NonNull.class)
     public static class BenchmarkValues {
         private final TupleExpr query;
         private final PCJOptimizer optimizer;

--- a/extras/rya.benchmark/src/main/java/org/apache/rya/benchmark/query/PCJOptimizerBenchmark.java
+++ b/extras/rya.benchmark/src/main/java/org/apache/rya/benchmark/query/PCJOptimizerBenchmark.java
@@ -28,7 +28,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Queue;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Param;
@@ -71,7 +71,7 @@ import org.apache.rya.indexing.pcj.matching.PCJOptimizer;
  * </pre>
  */
 @State(Scope.Thread)
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class PCJOptimizerBenchmark {
 
     /**
@@ -305,7 +305,7 @@ public class PCJOptimizerBenchmark {
     /**
      * The parameter values used by the benchmark. Used to lookup a benchmark' {@link BenchmarkValues}.
      */
-    @ParametersAreNonnullByDefault
+// SEE RYA-211     @ParametersAreNonnullByDefault
     public static class BenchmarkParams {
         private final int numPCJs;
         private final int pcjSPCount;
@@ -369,7 +369,7 @@ public class PCJOptimizerBenchmark {
      * Holds onto the SPARQL query that will be optimized as well as the optimizers
      * that will be used to optimize the query.
      */
-    @ParametersAreNonnullByDefault
+// SEE RYA-211     @ParametersAreNonnullByDefault
     public static class BenchmarkValues {
         private final TupleExpr query;
         private final PCJOptimizer optimizer;

--- a/extras/rya.benchmark/src/main/java/org/apache/rya/benchmark/query/QueriesBenchmarkConfReader.java
+++ b/extras/rya.benchmark/src/main/java/org/apache/rya/benchmark/query/QueriesBenchmarkConfReader.java
@@ -22,7 +22,8 @@ import static java.util.Objects.requireNonNull;
 
 import java.io.InputStream;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.xml.XMLConstants;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
@@ -39,7 +40,7 @@ import com.google.common.base.Suppliers;
 /**
  * Unmarshalls instances of {@link QueriesBenchmarkConf}.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public final class QueriesBenchmarkConfReader {
 
     // It is assumed the schema file is held within the root directory of the packaged jar.

--- a/extras/rya.benchmark/src/main/java/org/apache/rya/benchmark/query/QueriesBenchmarkConfReader.java
+++ b/extras/rya.benchmark/src/main/java/org/apache/rya/benchmark/query/QueriesBenchmarkConfReader.java
@@ -22,7 +22,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.io.InputStream;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 import javax.xml.XMLConstants;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
@@ -39,7 +39,7 @@ import com.google.common.base.Suppliers;
 /**
  * Unmarshalls instances of {@link QueriesBenchmarkConf}.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public final class QueriesBenchmarkConfReader {
 
     // It is assumed the schema file is held within the root directory of the packaged jar.

--- a/extras/rya.benchmark/src/main/java/org/apache/rya/benchmark/query/QueryBenchmark.java
+++ b/extras/rya.benchmark/src/main/java/org/apache/rya/benchmark/query/QueryBenchmark.java
@@ -28,7 +28,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.apache.log4j.ConsoleAppender;
 import org.apache.log4j.Level;
@@ -248,7 +248,7 @@ public class QueryBenchmark {
     /**
      * Executes an iteration of the benchmarked logic.
      */
-    @ParametersAreNonnullByDefault
+// SEE RYA-211     @ParametersAreNonnullByDefault
     public static final class QueryBenchmarkRun {
 
         private final SailConnection sailConn;

--- a/extras/rya.benchmark/src/main/java/org/apache/rya/benchmark/query/QueryBenchmark.java
+++ b/extras/rya.benchmark/src/main/java/org/apache/rya/benchmark/query/QueryBenchmark.java
@@ -28,7 +28,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.apache.log4j.ConsoleAppender;
 import org.apache.log4j.Level;
@@ -248,7 +249,7 @@ public class QueryBenchmark {
     /**
      * Executes an iteration of the benchmarked logic.
      */
-// SEE RYA-211     @ParametersAreNonnullByDefault
+    @DefaultAnnotation(NonNull.class)
     public static final class QueryBenchmarkRun {
 
         private final SailConnection sailConn;

--- a/extras/rya.console/src/main/java/org/apache/rya/shell/SharedShellState.java
+++ b/extras/rya.console/src/main/java/org/apache/rya/shell/SharedShellState.java
@@ -23,10 +23,10 @@ import static java.util.Objects.requireNonNull;
 import java.util.Objects;
 import java.util.concurrent.locks.ReentrantLock;
 
-import javax.annotation.Nullable;
-import javax.annotation.ParametersAreNonnullByDefault;
-import javax.annotation.concurrent.Immutable;
-import javax.annotation.concurrent.ThreadSafe;
+import edu.umd.cs.findbugs.annotations.Nullable;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.concurrent.Immutable;
+// SEE RYA-211 import javax.annotation.concurrent.ThreadSafe;
 
 import com.google.common.base.Optional;
 
@@ -36,8 +36,8 @@ import org.apache.rya.api.client.accumulo.AccumuloConnectionDetails;
 /**
  * Holds values that are shared between the various Rya command classes.
  */
-@ThreadSafe
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ThreadSafe
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class SharedShellState {
     // The shared nature of this object means we shouldn't assume only a single thread is accessing it.
     private final ReentrantLock lock = new ReentrantLock();
@@ -161,8 +161,8 @@ public class SharedShellState {
     /**
      * Values that define the state of a Rya Shell.
      */
-    @Immutable
-    @ParametersAreNonnullByDefault
+// SEE RYA-211     @Immutable
+// SEE RYA-211     @ParametersAreNonnullByDefault
     public static final class ShellState {
         // Indicates the state of the shell.
         private final ConnectionState connectionState;
@@ -258,7 +258,7 @@ public class SharedShellState {
         /**
          * Builds instances of {@link ShellState}.
          */
-        @ParametersAreNonnullByDefault
+// SEE RYA-211         @ParametersAreNonnullByDefault
         public static class Builder {
             private ConnectionState connectionState;
 

--- a/extras/rya.console/src/main/java/org/apache/rya/shell/SharedShellState.java
+++ b/extras/rya.console/src/main/java/org/apache/rya/shell/SharedShellState.java
@@ -24,9 +24,10 @@ import java.util.Objects;
 import java.util.concurrent.locks.ReentrantLock;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
-// SEE RYA-211 import javax.annotation.concurrent.Immutable;
-// SEE RYA-211 import javax.annotation.concurrent.ThreadSafe;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import net.jcip.annotations.Immutable;
+import net.jcip.annotations.ThreadSafe;
 
 import com.google.common.base.Optional;
 
@@ -36,8 +37,8 @@ import org.apache.rya.api.client.accumulo.AccumuloConnectionDetails;
 /**
  * Holds values that are shared between the various Rya command classes.
  */
-// SEE RYA-211 @ThreadSafe
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@ThreadSafe
+@DefaultAnnotation(NonNull.class)
 public class SharedShellState {
     // The shared nature of this object means we shouldn't assume only a single thread is accessing it.
     private final ReentrantLock lock = new ReentrantLock();
@@ -161,8 +162,8 @@ public class SharedShellState {
     /**
      * Values that define the state of a Rya Shell.
      */
-// SEE RYA-211     @Immutable
-// SEE RYA-211     @ParametersAreNonnullByDefault
+    @Immutable
+    @DefaultAnnotation(NonNull.class)
     public static final class ShellState {
         // Indicates the state of the shell.
         private final ConnectionState connectionState;
@@ -258,7 +259,7 @@ public class SharedShellState {
         /**
          * Builds instances of {@link ShellState}.
          */
-// SEE RYA-211         @ParametersAreNonnullByDefault
+        @DefaultAnnotation(NonNull.class)
         public static class Builder {
             private ConnectionState connectionState;
 

--- a/extras/rya.console/src/main/java/org/apache/rya/shell/util/ConnectorFactory.java
+++ b/extras/rya.console/src/main/java/org/apache/rya/shell/util/ConnectorFactory.java
@@ -20,7 +20,8 @@ package org.apache.rya.shell.util;
 
 import static java.util.Objects.requireNonNull;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
@@ -32,7 +33,7 @@ import org.apache.accumulo.core.client.security.tokens.PasswordToken;
 /**
  * Creates {@link Connector}s that are linked to an instance of Accumulo.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class ConnectorFactory {
 
     /**

--- a/extras/rya.console/src/main/java/org/apache/rya/shell/util/ConnectorFactory.java
+++ b/extras/rya.console/src/main/java/org/apache/rya/shell/util/ConnectorFactory.java
@@ -20,7 +20,7 @@ package org.apache.rya.shell.util;
 
 import static java.util.Objects.requireNonNull;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
@@ -32,7 +32,7 @@ import org.apache.accumulo.core.client.security.tokens.PasswordToken;
 /**
  * Creates {@link Connector}s that are linked to an instance of Accumulo.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class ConnectorFactory {
 
     /**

--- a/extras/rya.console/src/main/java/org/apache/rya/shell/util/InstanceNamesFormatter.java
+++ b/extras/rya.console/src/main/java/org/apache/rya/shell/util/InstanceNamesFormatter.java
@@ -22,12 +22,13 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.List;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * Pretty formats a list of Rya instance names.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class InstanceNamesFormatter {
 
     /**

--- a/extras/rya.console/src/main/java/org/apache/rya/shell/util/InstanceNamesFormatter.java
+++ b/extras/rya.console/src/main/java/org/apache/rya/shell/util/InstanceNamesFormatter.java
@@ -22,12 +22,12 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.List;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 /**
  * Pretty formats a list of Rya instance names.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class InstanceNamesFormatter {
 
     /**

--- a/extras/rya.console/src/main/java/org/apache/rya/shell/util/JLinePrompt.java
+++ b/extras/rya.console/src/main/java/org/apache/rya/shell/util/JLinePrompt.java
@@ -23,7 +23,8 @@ import static java.util.Objects.requireNonNull;
 import java.io.IOException;
 import java.util.Set;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.util.FieldUtils;
@@ -38,7 +39,7 @@ import jline.console.ConsoleReader;
  * Provides access to the host {@link Shell}'s {@link ConsoleReader} and some
  * utility functions for using it.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public abstract class JLinePrompt {
 
     /**

--- a/extras/rya.console/src/main/java/org/apache/rya/shell/util/JLinePrompt.java
+++ b/extras/rya.console/src/main/java/org/apache/rya/shell/util/JLinePrompt.java
@@ -23,7 +23,7 @@ import static java.util.Objects.requireNonNull;
 import java.io.IOException;
 import java.util.Set;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.util.FieldUtils;
@@ -38,7 +38,7 @@ import jline.console.ConsoleReader;
  * Provides access to the host {@link Shell}'s {@link ConsoleReader} and some
  * utility functions for using it.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public abstract class JLinePrompt {
 
     /**

--- a/extras/rya.console/src/main/java/org/apache/rya/shell/util/PasswordPrompt.java
+++ b/extras/rya.console/src/main/java/org/apache/rya/shell/util/PasswordPrompt.java
@@ -20,14 +20,14 @@ package org.apache.rya.shell.util;
 
 import java.io.IOException;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import jline.console.ConsoleReader;
 
 /**
  * A mechanism for prompting a user of the application for a password.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public interface PasswordPrompt {
 
     /**

--- a/extras/rya.console/src/main/java/org/apache/rya/shell/util/PasswordPrompt.java
+++ b/extras/rya.console/src/main/java/org/apache/rya/shell/util/PasswordPrompt.java
@@ -20,14 +20,15 @@ package org.apache.rya.shell.util;
 
 import java.io.IOException;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import jline.console.ConsoleReader;
 
 /**
  * A mechanism for prompting a user of the application for a password.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public interface PasswordPrompt {
 
     /**

--- a/extras/rya.console/src/main/java/org/apache/rya/shell/util/RyaDetailsFormatter.java
+++ b/extras/rya.console/src/main/java/org/apache/rya/shell/util/RyaDetailsFormatter.java
@@ -20,7 +20,7 @@ package org.apache.rya.shell.util;
 
 import static java.util.Objects.requireNonNull;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
@@ -32,7 +32,7 @@ import org.apache.rya.api.instance.RyaDetails.PCJIndexDetails.PCJDetails;
 /**
  * Formats an instance of {@link RyaDetails}.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class RyaDetailsFormatter {
 
     /**

--- a/extras/rya.console/src/main/java/org/apache/rya/shell/util/RyaDetailsFormatter.java
+++ b/extras/rya.console/src/main/java/org/apache/rya/shell/util/RyaDetailsFormatter.java
@@ -20,7 +20,8 @@ package org.apache.rya.shell.util;
 
 import static java.util.Objects.requireNonNull;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
@@ -32,7 +33,7 @@ import org.apache.rya.api.instance.RyaDetails.PCJIndexDetails.PCJDetails;
 /**
  * Formats an instance of {@link RyaDetails}.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class RyaDetailsFormatter {
 
     /**

--- a/extras/rya.console/src/main/java/org/apache/rya/shell/util/SparqlPrompt.java
+++ b/extras/rya.console/src/main/java/org/apache/rya/shell/util/SparqlPrompt.java
@@ -20,14 +20,14 @@ package org.apache.rya.shell.util;
 
 import java.io.IOException;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import jline.console.ConsoleReader;
 
 /**
  * A mechanism for prompting a user of the application for a SPARQL string.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public interface SparqlPrompt {
 
     /**
@@ -42,7 +42,7 @@ public interface SparqlPrompt {
     /**
      * Prompts a user for a SPARQL query using a JLine {@link ConsoleReader}.
      */
-    @ParametersAreNonnullByDefault
+// SEE RYA-211     @ParametersAreNonnullByDefault
     public static class JLineSparqlPrompt extends JLinePrompt implements SparqlPrompt {
 
         @Override

--- a/extras/rya.console/src/main/java/org/apache/rya/shell/util/SparqlPrompt.java
+++ b/extras/rya.console/src/main/java/org/apache/rya/shell/util/SparqlPrompt.java
@@ -20,14 +20,15 @@ package org.apache.rya.shell.util;
 
 import java.io.IOException;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import jline.console.ConsoleReader;
 
 /**
  * A mechanism for prompting a user of the application for a SPARQL string.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public interface SparqlPrompt {
 
     /**
@@ -42,7 +43,7 @@ public interface SparqlPrompt {
     /**
      * Prompts a user for a SPARQL query using a JLine {@link ConsoleReader}.
      */
-// SEE RYA-211     @ParametersAreNonnullByDefault
+    @DefaultAnnotation(NonNull.class)
     public static class JLineSparqlPrompt extends JLinePrompt implements SparqlPrompt {
 
         @Override

--- a/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/PcjMetadata.java
+++ b/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/PcjMetadata.java
@@ -24,8 +24,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.Collection;
 import java.util.Objects;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
-// SEE RYA-211 import javax.annotation.concurrent.Immutable;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import net.jcip.annotations.Immutable;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.rya.indexing.pcj.storage.accumulo.VariableOrder;
@@ -35,8 +36,8 @@ import com.google.common.collect.ImmutableSet;
 /**
  * Metadata that is stored in a PCJ table about the results that are stored within it.
  */
-// SEE RYA-211 @Immutable
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@Immutable
+@DefaultAnnotation(NonNull.class)
 public final class PcjMetadata {
     private final String sparql;
     private final long cardinality;

--- a/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/PcjMetadata.java
+++ b/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/PcjMetadata.java
@@ -24,8 +24,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.Collection;
 import java.util.Objects;
 
-import javax.annotation.ParametersAreNonnullByDefault;
-import javax.annotation.concurrent.Immutable;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.concurrent.Immutable;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.rya.indexing.pcj.storage.accumulo.VariableOrder;
@@ -35,8 +35,8 @@ import com.google.common.collect.ImmutableSet;
 /**
  * Metadata that is stored in a PCJ table about the results that are stored within it.
  */
-@Immutable
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @Immutable
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public final class PcjMetadata {
     private final String sparql;
     private final long cardinality;

--- a/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/PrecomputedJoinStorage.java
+++ b/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/PrecomputedJoinStorage.java
@@ -22,7 +22,8 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.apache.rya.indexing.pcj.storage.accumulo.VisibilityBindingSet;
 import org.openrdf.query.BindingSet;
@@ -30,7 +31,7 @@ import org.openrdf.query.BindingSet;
 /**
  * Functions that create and maintain the PCJ tables that are used by Rya.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public interface PrecomputedJoinStorage {
 
     /**

--- a/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/PrecomputedJoinStorage.java
+++ b/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/PrecomputedJoinStorage.java
@@ -22,7 +22,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.apache.rya.indexing.pcj.storage.accumulo.VisibilityBindingSet;
 import org.openrdf.query.BindingSet;
@@ -30,7 +30,7 @@ import org.openrdf.query.BindingSet;
 /**
  * Functions that create and maintain the PCJ tables that are used by Rya.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public interface PrecomputedJoinStorage {
 
     /**

--- a/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/accumulo/AccumuloPcjSerializer.java
+++ b/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/accumulo/AccumuloPcjSerializer.java
@@ -30,7 +30,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.openrdf.model.Value;
 import org.openrdf.query.Binding;
@@ -49,7 +49,7 @@ import org.apache.rya.api.resolver.RyaTypeResolverException;
  * Converts {@link BindingSet}s to byte[]s and back again. The bytes do not
  * include the binding names and are ordered with a {@link VariableOrder}.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class AccumuloPcjSerializer implements BindingSetConverter<byte[]> {
 
     @Override

--- a/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/accumulo/AccumuloPcjSerializer.java
+++ b/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/accumulo/AccumuloPcjSerializer.java
@@ -30,7 +30,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.openrdf.model.Value;
 import org.openrdf.query.Binding;
@@ -49,7 +50,7 @@ import org.apache.rya.api.resolver.RyaTypeResolverException;
  * Converts {@link BindingSet}s to byte[]s and back again. The bytes do not
  * include the binding names and are ordered with a {@link VariableOrder}.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class AccumuloPcjSerializer implements BindingSetConverter<byte[]> {
 
     @Override

--- a/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/accumulo/AccumuloPcjStorage.java
+++ b/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/accumulo/AccumuloPcjStorage.java
@@ -25,7 +25,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
@@ -50,7 +51,7 @@ import org.apache.rya.api.instance.RyaDetailsUpdater.RyaDetailsMutator.CouldNotA
 /**
  * An Accumulo backed implementation of {@link PrecomputedJoinStorage}.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class AccumuloPcjStorage implements PrecomputedJoinStorage {
 
     // Factories that are used to create new PCJs.

--- a/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/accumulo/AccumuloPcjStorage.java
+++ b/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/accumulo/AccumuloPcjStorage.java
@@ -25,7 +25,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
@@ -50,7 +50,7 @@ import org.apache.rya.api.instance.RyaDetailsUpdater.RyaDetailsMutator.CouldNotA
 /**
  * An Accumulo backed implementation of {@link PrecomputedJoinStorage}.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class AccumuloPcjStorage implements PrecomputedJoinStorage {
 
     // Factories that are used to create new PCJs.

--- a/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/accumulo/BindingSetConverter.java
+++ b/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/accumulo/BindingSetConverter.java
@@ -18,7 +18,7 @@
  */
 package org.apache.rya.indexing.pcj.storage.accumulo;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.openrdf.query.Binding;
 import org.openrdf.query.BindingSet;
@@ -30,7 +30,7 @@ import org.openrdf.query.BindingSet;
  *
  * @param <T> Defines the type of model {@link BindingSet}s will be converted into/from.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public interface BindingSetConverter<T> {
 
    /**

--- a/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/accumulo/BindingSetConverter.java
+++ b/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/accumulo/BindingSetConverter.java
@@ -18,7 +18,8 @@
  */
 package org.apache.rya.indexing.pcj.storage.accumulo;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.openrdf.query.Binding;
 import org.openrdf.query.BindingSet;
@@ -30,7 +31,7 @@ import org.openrdf.query.BindingSet;
  *
  * @param <T> Defines the type of model {@link BindingSet}s will be converted into/from.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public interface BindingSetConverter<T> {
 
    /**

--- a/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/accumulo/BindingSetStringConverter.java
+++ b/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/accumulo/BindingSetStringConverter.java
@@ -25,7 +25,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.openrdf.model.URI;
 import org.openrdf.model.Value;
@@ -46,7 +47,7 @@ import org.apache.rya.api.resolver.RdfToRyaConversions;
  * Converts {@link BindingSet}s to Strings and back again. The Strings do not
  * include the binding names and are ordered with a {@link VariableOrder}.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class BindingSetStringConverter implements BindingSetConverter<String> {
 
     public static final String BINDING_DELIM = ":::";

--- a/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/accumulo/BindingSetStringConverter.java
+++ b/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/accumulo/BindingSetStringConverter.java
@@ -25,7 +25,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.openrdf.model.URI;
 import org.openrdf.model.Value;
@@ -46,7 +46,7 @@ import org.apache.rya.api.resolver.RdfToRyaConversions;
  * Converts {@link BindingSet}s to Strings and back again. The Strings do not
  * include the binding names and are ordered with a {@link VariableOrder}.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class BindingSetStringConverter implements BindingSetConverter<String> {
 
     public static final String BINDING_DELIM = ":::";

--- a/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/accumulo/PcjTableNameFactory.java
+++ b/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/accumulo/PcjTableNameFactory.java
@@ -20,13 +20,14 @@ package org.apache.rya.indexing.pcj.storage.accumulo;
 
 import static java.util.Objects.requireNonNull;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * Creates Accumulo table names that may be recognized by Rya as a table that
  * holds the results of a Precomputed Join.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class PcjTableNameFactory {
 
     /**

--- a/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/accumulo/PcjTableNameFactory.java
+++ b/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/accumulo/PcjTableNameFactory.java
@@ -20,13 +20,13 @@ package org.apache.rya.indexing.pcj.storage.accumulo;
 
 import static java.util.Objects.requireNonNull;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 /**
  * Creates Accumulo table names that may be recognized by Rya as a table that
  * holds the results of a Precomputed Join.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class PcjTableNameFactory {
 
     /**

--- a/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/accumulo/PcjTables.java
+++ b/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/accumulo/PcjTables.java
@@ -30,7 +30,7 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
@@ -74,7 +74,7 @@ import com.google.common.base.Optional;
 /**
  * Functions that create and maintain the PCJ tables that are used by Rya.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class PcjTables {
     private static final Logger log = Logger.getLogger(PcjTables.class);
 

--- a/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/accumulo/PcjTables.java
+++ b/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/accumulo/PcjTables.java
@@ -30,7 +30,8 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
@@ -74,7 +75,7 @@ import com.google.common.base.Optional;
 /**
  * Functions that create and maintain the PCJ tables that are used by Rya.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class PcjTables {
     private static final Logger log = Logger.getLogger(PcjTables.class);
 

--- a/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/accumulo/PcjVarOrderFactory.java
+++ b/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/accumulo/PcjVarOrderFactory.java
@@ -20,7 +20,8 @@ package org.apache.rya.indexing.pcj.storage.accumulo;
 
 import java.util.Set;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.openrdf.query.MalformedQueryException;
 
@@ -28,7 +29,7 @@ import org.openrdf.query.MalformedQueryException;
  * Create alternative variable orders for a SPARQL query based on
  * the original ordering of its results.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public interface PcjVarOrderFactory {
 
     /**

--- a/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/accumulo/PcjVarOrderFactory.java
+++ b/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/accumulo/PcjVarOrderFactory.java
@@ -20,7 +20,7 @@ package org.apache.rya.indexing.pcj.storage.accumulo;
 
 import java.util.Set;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.openrdf.query.MalformedQueryException;
 
@@ -28,7 +28,7 @@ import org.openrdf.query.MalformedQueryException;
  * Create alternative variable orders for a SPARQL query based on
  * the original ordering of its results.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public interface PcjVarOrderFactory {
 
     /**

--- a/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/accumulo/ScannerBindingSetIterator.java
+++ b/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/accumulo/ScannerBindingSetIterator.java
@@ -23,7 +23,8 @@ import static java.util.Objects.requireNonNull;
 import java.util.Iterator;
 import java.util.Map.Entry;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.data.Key;
@@ -35,7 +36,7 @@ import org.openrdf.query.BindingSet;
  * Iterates over the results of a {@link Scanner} assuming the results are
  * binding sets that can be converted using a {@link AccumuloPcjSerializer}.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class ScannerBindingSetIterator implements Iterator<BindingSet> {
 
     private static final AccumuloPcjSerializer converter = new AccumuloPcjSerializer();

--- a/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/accumulo/ScannerBindingSetIterator.java
+++ b/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/accumulo/ScannerBindingSetIterator.java
@@ -23,7 +23,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.Iterator;
 import java.util.Map.Entry;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.data.Key;
@@ -35,7 +35,7 @@ import org.openrdf.query.BindingSet;
  * Iterates over the results of a {@link Scanner} assuming the results are
  * binding sets that can be converted using a {@link AccumuloPcjSerializer}.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class ScannerBindingSetIterator implements Iterator<BindingSet> {
 
     private static final AccumuloPcjSerializer converter = new AccumuloPcjSerializer();

--- a/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/accumulo/ShiftVarOrderFactory.java
+++ b/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/accumulo/ShiftVarOrderFactory.java
@@ -24,7 +24,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.openrdf.query.MalformedQueryException;
 import org.openrdf.query.parser.sparql.SPARQLParser;
@@ -35,7 +35,7 @@ import com.google.common.collect.Lists;
  * Shifts the variables to the left so that each variable will appear at
  * the head of the varOrder once.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class ShiftVarOrderFactory implements PcjVarOrderFactory {
 
     @Override

--- a/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/accumulo/ShiftVarOrderFactory.java
+++ b/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/accumulo/ShiftVarOrderFactory.java
@@ -24,7 +24,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.openrdf.query.MalformedQueryException;
 import org.openrdf.query.parser.sparql.SPARQLParser;
@@ -35,7 +36,7 @@ import com.google.common.collect.Lists;
  * Shifts the variables to the left so that each variable will appear at
  * the head of the varOrder once.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class ShiftVarOrderFactory implements PcjVarOrderFactory {
 
     @Override

--- a/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/accumulo/VariableOrder.java
+++ b/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/accumulo/VariableOrder.java
@@ -23,8 +23,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.Collection;
 import java.util.Iterator;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
-// SEE RYA-211 import javax.annotation.concurrent.Immutable;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import net.jcip.annotations.Immutable;
 
 import org.openrdf.query.BindingSet;
 
@@ -36,8 +37,8 @@ import com.google.common.collect.ImmutableList;
  * specify the order {@link Binding}s within the set are serialized to Accumulo.
  * This order effects which rows a prefix scan will hit.
  */
-// SEE RYA-211 @Immutable
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@Immutable
+@DefaultAnnotation(NonNull.class)
 public final class VariableOrder implements Iterable<String> {
 
     public static final String VAR_ORDER_DELIM = ";";

--- a/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/accumulo/VariableOrder.java
+++ b/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/accumulo/VariableOrder.java
@@ -23,8 +23,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.Collection;
 import java.util.Iterator;
 
-import javax.annotation.ParametersAreNonnullByDefault;
-import javax.annotation.concurrent.Immutable;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.concurrent.Immutable;
 
 import org.openrdf.query.BindingSet;
 
@@ -36,8 +36,8 @@ import com.google.common.collect.ImmutableList;
  * specify the order {@link Binding}s within the set are serialized to Accumulo.
  * This order effects which rows a prefix scan will hit.
  */
-@Immutable
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @Immutable
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public final class VariableOrder implements Iterable<String> {
 
     public static final String VAR_ORDER_DELIM = ";";

--- a/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/accumulo/VisibilityBindingSet.java
+++ b/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/accumulo/VisibilityBindingSet.java
@@ -20,14 +20,14 @@ package org.apache.rya.indexing.pcj.storage.accumulo;
 
 import static java.util.Objects.requireNonNull;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.openrdf.query.BindingSet;
 
 /**
  * Decorates a {@link BindingSet} with a collection of visibilities.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class VisibilityBindingSet extends BindingSetDecorator {
     private static final long serialVersionUID = 1L;
     private String visibility;

--- a/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/accumulo/VisibilityBindingSet.java
+++ b/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/accumulo/VisibilityBindingSet.java
@@ -20,14 +20,15 @@ package org.apache.rya.indexing.pcj.storage.accumulo;
 
 import static java.util.Objects.requireNonNull;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.openrdf.query.BindingSet;
 
 /**
  * Decorates a {@link BindingSet} with a collection of visibilities.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class VisibilityBindingSet extends BindingSetDecorator {
     private static final long serialVersionUID = 1L;
     private String visibility;

--- a/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/accumulo/VisibilityBindingSetStringConverter.java
+++ b/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/accumulo/VisibilityBindingSetStringConverter.java
@@ -18,7 +18,8 @@
  */
 package org.apache.rya.indexing.pcj.storage.accumulo;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.openrdf.query.BindingSet;
 
@@ -26,7 +27,7 @@ import org.openrdf.query.BindingSet;
  * Converts {@link BindingSet}s to Strings and back again. The Strings do not
  * include the binding names and are ordered with a {@link VariableOrder}.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class VisibilityBindingSetStringConverter extends BindingSetStringConverter {
     public static final char VISIBILITY_DELIM = 1;
 

--- a/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/accumulo/VisibilityBindingSetStringConverter.java
+++ b/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/storage/accumulo/VisibilityBindingSetStringConverter.java
@@ -18,7 +18,7 @@
  */
 package org.apache.rya.indexing.pcj.storage.accumulo;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.openrdf.query.BindingSet;
 
@@ -26,7 +26,7 @@ import org.openrdf.query.BindingSet;
  * Converts {@link BindingSet}s to Strings and back again. The Strings do not
  * include the binding names and are ordered with a {@link VariableOrder}.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class VisibilityBindingSetStringConverter extends BindingSetStringConverter {
     public static final char VISIBILITY_DELIM = 1;
 

--- a/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/update/PrecomputedJoinUpdater.java
+++ b/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/update/PrecomputedJoinUpdater.java
@@ -20,7 +20,8 @@ package org.apache.rya.indexing.pcj.update;
 
 import java.util.Collection;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.apache.rya.indexing.pcj.storage.PcjException;
 
@@ -30,7 +31,7 @@ import org.apache.rya.api.domain.RyaStatement;
  * Updates the state of all PCJ indices whenever {@link RyaStatement}s are
  * added to or removed from the system.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public interface PrecomputedJoinUpdater {
 
     /**

--- a/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/update/PrecomputedJoinUpdater.java
+++ b/extras/rya.indexing.pcj/src/main/java/org/apache/rya/indexing/pcj/update/PrecomputedJoinUpdater.java
@@ -20,7 +20,7 @@ package org.apache.rya.indexing.pcj.update;
 
 import java.util.Collection;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.apache.rya.indexing.pcj.storage.PcjException;
 
@@ -30,7 +30,7 @@ import org.apache.rya.api.domain.RyaStatement;
  * Updates the state of all PCJ indices whenever {@link RyaStatement}s are
  * added to or removed from the system.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public interface PrecomputedJoinUpdater {
 
     /**

--- a/extras/rya.pcj.fluo/pcj.fluo.api/src/main/java/org/apache/rya/indexing/pcj/fluo/api/CreatePcj.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.api/src/main/java/org/apache/rya/indexing/pcj/fluo/api/CreatePcj.java
@@ -26,7 +26,7 @@ import static org.apache.rya.indexing.pcj.fluo.app.IncrementalUpdateConstants.NO
 import java.util.HashSet;
 import java.util.Set;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.apache.rya.indexing.pcj.fluo.app.FluoStringConverter;
 import org.apache.rya.indexing.pcj.fluo.app.query.FluoQuery;
@@ -71,7 +71,7 @@ import org.apache.fluo.api.client.Transaction;
  * will percolate to the top of the query, and those results will be exported to
  * Rya's query system.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class CreatePcj {
 
     /**

--- a/extras/rya.pcj.fluo/pcj.fluo.api/src/main/java/org/apache/rya/indexing/pcj/fluo/api/CreatePcj.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.api/src/main/java/org/apache/rya/indexing/pcj/fluo/api/CreatePcj.java
@@ -26,7 +26,8 @@ import static org.apache.rya.indexing.pcj.fluo.app.IncrementalUpdateConstants.NO
 import java.util.HashSet;
 import java.util.Set;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.apache.rya.indexing.pcj.fluo.app.FluoStringConverter;
 import org.apache.rya.indexing.pcj.fluo.app.query.FluoQuery;
@@ -71,7 +72,7 @@ import org.apache.fluo.api.client.Transaction;
  * will percolate to the top of the query, and those results will be exported to
  * Rya's query system.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class CreatePcj {
 
     /**

--- a/extras/rya.pcj.fluo/pcj.fluo.api/src/main/java/org/apache/rya/indexing/pcj/fluo/api/DeletePcj.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.api/src/main/java/org/apache/rya/indexing/pcj/fluo/api/DeletePcj.java
@@ -25,7 +25,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.apache.rya.indexing.pcj.fluo.app.NodeType;
 import org.apache.rya.indexing.pcj.fluo.app.query.FilterMetadata;
@@ -56,7 +56,7 @@ import org.apache.fluo.api.data.Span;
  *       into memory.</li>
  * </ol>
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class DeletePcj {
 
     private final FluoQueryMetadataDAO dao = new FluoQueryMetadataDAO();

--- a/extras/rya.pcj.fluo/pcj.fluo.api/src/main/java/org/apache/rya/indexing/pcj/fluo/api/DeletePcj.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.api/src/main/java/org/apache/rya/indexing/pcj/fluo/api/DeletePcj.java
@@ -25,7 +25,8 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.apache.rya.indexing.pcj.fluo.app.NodeType;
 import org.apache.rya.indexing.pcj.fluo.app.query.FilterMetadata;
@@ -56,7 +57,7 @@ import org.apache.fluo.api.data.Span;
  *       into memory.</li>
  * </ol>
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class DeletePcj {
 
     private final FluoQueryMetadataDAO dao = new FluoQueryMetadataDAO();

--- a/extras/rya.pcj.fluo/pcj.fluo.api/src/main/java/org/apache/rya/indexing/pcj/fluo/api/GetQueryReport.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.api/src/main/java/org/apache/rya/indexing/pcj/fluo/api/GetQueryReport.java
@@ -25,9 +25,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.Nullable;
-import javax.annotation.ParametersAreNonnullByDefault;
-import javax.annotation.concurrent.Immutable;
+import edu.umd.cs.findbugs.annotations.Nullable;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.concurrent.Immutable;
 
 import org.apache.rya.indexing.pcj.fluo.app.query.FilterMetadata;
 import org.apache.rya.indexing.pcj.fluo.app.query.FluoQuery;
@@ -50,7 +50,7 @@ import org.apache.fluo.api.data.Span;
  * Get a reports that indicates how many binding sets have been emitted for
  * the queries that is being managed by the fluo application.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class GetQueryReport {
 
     private final FluoQueryMetadataDAO metadataDao = new FluoQueryMetadataDAO();
@@ -145,8 +145,8 @@ public class GetQueryReport {
      * as well as the number of Binding Sets that have been emitted for each of
      * the query nodes.
      */
-    @Immutable
-    @ParametersAreNonnullByDefault
+// SEE RYA-211     @Immutable
+// SEE RYA-211     @ParametersAreNonnullByDefault
     public static final class QueryReport {
 
         /**
@@ -212,7 +212,7 @@ public class GetQueryReport {
         /**
          * Builds instances of {@link QueryReport}.
          */
-        @ParametersAreNonnullByDefault
+// SEE RYA-211         @ParametersAreNonnullByDefault
         public static final class Builder {
 
             private FluoQuery fluoQuery = null;

--- a/extras/rya.pcj.fluo/pcj.fluo.api/src/main/java/org/apache/rya/indexing/pcj/fluo/api/GetQueryReport.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.api/src/main/java/org/apache/rya/indexing/pcj/fluo/api/GetQueryReport.java
@@ -26,8 +26,9 @@ import java.util.List;
 import java.util.Map;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
-// SEE RYA-211 import javax.annotation.concurrent.Immutable;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import net.jcip.annotations.Immutable;
 
 import org.apache.rya.indexing.pcj.fluo.app.query.FilterMetadata;
 import org.apache.rya.indexing.pcj.fluo.app.query.FluoQuery;
@@ -50,7 +51,7 @@ import org.apache.fluo.api.data.Span;
  * Get a reports that indicates how many binding sets have been emitted for
  * the queries that is being managed by the fluo application.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class GetQueryReport {
 
     private final FluoQueryMetadataDAO metadataDao = new FluoQueryMetadataDAO();
@@ -145,8 +146,8 @@ public class GetQueryReport {
      * as well as the number of Binding Sets that have been emitted for each of
      * the query nodes.
      */
-// SEE RYA-211     @Immutable
-// SEE RYA-211     @ParametersAreNonnullByDefault
+    @Immutable
+    @DefaultAnnotation(NonNull.class)
     public static final class QueryReport {
 
         /**
@@ -212,7 +213,7 @@ public class GetQueryReport {
         /**
          * Builds instances of {@link QueryReport}.
          */
-// SEE RYA-211         @ParametersAreNonnullByDefault
+        @DefaultAnnotation(NonNull.class)
         public static final class Builder {
 
             private FluoQuery fluoQuery = null;

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/BindingSetRow.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/BindingSetRow.java
@@ -21,8 +21,9 @@ package org.apache.rya.indexing.pcj.fluo.app;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.rya.indexing.pcj.fluo.app.IncrementalUpdateConstants.NODEID_BS_DELIM;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
-// SEE RYA-211 import javax.annotation.concurrent.Immutable;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import net.jcip.annotations.Immutable;
 
 import org.apache.fluo.api.data.Bytes;
 
@@ -30,8 +31,8 @@ import org.apache.fluo.api.data.Bytes;
  * The values of an Accumulo Row ID for a row that stores a Binding set for
  * a specific Node ID of a query.
  */
-// SEE RYA-211 @Immutable
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@Immutable
+@DefaultAnnotation(NonNull.class)
 public class BindingSetRow {
     private final String nodeId;
     private final String bindingSetString;

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/BindingSetRow.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/BindingSetRow.java
@@ -21,8 +21,8 @@ package org.apache.rya.indexing.pcj.fluo.app;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.rya.indexing.pcj.fluo.app.IncrementalUpdateConstants.NODEID_BS_DELIM;
 
-import javax.annotation.ParametersAreNonnullByDefault;
-import javax.annotation.concurrent.Immutable;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.concurrent.Immutable;
 
 import org.apache.fluo.api.data.Bytes;
 
@@ -30,8 +30,8 @@ import org.apache.fluo.api.data.Bytes;
  * The values of an Accumulo Row ID for a row that stores a Binding set for
  * a specific Node ID of a query.
  */
-@Immutable
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @Immutable
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class BindingSetRow {
     private final String nodeId;
     private final String bindingSetString;

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/FilterFinder.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/FilterFinder.java
@@ -23,7 +23,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.openrdf.query.algebra.Filter;
 import org.openrdf.query.algebra.helpers.QueryModelVisitorBase;
@@ -35,7 +36,7 @@ import com.google.common.base.Optional;
 /**
  * Searches a SPARQL query for {@link Filter}s.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 class FilterFinder {
 
     /**

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/FilterFinder.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/FilterFinder.java
@@ -23,7 +23,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.openrdf.query.algebra.Filter;
 import org.openrdf.query.algebra.helpers.QueryModelVisitorBase;
@@ -35,7 +35,7 @@ import com.google.common.base.Optional;
 /**
  * Searches a SPARQL query for {@link Filter}s.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 class FilterFinder {
 
     /**

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/FilterResultUpdater.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/FilterResultUpdater.java
@@ -21,7 +21,7 @@ package org.apache.rya.indexing.pcj.fluo.app;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.rya.indexing.pcj.fluo.app.IncrementalUpdateConstants.NODEID_BS_DELIM;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.apache.rya.indexing.pcj.fluo.app.query.FilterMetadata;
 import org.apache.rya.indexing.pcj.fluo.app.query.FluoQueryColumns;
@@ -57,7 +57,7 @@ import org.apache.fluo.api.data.Column;
  * Updates the results of a Filter node when its child has added a new Binding
  * Set to its results.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class FilterResultUpdater {
 
     private static final BindingSetStringConverter ID_CONVERTER = new BindingSetStringConverter();

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/FilterResultUpdater.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/FilterResultUpdater.java
@@ -21,7 +21,8 @@ package org.apache.rya.indexing.pcj.fluo.app;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.rya.indexing.pcj.fluo.app.IncrementalUpdateConstants.NODEID_BS_DELIM;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.apache.rya.indexing.pcj.fluo.app.query.FilterMetadata;
 import org.apache.rya.indexing.pcj.fluo.app.query.FluoQueryColumns;
@@ -57,7 +58,7 @@ import org.apache.fluo.api.data.Column;
  * Updates the results of a Filter node when its child has added a new Binding
  * Set to its results.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class FilterResultUpdater {
 
     private static final BindingSetStringConverter ID_CONVERTER = new BindingSetStringConverter();

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/FluoStringConverter.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/FluoStringConverter.java
@@ -23,7 +23,7 @@ import static org.apache.rya.indexing.pcj.fluo.app.IncrementalUpdateConstants.DE
 import static org.apache.rya.indexing.pcj.fluo.app.IncrementalUpdateConstants.TYPE_DELIM;
 import static org.apache.rya.indexing.pcj.fluo.app.IncrementalUpdateConstants.URI_TYPE;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.openrdf.model.Literal;
 import org.openrdf.model.URI;
@@ -40,7 +40,7 @@ import org.apache.rya.api.resolver.RdfToRyaConversions;
  * Contains method that convert between the Sesame representations of RDF
  * components and the Strings that are used by the Fluo PCJ application.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class FluoStringConverter {
 
     /**

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/FluoStringConverter.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/FluoStringConverter.java
@@ -23,7 +23,8 @@ import static org.apache.rya.indexing.pcj.fluo.app.IncrementalUpdateConstants.DE
 import static org.apache.rya.indexing.pcj.fluo.app.IncrementalUpdateConstants.TYPE_DELIM;
 import static org.apache.rya.indexing.pcj.fluo.app.IncrementalUpdateConstants.URI_TYPE;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.openrdf.model.Literal;
 import org.openrdf.model.URI;
@@ -40,7 +41,7 @@ import org.apache.rya.api.resolver.RdfToRyaConversions;
  * Contains method that convert between the Sesame representations of RDF
  * components and the Strings that are used by the Fluo PCJ application.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class FluoStringConverter {
 
     /**

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/JoinResultUpdater.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/JoinResultUpdater.java
@@ -27,7 +27,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.apache.rya.indexing.pcj.fluo.app.query.FluoQueryColumns;
 import org.apache.rya.indexing.pcj.fluo.app.query.FluoQueryMetadataDAO;
@@ -57,7 +58,7 @@ import org.apache.fluo.api.data.Span;
  * Updates the results of a Join node when one of its children has added a
  * new Binding Set to its results.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class JoinResultUpdater {
 
     private static final BindingSetStringConverter idConverter = new BindingSetStringConverter();

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/JoinResultUpdater.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/JoinResultUpdater.java
@@ -27,7 +27,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.apache.rya.indexing.pcj.fluo.app.query.FluoQueryColumns;
 import org.apache.rya.indexing.pcj.fluo.app.query.FluoQueryMetadataDAO;
@@ -57,7 +57,7 @@ import org.apache.fluo.api.data.Span;
  * Updates the results of a Join node when one of its children has added a
  * new Binding Set to its results.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class JoinResultUpdater {
 
     private static final BindingSetStringConverter idConverter = new BindingSetStringConverter();

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/QueryResultUpdater.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/QueryResultUpdater.java
@@ -21,7 +21,8 @@ package org.apache.rya.indexing.pcj.fluo.app;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.rya.indexing.pcj.fluo.app.IncrementalUpdateConstants.NODEID_BS_DELIM;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.apache.rya.indexing.pcj.fluo.app.query.FluoQueryColumns;
 import org.apache.rya.indexing.pcj.fluo.app.query.QueryMetadata;
@@ -39,7 +40,7 @@ import org.apache.fluo.api.data.Column;
  * Updates the results of a Query node when one of its children has added a
  * new Binding Set to its results.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class QueryResultUpdater {
     
     private final BindingSetStringConverter converter = new BindingSetStringConverter();

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/QueryResultUpdater.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/QueryResultUpdater.java
@@ -21,7 +21,7 @@ package org.apache.rya.indexing.pcj.fluo.app;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.rya.indexing.pcj.fluo.app.IncrementalUpdateConstants.NODEID_BS_DELIM;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.apache.rya.indexing.pcj.fluo.app.query.FluoQueryColumns;
 import org.apache.rya.indexing.pcj.fluo.app.query.QueryMetadata;
@@ -39,7 +39,7 @@ import org.apache.fluo.api.data.Column;
  * Updates the results of a Query node when one of its children has added a
  * new Binding Set to its results.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class QueryResultUpdater {
     
     private final BindingSetStringConverter converter = new BindingSetStringConverter();

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/export/IncrementalResultExporter.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/export/IncrementalResultExporter.java
@@ -18,7 +18,7 @@
  */
 package org.apache.rya.indexing.pcj.fluo.app.export;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.apache.fluo.api.client.TransactionBase;
 import org.apache.rya.indexing.pcj.storage.accumulo.VisibilityBindingSet;
@@ -28,7 +28,7 @@ import org.apache.rya.indexing.pcj.storage.accumulo.VisibilityBindingSet;
  * Exports a single Binding Set that is a new result for a SPARQL query to some
  * other location.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public interface IncrementalResultExporter {
 
     /**

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/export/IncrementalResultExporter.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/export/IncrementalResultExporter.java
@@ -18,7 +18,8 @@
  */
 package org.apache.rya.indexing.pcj.fluo.app.export;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.apache.fluo.api.client.TransactionBase;
 import org.apache.rya.indexing.pcj.storage.accumulo.VisibilityBindingSet;
@@ -28,7 +29,7 @@ import org.apache.rya.indexing.pcj.storage.accumulo.VisibilityBindingSet;
  * Exports a single Binding Set that is a new result for a SPARQL query to some
  * other location.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public interface IncrementalResultExporter {
 
     /**

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/export/IncrementalResultExporterFactory.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/export/IncrementalResultExporterFactory.java
@@ -18,7 +18,7 @@
  */
 package org.apache.rya.indexing.pcj.fluo.app.export;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import com.google.common.base.Optional;
 
@@ -28,7 +28,7 @@ import org.apache.fluo.api.observer.Observer.Context;
  * Builds instances of {@link IncrementalResultExporter} using the provided
  * configurations.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public interface IncrementalResultExporterFactory {
 
     /**

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/export/IncrementalResultExporterFactory.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/export/IncrementalResultExporterFactory.java
@@ -18,7 +18,8 @@
  */
 package org.apache.rya.indexing.pcj.fluo.app.export;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import com.google.common.base.Optional;
 
@@ -28,7 +29,7 @@ import org.apache.fluo.api.observer.Observer.Context;
  * Builds instances of {@link IncrementalResultExporter} using the provided
  * configurations.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public interface IncrementalResultExporterFactory {
 
     /**

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/export/ParametersBase.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/export/ParametersBase.java
@@ -22,14 +22,14 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Map;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import com.google.common.base.Optional;
 
 /**
  * Contains common parsing functions that make it easier to interpret parameter maps.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public abstract class ParametersBase {
 
     protected final Map<String, String> params;

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/export/ParametersBase.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/export/ParametersBase.java
@@ -22,14 +22,15 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Map;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import com.google.common.base.Optional;
 
 /**
  * Contains common parsing functions that make it easier to interpret parameter maps.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public abstract class ParametersBase {
 
     protected final Map<String, String> params;

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/export/rya/RyaExportParameters.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/export/rya/RyaExportParameters.java
@@ -21,7 +21,8 @@ package org.apache.rya.indexing.pcj.fluo.app.export.rya;
 import java.util.Map;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.apache.rya.indexing.pcj.fluo.app.export.ParametersBase;
 
@@ -34,7 +35,7 @@ import org.apache.fluo.api.observer.Observer;
  * {@link Observer#init(io.fluo.api.observer.Observer.Context)} method related
  * to Rya PCJ exporting.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class RyaExportParameters extends ParametersBase {
 
     public static final String CONF_EXPORT_TO_RYA = "pcj.fluo.export.rya.enabled";

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/export/rya/RyaExportParameters.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/export/rya/RyaExportParameters.java
@@ -20,8 +20,8 @@ package org.apache.rya.indexing.pcj.fluo.app.export.rya;
 
 import java.util.Map;
 
-import javax.annotation.Nullable;
-import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.Nullable;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.apache.rya.indexing.pcj.fluo.app.export.ParametersBase;
 
@@ -34,7 +34,7 @@ import org.apache.fluo.api.observer.Observer;
  * {@link Observer#init(io.fluo.api.observer.Observer.Context)} method related
  * to Rya PCJ exporting.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class RyaExportParameters extends ParametersBase {
 
     public static final String CONF_EXPORT_TO_RYA = "pcj.fluo.export.rya.enabled";

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/observers/BindingSetUpdater.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/observers/BindingSetUpdater.java
@@ -20,7 +20,8 @@ package org.apache.rya.indexing.pcj.fluo.app.observers;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.apache.rya.indexing.pcj.fluo.app.BindingSetRow;
 import org.apache.rya.indexing.pcj.fluo.app.FilterResultUpdater;
@@ -44,7 +45,7 @@ import org.apache.fluo.api.observer.AbstractObserver;
  * Set. This observer updates its parent if the new Binding Set effects the parent's
  * results.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public abstract class BindingSetUpdater extends AbstractObserver {
 
     // DAO

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/observers/BindingSetUpdater.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/observers/BindingSetUpdater.java
@@ -20,7 +20,7 @@ package org.apache.rya.indexing.pcj.fluo.app.observers;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.apache.rya.indexing.pcj.fluo.app.BindingSetRow;
 import org.apache.rya.indexing.pcj.fluo.app.FilterResultUpdater;
@@ -44,7 +44,7 @@ import org.apache.fluo.api.observer.AbstractObserver;
  * Set. This observer updates its parent if the new Binding Set effects the parent's
  * results.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public abstract class BindingSetUpdater extends AbstractObserver {
 
     // DAO

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/query/CommonNodeMetadata.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/query/CommonNodeMetadata.java
@@ -20,8 +20,9 @@ package org.apache.rya.indexing.pcj.fluo.app.query;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
-// SEE RYA-211 import javax.annotation.concurrent.Immutable;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import net.jcip.annotations.Immutable;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.rya.indexing.pcj.storage.accumulo.VariableOrder;
@@ -31,8 +32,8 @@ import com.google.common.base.Objects;
 /**
  * Metadata that is common to all nodes that are part of a query.
  */
-// SEE RYA-211 @Immutable
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@Immutable
+@DefaultAnnotation(NonNull.class)
 public abstract class CommonNodeMetadata {
 
     private final String nodeId;

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/query/CommonNodeMetadata.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/query/CommonNodeMetadata.java
@@ -20,8 +20,8 @@ package org.apache.rya.indexing.pcj.fluo.app.query;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import javax.annotation.ParametersAreNonnullByDefault;
-import javax.annotation.concurrent.Immutable;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.concurrent.Immutable;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.rya.indexing.pcj.storage.accumulo.VariableOrder;
@@ -31,8 +31,8 @@ import com.google.common.base.Objects;
 /**
  * Metadata that is common to all nodes that are part of a query.
  */
-@Immutable
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @Immutable
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public abstract class CommonNodeMetadata {
 
     private final String nodeId;

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/query/FilterMetadata.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/query/FilterMetadata.java
@@ -21,9 +21,9 @@ package org.apache.rya.indexing.pcj.fluo.app.query;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import javax.annotation.Nullable;
-import javax.annotation.ParametersAreNonnullByDefault;
-import javax.annotation.concurrent.Immutable;
+import edu.umd.cs.findbugs.annotations.Nullable;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.concurrent.Immutable;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.rya.indexing.pcj.storage.accumulo.VariableOrder;
@@ -33,8 +33,8 @@ import com.google.common.base.Objects;
 /**
  * Metadata that is specific to Filter nodes.
  */
-@Immutable
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @Immutable
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class FilterMetadata extends CommonNodeMetadata {
 
     private final String originalSparql;
@@ -158,7 +158,7 @@ public class FilterMetadata extends CommonNodeMetadata {
     /**
      * Builds instances of {@link FilterMetadata}.
      */
-    @ParametersAreNonnullByDefault
+// SEE RYA-211     @ParametersAreNonnullByDefault
     public static final class Builder {
 
         private final String nodeId;

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/query/FilterMetadata.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/query/FilterMetadata.java
@@ -22,8 +22,9 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
-// SEE RYA-211 import javax.annotation.concurrent.Immutable;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import net.jcip.annotations.Immutable;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.rya.indexing.pcj.storage.accumulo.VariableOrder;
@@ -33,8 +34,8 @@ import com.google.common.base.Objects;
 /**
  * Metadata that is specific to Filter nodes.
  */
-// SEE RYA-211 @Immutable
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@Immutable
+@DefaultAnnotation(NonNull.class)
 public class FilterMetadata extends CommonNodeMetadata {
 
     private final String originalSparql;
@@ -158,7 +159,7 @@ public class FilterMetadata extends CommonNodeMetadata {
     /**
      * Builds instances of {@link FilterMetadata}.
      */
-// SEE RYA-211     @ParametersAreNonnullByDefault
+    @DefaultAnnotation(NonNull.class)
     public static final class Builder {
 
         private final String nodeId;

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/query/FluoQuery.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/query/FluoQuery.java
@@ -26,8 +26,9 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
-// SEE RYA-211 import javax.annotation.concurrent.Immutable;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import net.jcip.annotations.Immutable;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 
@@ -38,8 +39,8 @@ import com.google.common.collect.ImmutableMap;
 /**
  * Metadata for every node of a query that is being updated by the Fluo application.
  */
-// SEE RYA-211 @Immutable
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@Immutable
+@DefaultAnnotation(NonNull.class)
 public class FluoQuery {
 
     private final QueryMetadata queryMetadata;
@@ -196,7 +197,7 @@ public class FluoQuery {
     /**
      * Builds instances of {@link FluoQuery}.
      */
-// SEE RYA-211     @ParametersAreNonnullByDefault
+    @DefaultAnnotation(NonNull.class)
     public static final class Builder {
 
         private QueryMetadata.Builder queryBuilder = null;

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/query/FluoQuery.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/query/FluoQuery.java
@@ -25,9 +25,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import javax.annotation.Nullable;
-import javax.annotation.ParametersAreNonnullByDefault;
-import javax.annotation.concurrent.Immutable;
+import edu.umd.cs.findbugs.annotations.Nullable;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.concurrent.Immutable;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 
@@ -38,8 +38,8 @@ import com.google.common.collect.ImmutableMap;
 /**
  * Metadata for every node of a query that is being updated by the Fluo application.
  */
-@Immutable
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @Immutable
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class FluoQuery {
 
     private final QueryMetadata queryMetadata;
@@ -196,7 +196,7 @@ public class FluoQuery {
     /**
      * Builds instances of {@link FluoQuery}.
      */
-    @ParametersAreNonnullByDefault
+// SEE RYA-211     @ParametersAreNonnullByDefault
     public static final class Builder {
 
         private QueryMetadata.Builder queryBuilder = null;

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/query/FluoQueryColumns.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/query/FluoQueryColumns.java
@@ -23,7 +23,8 @@ import static java.util.Objects.requireNonNull;
 import java.util.Arrays;
 import java.util.List;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.apache.fluo.api.data.Column;
 
@@ -163,7 +164,7 @@ public class FluoQueryColumns {
      * Enumerates the {@link Column}s that hold all of the fields for each type
      * of node that can compose a query.
      */
-// SEE RYA-211     @ParametersAreNonnullByDefault
+    @DefaultAnnotation(NonNull.class)
     public enum QueryNodeMetadataColumns {
         /**
          * The columns a {@link QueryMetadata} object's fields are stored within.

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/query/FluoQueryColumns.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/query/FluoQueryColumns.java
@@ -23,7 +23,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.apache.fluo.api.data.Column;
 
@@ -163,7 +163,7 @@ public class FluoQueryColumns {
      * Enumerates the {@link Column}s that hold all of the fields for each type
      * of node that can compose a query.
      */
-    @ParametersAreNonnullByDefault
+// SEE RYA-211     @ParametersAreNonnullByDefault
     public enum QueryNodeMetadataColumns {
         /**
          * The columns a {@link QueryMetadata} object's fields are stored within.

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/query/FluoQueryMetadataDAO.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/query/FluoQueryMetadataDAO.java
@@ -22,7 +22,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Map;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.apache.rya.indexing.pcj.fluo.app.NodeType;
 import org.apache.rya.indexing.pcj.fluo.app.query.JoinMetadata.JoinType;
@@ -39,7 +39,7 @@ import org.apache.fluo.api.data.Column;
  * Reads and writes {@link FluoQuery} instances and their components to/from
  * a Fluo table.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class FluoQueryMetadataDAO {
 
     /**

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/query/FluoQueryMetadataDAO.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/query/FluoQueryMetadataDAO.java
@@ -22,7 +22,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Map;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.apache.rya.indexing.pcj.fluo.app.NodeType;
 import org.apache.rya.indexing.pcj.fluo.app.query.JoinMetadata.JoinType;
@@ -39,7 +40,7 @@ import org.apache.fluo.api.data.Column;
  * Reads and writes {@link FluoQuery} instances and their components to/from
  * a Fluo table.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class FluoQueryMetadataDAO {
 
     /**

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/query/JoinMetadata.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/query/JoinMetadata.java
@@ -21,8 +21,9 @@ package org.apache.rya.indexing.pcj.fluo.app.query;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
-// SEE RYA-211 import javax.annotation.concurrent.Immutable;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import net.jcip.annotations.Immutable;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.rya.indexing.pcj.storage.accumulo.VariableOrder;
@@ -32,8 +33,8 @@ import com.google.common.base.Objects;
 /**
  * Metadata that is specific to Join nodes.
  */
-// SEE RYA-211 @Immutable
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@Immutable
+@DefaultAnnotation(NonNull.class)
 public class JoinMetadata extends CommonNodeMetadata {
 
     /**
@@ -161,7 +162,7 @@ public class JoinMetadata extends CommonNodeMetadata {
     /**
      * Builds instances of {@link JoinMetadata}.
      */
-// SEE RYA-211     @ParametersAreNonnullByDefault
+    @DefaultAnnotation(NonNull.class)
     public static final class Builder {
 
         private final String nodeId;

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/query/JoinMetadata.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/query/JoinMetadata.java
@@ -20,9 +20,9 @@ package org.apache.rya.indexing.pcj.fluo.app.query;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import javax.annotation.Nullable;
-import javax.annotation.ParametersAreNonnullByDefault;
-import javax.annotation.concurrent.Immutable;
+import edu.umd.cs.findbugs.annotations.Nullable;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.concurrent.Immutable;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.rya.indexing.pcj.storage.accumulo.VariableOrder;
@@ -32,8 +32,8 @@ import com.google.common.base.Objects;
 /**
  * Metadata that is specific to Join nodes.
  */
-@Immutable
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @Immutable
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class JoinMetadata extends CommonNodeMetadata {
 
     /**
@@ -161,7 +161,7 @@ public class JoinMetadata extends CommonNodeMetadata {
     /**
      * Builds instances of {@link JoinMetadata}.
      */
-    @ParametersAreNonnullByDefault
+// SEE RYA-211     @ParametersAreNonnullByDefault
     public static final class Builder {
 
         private final String nodeId;

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/query/QueryMetadata.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/query/QueryMetadata.java
@@ -21,8 +21,9 @@ package org.apache.rya.indexing.pcj.fluo.app.query;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
-// SEE RYA-211 import javax.annotation.concurrent.Immutable;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import net.jcip.annotations.Immutable;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.rya.indexing.pcj.storage.accumulo.VariableOrder;
@@ -32,8 +33,8 @@ import com.google.common.base.Objects;
 /**
  * Metadata that is specific to a Projection.
  */
-// SEE RYA-211 @Immutable
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@Immutable
+@DefaultAnnotation(NonNull.class)
 public class QueryMetadata extends CommonNodeMetadata {
 
     private final String sparql;
@@ -125,7 +126,7 @@ public class QueryMetadata extends CommonNodeMetadata {
     /**
      * Builds instances of {@link QueryMetadata}.
      */
-// SEE RYA-211     @ParametersAreNonnullByDefault
+    @DefaultAnnotation(NonNull.class)
     public static final class Builder {
 
         private final String nodeId;

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/query/QueryMetadata.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/query/QueryMetadata.java
@@ -20,9 +20,9 @@ package org.apache.rya.indexing.pcj.fluo.app.query;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import javax.annotation.Nullable;
-import javax.annotation.ParametersAreNonnullByDefault;
-import javax.annotation.concurrent.Immutable;
+import edu.umd.cs.findbugs.annotations.Nullable;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.concurrent.Immutable;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.rya.indexing.pcj.storage.accumulo.VariableOrder;
@@ -32,8 +32,8 @@ import com.google.common.base.Objects;
 /**
  * Metadata that is specific to a Projection.
  */
-@Immutable
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @Immutable
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class QueryMetadata extends CommonNodeMetadata {
 
     private final String sparql;
@@ -125,7 +125,7 @@ public class QueryMetadata extends CommonNodeMetadata {
     /**
      * Builds instances of {@link QueryMetadata}.
      */
-    @ParametersAreNonnullByDefault
+// SEE RYA-211     @ParametersAreNonnullByDefault
     public static final class Builder {
 
         private final String nodeId;

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/query/SparqlFluoQueryBuilder.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/query/SparqlFluoQueryBuilder.java
@@ -32,8 +32,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
-import javax.annotation.ParametersAreNonnullByDefault;
-import javax.annotation.concurrent.Immutable;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.concurrent.Immutable;
 
 import org.apache.rya.indexing.pcj.fluo.app.FilterResultUpdater;
 import org.apache.rya.indexing.pcj.fluo.app.FluoStringConverter;
@@ -89,7 +89,7 @@ public class SparqlFluoQueryBuilder {
      * of a {@link ParsedQuery}. This structure should only be used while creating
      * a new PCJ in Fluo and disposed of afterwards.
      */
-    @ParametersAreNonnullByDefault
+// SEE RYA-211     @ParametersAreNonnullByDefault
     public static final class NodeIds {
 
         /**
@@ -415,8 +415,8 @@ public class SparqlFluoQueryBuilder {
         /**
          * Holds the Variable Order of the binding sets for the children of a join node.
          */
-        @Immutable
-        @ParametersAreNonnullByDefault
+// SEE RYA-211         @Immutable
+// SEE RYA-211         @ParametersAreNonnullByDefault
         private static final class JoinVarOrders {
             private final VariableOrder leftVarOrder;
             private final VariableOrder rightVarOrder;

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/query/SparqlFluoQueryBuilder.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/query/SparqlFluoQueryBuilder.java
@@ -32,8 +32,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
-// SEE RYA-211 import javax.annotation.concurrent.Immutable;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import net.jcip.annotations.Immutable;
 
 import org.apache.rya.indexing.pcj.fluo.app.FilterResultUpdater;
 import org.apache.rya.indexing.pcj.fluo.app.FluoStringConverter;
@@ -89,7 +90,7 @@ public class SparqlFluoQueryBuilder {
      * of a {@link ParsedQuery}. This structure should only be used while creating
      * a new PCJ in Fluo and disposed of afterwards.
      */
-// SEE RYA-211     @ParametersAreNonnullByDefault
+    @DefaultAnnotation(NonNull.class)
     public static final class NodeIds {
 
         /**
@@ -415,8 +416,8 @@ public class SparqlFluoQueryBuilder {
         /**
          * Holds the Variable Order of the binding sets for the children of a join node.
          */
-// SEE RYA-211         @Immutable
-// SEE RYA-211         @ParametersAreNonnullByDefault
+        @Immutable
+        @DefaultAnnotation(NonNull.class)
         private static final class JoinVarOrders {
             private final VariableOrder leftVarOrder;
             private final VariableOrder rightVarOrder;

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/query/StatementPatternMetadata.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/query/StatementPatternMetadata.java
@@ -20,9 +20,9 @@ package org.apache.rya.indexing.pcj.fluo.app.query;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import javax.annotation.Nullable;
-import javax.annotation.ParametersAreNonnullByDefault;
-import javax.annotation.concurrent.Immutable;
+import edu.umd.cs.findbugs.annotations.Nullable;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.concurrent.Immutable;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.rya.indexing.pcj.storage.accumulo.VariableOrder;
@@ -32,8 +32,8 @@ import com.google.common.base.Objects;
 /**
  * Metadata that is specific to Statement Pattern nodes.
  */
-@Immutable
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @Immutable
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class StatementPatternMetadata extends CommonNodeMetadata {
 
     private final String statementPattern;
@@ -125,7 +125,7 @@ public class StatementPatternMetadata extends CommonNodeMetadata {
     /**
      * Builds instances of {@link StatementPatternMetadata}.
      */
-    @ParametersAreNonnullByDefault
+// SEE RYA-211     @ParametersAreNonnullByDefault
     public static final class Builder {
 
         private final String nodeId;

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/query/StatementPatternMetadata.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/query/StatementPatternMetadata.java
@@ -21,8 +21,9 @@ package org.apache.rya.indexing.pcj.fluo.app.query;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
-// SEE RYA-211 import javax.annotation.concurrent.Immutable;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import net.jcip.annotations.Immutable;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.rya.indexing.pcj.storage.accumulo.VariableOrder;
@@ -32,8 +33,8 @@ import com.google.common.base.Objects;
 /**
  * Metadata that is specific to Statement Pattern nodes.
  */
-// SEE RYA-211 @Immutable
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@Immutable
+@DefaultAnnotation(NonNull.class)
 public class StatementPatternMetadata extends CommonNodeMetadata {
 
     private final String statementPattern;
@@ -125,7 +126,7 @@ public class StatementPatternMetadata extends CommonNodeMetadata {
     /**
      * Builds instances of {@link StatementPatternMetadata}.
      */
-// SEE RYA-211     @ParametersAreNonnullByDefault
+    @DefaultAnnotation(NonNull.class)
     public static final class Builder {
 
         private final String nodeId;

--- a/extras/rya.pcj.fluo/pcj.fluo.client/src/main/java/org/apache/rya/indexing/pcj/fluo/client/PcjAdminClient.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.client/src/main/java/org/apache/rya/indexing/pcj/fluo/client/PcjAdminClient.java
@@ -32,7 +32,8 @@ import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
@@ -65,7 +66,7 @@ import org.apache.rya.rdftriplestore.RyaSailRepository;
 /**
  * An application that helps Rya PCJ administrators interact with the cluster.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class PcjAdminClient {
 
     private static final Logger log = LogManager.getLogger(PcjAdminClient.class);

--- a/extras/rya.pcj.fluo/pcj.fluo.client/src/main/java/org/apache/rya/indexing/pcj/fluo/client/PcjAdminClient.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.client/src/main/java/org/apache/rya/indexing/pcj/fluo/client/PcjAdminClient.java
@@ -32,7 +32,7 @@ import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
@@ -65,7 +65,7 @@ import org.apache.rya.rdftriplestore.RyaSailRepository;
 /**
  * An application that helps Rya PCJ administrators interact with the cluster.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class PcjAdminClient {
 
     private static final Logger log = LogManager.getLogger(PcjAdminClient.class);

--- a/extras/rya.pcj.fluo/pcj.fluo.client/src/main/java/org/apache/rya/indexing/pcj/fluo/client/PcjAdminClientCommand.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.client/src/main/java/org/apache/rya/indexing/pcj/fluo/client/PcjAdminClientCommand.java
@@ -18,7 +18,7 @@
  */
 package org.apache.rya.indexing.pcj.fluo.client;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.apache.accumulo.core.client.Connector;
 
@@ -28,7 +28,7 @@ import org.apache.rya.rdftriplestore.RyaSailRepository;
 /**
  * A command that may be executed by the {@link PcjAdminClient}.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public interface PcjAdminClientCommand {
 
     /**

--- a/extras/rya.pcj.fluo/pcj.fluo.client/src/main/java/org/apache/rya/indexing/pcj/fluo/client/PcjAdminClientCommand.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.client/src/main/java/org/apache/rya/indexing/pcj/fluo/client/PcjAdminClientCommand.java
@@ -18,7 +18,8 @@
  */
 package org.apache.rya.indexing.pcj.fluo.client;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.apache.accumulo.core.client.Connector;
 
@@ -28,7 +29,7 @@ import org.apache.rya.rdftriplestore.RyaSailRepository;
 /**
  * A command that may be executed by the {@link PcjAdminClient}.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public interface PcjAdminClientCommand {
 
     /**

--- a/extras/rya.pcj.fluo/pcj.fluo.client/src/main/java/org/apache/rya/indexing/pcj/fluo/client/PcjAdminClientProperties.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.client/src/main/java/org/apache/rya/indexing/pcj/fluo/client/PcjAdminClientProperties.java
@@ -23,13 +23,14 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.Properties;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * Interprets a {@link Properties} object so that it is easier to access
  * configuration values used by {@link PcjAdminClient}.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class PcjAdminClientProperties {
 
     // Properties that configure how Fluo will connect to Accumulo.

--- a/extras/rya.pcj.fluo/pcj.fluo.client/src/main/java/org/apache/rya/indexing/pcj/fluo/client/PcjAdminClientProperties.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.client/src/main/java/org/apache/rya/indexing/pcj/fluo/client/PcjAdminClientProperties.java
@@ -22,14 +22,14 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Properties;
 
-import javax.annotation.Nullable;
-import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.Nullable;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 /**
  * Interprets a {@link Properties} object so that it is easier to access
  * configuration values used by {@link PcjAdminClient}.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class PcjAdminClientProperties {
 
     // Properties that configure how Fluo will connect to Accumulo.

--- a/extras/rya.pcj.fluo/pcj.fluo.client/src/main/java/org/apache/rya/indexing/pcj/fluo/client/command/ListQueriesCommand.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.client/src/main/java/org/apache/rya/indexing/pcj/fluo/client/command/ListQueriesCommand.java
@@ -23,7 +23,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.apache.accumulo.core.client.Connector;
 import org.apache.logging.log4j.LogManager;
@@ -47,7 +47,7 @@ import org.apache.rya.rdftriplestore.RyaSailRepository;
 /**
  * A command that lists information about the queries that are being managed by the Fluo app.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class ListQueriesCommand implements PcjAdminClientCommand {
     private static final Logger log = LogManager.getLogger(ListQueriesCommand.class);
 

--- a/extras/rya.pcj.fluo/pcj.fluo.client/src/main/java/org/apache/rya/indexing/pcj/fluo/client/command/ListQueriesCommand.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.client/src/main/java/org/apache/rya/indexing/pcj/fluo/client/command/ListQueriesCommand.java
@@ -23,7 +23,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.HashMap;
 import java.util.Map;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.apache.accumulo.core.client.Connector;
 import org.apache.logging.log4j.LogManager;
@@ -47,7 +48,7 @@ import org.apache.rya.rdftriplestore.RyaSailRepository;
 /**
  * A command that lists information about the queries that are being managed by the Fluo app.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class ListQueriesCommand implements PcjAdminClientCommand {
     private static final Logger log = LogManager.getLogger(ListQueriesCommand.class);
 

--- a/extras/rya.pcj.fluo/pcj.fluo.client/src/main/java/org/apache/rya/indexing/pcj/fluo/client/command/LoadTriplesCommand.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.client/src/main/java/org/apache/rya/indexing/pcj/fluo/client/command/LoadTriplesCommand.java
@@ -25,7 +25,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.apache.accumulo.core.client.Connector;
 import org.apache.commons.io.FilenameUtils;
@@ -51,7 +51,7 @@ import org.apache.rya.rdftriplestore.RyaSailRepository;
 /**
  * A command that loads the contents of an NTriple file into the Fluo application.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class LoadTriplesCommand implements PcjAdminClientCommand {
     private static final Logger log = LogManager.getLogger(LoadTriplesCommand.class);
 

--- a/extras/rya.pcj.fluo/pcj.fluo.client/src/main/java/org/apache/rya/indexing/pcj/fluo/client/command/LoadTriplesCommand.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.client/src/main/java/org/apache/rya/indexing/pcj/fluo/client/command/LoadTriplesCommand.java
@@ -25,7 +25,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.apache.accumulo.core.client.Connector;
 import org.apache.commons.io.FilenameUtils;
@@ -51,7 +52,7 @@ import org.apache.rya.rdftriplestore.RyaSailRepository;
 /**
  * A command that loads the contents of an NTriple file into the Fluo application.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class LoadTriplesCommand implements PcjAdminClientCommand {
     private static final Logger log = LogManager.getLogger(LoadTriplesCommand.class);
 

--- a/extras/rya.pcj.fluo/pcj.fluo.client/src/main/java/org/apache/rya/indexing/pcj/fluo/client/command/NewQueryCommand.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.client/src/main/java/org/apache/rya/indexing/pcj/fluo/client/command/NewQueryCommand.java
@@ -25,7 +25,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.apache.accumulo.core.client.Connector;
 import org.apache.commons.io.IOUtils;
@@ -52,7 +52,7 @@ import org.apache.rya.rdftriplestore.RyaSailRepository;
  * A command that creates a creates a new PCJ in the Fluo app and loads historic
  * statement pattern matches for it.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class NewQueryCommand implements PcjAdminClientCommand {
     private static final Logger log = LogManager.getLogger(NewQueryCommand.class);
 

--- a/extras/rya.pcj.fluo/pcj.fluo.client/src/main/java/org/apache/rya/indexing/pcj/fluo/client/command/NewQueryCommand.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.client/src/main/java/org/apache/rya/indexing/pcj/fluo/client/command/NewQueryCommand.java
@@ -25,7 +25,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.apache.accumulo.core.client.Connector;
 import org.apache.commons.io.IOUtils;
@@ -52,7 +53,7 @@ import org.apache.rya.rdftriplestore.RyaSailRepository;
  * A command that creates a creates a new PCJ in the Fluo app and loads historic
  * statement pattern matches for it.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class NewQueryCommand implements PcjAdminClientCommand {
     private static final Logger log = LogManager.getLogger(NewQueryCommand.class);
 

--- a/extras/rya.pcj.fluo/pcj.fluo.client/src/main/java/org/apache/rya/indexing/pcj/fluo/client/util/ParsedQueryRequest.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.client/src/main/java/org/apache/rya/indexing/pcj/fluo/client/util/ParsedQueryRequest.java
@@ -27,8 +27,9 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
-// SEE RYA-211 import javax.annotation.concurrent.Immutable;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import net.jcip.annotations.Immutable;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.rya.indexing.pcj.storage.accumulo.VariableOrder;
@@ -36,8 +37,8 @@ import org.apache.rya.indexing.pcj.storage.accumulo.VariableOrder;
 /**
  * Represents a request to create a new PCJ in the Fluo app.
  */
-// SEE RYA-211 @Immutable
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@Immutable
+@DefaultAnnotation(NonNull.class)
 public class ParsedQueryRequest {
 
     private final String sparql;

--- a/extras/rya.pcj.fluo/pcj.fluo.client/src/main/java/org/apache/rya/indexing/pcj/fluo/client/util/ParsedQueryRequest.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.client/src/main/java/org/apache/rya/indexing/pcj/fluo/client/util/ParsedQueryRequest.java
@@ -27,8 +27,8 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.annotation.ParametersAreNonnullByDefault;
-import javax.annotation.concurrent.Immutable;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.concurrent.Immutable;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.rya.indexing.pcj.storage.accumulo.VariableOrder;
@@ -36,8 +36,8 @@ import org.apache.rya.indexing.pcj.storage.accumulo.VariableOrder;
 /**
  * Represents a request to create a new PCJ in the Fluo app.
  */
-@Immutable
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @Immutable
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class ParsedQueryRequest {
 
     private final String sparql;

--- a/extras/rya.pcj.fluo/pcj.fluo.client/src/main/java/org/apache/rya/indexing/pcj/fluo/client/util/QueryReportRenderer.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.client/src/main/java/org/apache/rya/indexing/pcj/fluo/client/util/QueryReportRenderer.java
@@ -20,7 +20,7 @@ package org.apache.rya.indexing.pcj.fluo.client.util;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.rya.indexing.pcj.fluo.api.GetQueryReport.QueryReport;
@@ -37,7 +37,7 @@ import org.openrdf.queryrender.sparql.SPARQLQueryRenderer;
 /**
  * Pretty renders a {@link QueryReport}.
  */
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class QueryReportRenderer {
 
     /**

--- a/extras/rya.pcj.fluo/pcj.fluo.client/src/main/java/org/apache/rya/indexing/pcj/fluo/client/util/QueryReportRenderer.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.client/src/main/java/org/apache/rya/indexing/pcj/fluo/client/util/QueryReportRenderer.java
@@ -20,7 +20,8 @@ package org.apache.rya.indexing.pcj.fluo.client.util;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.rya.indexing.pcj.fluo.api.GetQueryReport.QueryReport;
@@ -37,7 +38,7 @@ import org.openrdf.queryrender.sparql.SPARQLQueryRenderer;
 /**
  * Pretty renders a {@link QueryReport}.
  */
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
 public class QueryReportRenderer {
 
     /**

--- a/extras/rya.pcj.fluo/pcj.fluo.client/src/main/java/org/apache/rya/indexing/pcj/fluo/client/util/Report.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.client/src/main/java/org/apache/rya/indexing/pcj/fluo/client/util/Report.java
@@ -21,8 +21,8 @@ package org.apache.rya.indexing.pcj.fluo.client.util;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import javax.annotation.ParametersAreNonnullByDefault;
-import javax.annotation.concurrent.Immutable;
+// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
+// SEE RYA-211 import javax.annotation.concurrent.Immutable;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -33,8 +33,8 @@ import com.google.common.collect.ImmutableList;
  * left hand side of the table and the value of the item on the right hand side.
  * If an item does not have any values, then it prints an empty line.
  */
-@Immutable
-@ParametersAreNonnullByDefault
+// SEE RYA-211 @Immutable
+// SEE RYA-211 @ParametersAreNonnullByDefault
 public class Report {
 
     private final ImmutableList<ReportItem> items;
@@ -111,8 +111,8 @@ public class Report {
      * An item that may appear within a {@link Report}. Each item has a title
      * that briefly describes the value it holds.
      */
-    @Immutable
-    @ParametersAreNonnullByDefault
+// SEE RYA-211     @Immutable
+// SEE RYA-211     @ParametersAreNonnullByDefault
     public static final class ReportItem {
         private final String title;
         private final String[] valueLines;
@@ -172,7 +172,7 @@ public class Report {
     /**
      * Builds instances of {@link Report}.
      */
-    @ParametersAreNonnullByDefault
+// SEE RYA-211     @ParametersAreNonnullByDefault
     public static final class Builder {
 
         private final ImmutableList.Builder<ReportItem> lines = ImmutableList.builder();

--- a/extras/rya.pcj.fluo/pcj.fluo.client/src/main/java/org/apache/rya/indexing/pcj/fluo/client/util/Report.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.client/src/main/java/org/apache/rya/indexing/pcj/fluo/client/util/Report.java
@@ -21,8 +21,9 @@ package org.apache.rya.indexing.pcj.fluo.client.util;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
-// SEE RYA-211 import javax.annotation.ParametersAreNonnullByDefault;
-// SEE RYA-211 import javax.annotation.concurrent.Immutable;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import net.jcip.annotations.Immutable;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -33,8 +34,8 @@ import com.google.common.collect.ImmutableList;
  * left hand side of the table and the value of the item on the right hand side.
  * If an item does not have any values, then it prints an empty line.
  */
-// SEE RYA-211 @Immutable
-// SEE RYA-211 @ParametersAreNonnullByDefault
+@Immutable
+@DefaultAnnotation(NonNull.class)
 public class Report {
 
     private final ImmutableList<ReportItem> items;
@@ -111,8 +112,8 @@ public class Report {
      * An item that may appear within a {@link Report}. Each item has a title
      * that briefly describes the value it holds.
      */
-// SEE RYA-211     @Immutable
-// SEE RYA-211     @ParametersAreNonnullByDefault
+    @Immutable
+    @DefaultAnnotation(NonNull.class)
     public static final class ReportItem {
         private final String title;
         private final String[] valueLines;
@@ -172,7 +173,7 @@ public class Report {
     /**
      * Builds instances of {@link Report}.
      */
-// SEE RYA-211     @ParametersAreNonnullByDefault
+    @DefaultAnnotation(NonNull.class)
     public static final class Builder {
 
         private final ImmutableList.Builder<ReportItem> lines = ImmutableList.builder();

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@ under the License.
         <fluo.version>1.0.0-incubating</fluo.version>
         
         <jmh.version>1.13</jmh.version>
-        <jsr305.version>3.0.1</jsr305.version>
+        <jsr305.version>1.3.9-1</jsr305.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -331,6 +331,13 @@ under the License.
                 <groupId>org.apache.hadoop</groupId>
                 <artifactId>hadoop-common</artifactId>
                 <version>${hadoop.version}</version>
+                <exclusions>
+                    <!-- released under the LGPL license -->
+                    <exclusion>
+                        <groupId>com.google.code.findbugs</groupId>
+                        <artifactId>jsr305</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
@@ -502,6 +509,13 @@ under the License.
                 <groupId>org.apache.fluo</groupId>
                 <artifactId>fluo-core</artifactId>
                 <version>${fluo.version}</version>
+                <exclusions>
+                    <!-- released under the LGPL license -->
+                    <exclusion>
+                        <groupId>com.google.code.findbugs</groupId>
+                        <artifactId>jsr305</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.fluo</groupId>
@@ -556,8 +570,8 @@ under the License.
             </dependency>
             
             <dependency>
-                <groupId>com.google.code.findbugs</groupId>
-                <artifactId>jsr305</artifactId>
+                <groupId>com.github.stephenc.findbugs</groupId>
+                <artifactId>findbugs-annotations</artifactId>
                 <version>${jsr305.version}</version>
             </dependency>
             
@@ -566,6 +580,13 @@ under the License.
                 <artifactId>accumulo-minicluster</artifactId>
                 <version>${accumulo.version}</version>
                 <scope>test</scope>
+                <exclusions>
+                    <!-- released under the LGPL license -->
+                    <exclusion>
+                        <groupId>com.google.code.findbugs</groupId>
+                        <artifactId>jsr305</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,10 @@ under the License.
         <fluo.version>1.0.0-incubating</fluo.version>
         
         <jmh.version>1.13</jmh.version>
+
         <jsr305.version>1.3.9-1</jsr305.version>
+        <jcip.version>1.0-1</jcip.version>
+        <findbugs.plugin.version>3.0.4</findbugs.plugin.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -574,6 +577,11 @@ under the License.
                 <artifactId>findbugs-annotations</artifactId>
                 <version>${jsr305.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.github.stephenc.jcip</groupId>
+                <artifactId>jcip-annotations</artifactId>
+                <version>${jcip.version}</version>
+            </dependency>
             
             <dependency>
                 <groupId>org.apache.accumulo</groupId>
@@ -829,6 +837,16 @@ under the License.
             </plugin>
         </plugins>
     </build>
+
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>findbugs-maven-plugin</artifactId>
+                <version>${findbugs.plugin.version}</version>
+            </plugin>
+        </plugins>
+    </reporting>
 
     <repositories>
         <repository>


### PR DESCRIPTION
## Description

Removed findbugs:jsr305 Dependency.  Replaced with findbugs-annotations.

Several annotations are not available in findbugs-annotations.  These annotations where commented out and a new JIRA ticket (RYA-211) was created to deal with them:

- @ThreadSafe
- @Immutable
- @ParametersAreNonnullByDefault

### Tests

Current tests pass.  No New tests.

### Links
[Jira](https://issues.apache.org/jira/browse/RYA-200)

### Checklist
- [ ] Code Review
- [ ] Squash Commits

#### People To Reivew
@isper3at 