### PR TITLE
RYA-119 Added MongoDB Column Visibility (called Document Visibility).

### DIFF
--- a/common/rya.api/src/main/java/org/apache/rya/api/persist/RyaDAO.java
+++ b/common/rya.api/src/main/java/org/apache/rya/api/persist/RyaDAO.java
@@ -8,9 +8,9 @@ package org.apache.rya.api.persist;
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -46,7 +46,7 @@ public interface RyaDAO<C extends RdfCloudTripleStoreConfiguration> extends RyaC
 
     /**
      *
-     * @return true if the store is already initiailized
+     * @return true if the store is already initialized
      * @throws RyaDAOException
      */
     public boolean isInitialized() throws RyaDAOException;
@@ -69,10 +69,10 @@ public interface RyaDAO<C extends RdfCloudTripleStoreConfiguration> extends RyaC
     /**
      * Add and commit a collection of RyaStatements
      *
-     * @param statement
+     * @param statementIter
      * @throws RyaDAOException
      */
-    public void add(Iterator<RyaStatement> statement) throws RyaDAOException;
+    public void add(Iterator<RyaStatement> statementIter) throws RyaDAOException;
 
     /**
      * Delete a RyaStatement. The Configuration should provide the auths to perform the delete
@@ -89,7 +89,7 @@ public interface RyaDAO<C extends RdfCloudTripleStoreConfiguration> extends RyaC
      * @param conf
      * @throws RyaDAOException
      */
-    public void dropGraph(C conf, RyaURI... graphs) throws RyaDAOException; 
+    public void dropGraph(C conf, RyaURI... graphs) throws RyaDAOException;
 
     /**
      * Delete a collection of RyaStatements.

--- a/dao/mongodb.rya/pom.xml
+++ b/dao/mongodb.rya/pom.xml
@@ -81,6 +81,11 @@ Tests will fail with the following error when using 32bit JVM on either Linux or
         </dependency>
 
         <dependency>
+            <groupId>org.apache.accumulo</groupId>
+            <artifactId>accumulo-core</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongo-java-driver</artifactId>
         </dependency>

--- a/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/MongoDBRdfConfiguration.java
+++ b/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/MongoDBRdfConfiguration.java
@@ -8,9 +8,9 @@ package org.apache.rya.mongodb;
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -19,14 +19,11 @@ package org.apache.rya.mongodb;
  * under the License.
  */
 
-
-
 import java.util.List;
 
-import org.apache.rya.api.RdfCloudTripleStoreConfiguration;
-import org.apache.rya.api.persist.index.RyaSecondaryIndexer;
-
+import org.apache.accumulo.core.security.Authorizations;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.rya.api.RdfCloudTripleStoreConfiguration;
 
 import com.google.common.collect.Lists;
 import com.mongodb.MongoClient;
@@ -38,21 +35,29 @@ public class MongoDBRdfConfiguration extends RdfCloudTripleStoreConfiguration {
     public static final String MONGO_DB_NAME = "mongo.db.name";
     public static final String MONGO_COLLECTION_PREFIX = "mongo.db.collectionprefix";
     public static final String MONGO_USER = "mongo.db.user";
-    public static final String  MONGO_USER_PASSWORD = "mongo.db.userpassword";
+    public static final String MONGO_USER_PASSWORD = "mongo.db.userpassword";
     public static final String CONF_ADDITIONAL_INDEXERS = "ac.additional.indexers";
-	private MongoClient mongoClient;
+    private MongoClient mongoClient;
 
     public MongoDBRdfConfiguration() {
         super();
     }
 
-    public MongoDBRdfConfiguration(Configuration other) {
+    public MongoDBRdfConfiguration(final Configuration other) {
         super(other);
     }
 
     @Override
     public MongoDBRdfConfiguration clone() {
         return new MongoDBRdfConfiguration(this);
+    }
+
+    public Authorizations getAuthorizations() {
+        final String[] auths = getAuths();
+        if (auths == null || auths.length == 0) {
+            return MongoDbRdfConstants.ALL_AUTHORIZATIONS;
+        }
+        return new Authorizations(auths);
     }
 
     public String getTriplesCollectionName() {
@@ -63,7 +68,7 @@ public class MongoDBRdfConfiguration extends RdfCloudTripleStoreConfiguration {
         return this.get(MONGO_COLLECTION_PREFIX, "rya");
     }
 
-    public void setCollectionName(String name) {
+    public void setCollectionName(final String name) {
         this.set(MONGO_COLLECTION_PREFIX, name);
     }
 
@@ -71,7 +76,7 @@ public class MongoDBRdfConfiguration extends RdfCloudTripleStoreConfiguration {
         return this.get(MONGO_INSTANCE, "localhost");
     }
 
-    public void setMongoInstance(String name) {
+    public void setMongoInstance(final String name) {
         this.set(MONGO_INSTANCE, name);
     }
 
@@ -79,7 +84,7 @@ public class MongoDBRdfConfiguration extends RdfCloudTripleStoreConfiguration {
         return this.get(MONGO_INSTANCE_PORT, "27017");
     }
 
-    public void setMongoPort(String name) {
+    public void setMongoPort(final String name) {
         this.set(MONGO_INSTANCE_PORT, name);
     }
 
@@ -87,33 +92,33 @@ public class MongoDBRdfConfiguration extends RdfCloudTripleStoreConfiguration {
         return this.get(MONGO_DB_NAME, "rya");
     }
 
-    public void setMongoDBName(String name) {
+    public void setMongoDBName(final String name) {
         this.set(MONGO_DB_NAME, name);
     }
 
     public String getNameSpacesCollectionName() {
         return this.get(MONGO_COLLECTION_PREFIX, "rya") + "_ns";
     }
-    
-    public void setAdditionalIndexers(Class<? extends MongoSecondaryIndex>... indexers) {
-        List<String> strs = Lists.newArrayList();
-        for (Class<?> ai : indexers){
+
+    public void setAdditionalIndexers(final Class<? extends MongoSecondaryIndex>... indexers) {
+        final List<String> strs = Lists.newArrayList();
+        for (final Class<?> ai : indexers){
             strs.add(ai.getName());
         }
-        
+
         setStrings(CONF_ADDITIONAL_INDEXERS, strs.toArray(new String[]{}));
     }
 
     public List<MongoSecondaryIndex> getAdditionalIndexers() {
         return getInstances(CONF_ADDITIONAL_INDEXERS, MongoSecondaryIndex.class);
-    }    
-    
-    public void setMongoClient(MongoClient client){
-    	this.mongoClient = client;
     }
-    
+
+    public void setMongoClient(final MongoClient client){
+        this.mongoClient = client;
+    }
+
     public MongoClient getMongoClient() {
-    	return mongoClient;
+        return mongoClient;
     }
 
 }

--- a/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/MongoDbRdfConstants.java
+++ b/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/MongoDbRdfConstants.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.mongodb;
+
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.rya.mongodb.document.visibility.DocumentVisibility;
+
+/**
+ * Interface MongoDbRdfConstants. Holds constants for MongoDB related
+ * operations.
+ */
+public interface MongoDbRdfConstants {
+    /**
+     * Constant Authorization that allows user to view all documents.
+     */
+    public static final Authorizations ALL_AUTHORIZATIONS = Authorizations.EMPTY;
+
+    /**
+     * Constant representing a non-{@code null} {@link DocumentVisibility} which
+     * should be used if the document does not specify a document visibility.
+     */
+    public static final DocumentVisibility EMPTY_DV = new DocumentVisibility(new byte[0]);
+}

--- a/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/dao/SimpleMongoDBStorageStrategy.java
+++ b/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/dao/SimpleMongoDBStorageStrategy.java
@@ -32,6 +32,9 @@ import org.apache.rya.api.domain.RyaType;
 import org.apache.rya.api.domain.RyaURI;
 import org.apache.rya.api.domain.StatementMetadata;
 import org.apache.rya.api.persist.query.RyaQuery;
+import org.apache.rya.mongodb.document.visibility.DocumentVisibility;
+import org.apache.rya.mongodb.document.visibility.DocumentVisibilityAdapter;
+import org.apache.rya.mongodb.document.visibility.DocumentVisibilityAdapter.MalformedDocumentVisibilityException;
 import org.openrdf.model.impl.ValueFactoryImpl;
 import org.openrdf.model.vocabulary.XMLSchema;
 
@@ -44,15 +47,18 @@ import com.mongodb.DBObject;
  */
 public class SimpleMongoDBStorageStrategy implements MongoDBStorageStrategy<RyaStatement> {
     private static final Logger LOG = Logger.getLogger(SimpleMongoDBStorageStrategy.class);
-    protected static final String ID = "_id";
-    protected static final String OBJECT_TYPE = "objectType";
-    protected static final String URI_TYPE_VALUE = XMLSchema.ANYURI.stringValue();
-    protected static final String CONTEXT = "context";
-    protected static final String PREDICATE = "predicate";
-    protected static final String OBJECT = "object";
-    protected static final String SUBJECT = "subject";
+
+    public static final String ID = "_id";
+    public static final String OBJECT_TYPE = "objectType";
+    public static final String OBJECT_TYPE_VALUE = XMLSchema.ANYURI.stringValue();
+    public static final String CONTEXT = "context";
+    public static final String PREDICATE = "predicate";
+    public static final String OBJECT = "object";
+    public static final String SUBJECT = "subject";
     public static final String TIMESTAMP = "insertTimestamp";
-    protected static final String STATEMENT_METADATA = "statementMetadata";
+    public static final String STATEMENT_METADATA = "statementMetadata";
+    public static final String DOCUMENT_VISIBILITY = "documentVisibility";
+
     protected ValueFactoryImpl factory = new ValueFactoryImpl();
 
     @Override
@@ -96,12 +102,18 @@ public class SimpleMongoDBStorageStrategy implements MongoDBStorageStrategy<RyaS
 
     @Override
     public RyaStatement deserializeDBObject(final DBObject queryResult) {
-        final Map result = queryResult.toMap();
+        final Map<?, ?> result = queryResult.toMap();
         final String subject = (String) result.get(SUBJECT);
         final String object = (String) result.get(OBJECT);
         final String objectType = (String) result.get(OBJECT_TYPE);
         final String predicate = (String) result.get(PREDICATE);
         final String context = (String) result.get(CONTEXT);
+        DocumentVisibility documentVisibility = null;
+        try {
+            documentVisibility = DocumentVisibilityAdapter.toDocumentVisibility(queryResult);
+        } catch (final MalformedDocumentVisibilityException e) {
+            LOG.error("Unable to convert document visibility");
+        }
         final Long timestamp = (Long) result.get(TIMESTAMP);
         final String statementMetadata = (String) result.get(STATEMENT_METADATA);
         RyaType objectRya = null;
@@ -120,17 +132,18 @@ public class SimpleMongoDBStorageStrategy implements MongoDBStorageStrategy<RyaS
             statement = new RyaStatement(new RyaURI(subject), new RyaURI(predicate), objectRya);
         }
 
+        statement.setColumnVisibility(documentVisibility.flatten());
         if(timestamp != null) {
             statement.setTimestamp(timestamp);
         }
         if(statementMetadata != null) {
             try {
-                StatementMetadata metadata = new StatementMetadata(statementMetadata);
+                final StatementMetadata metadata = new StatementMetadata(statementMetadata);
                 statement.setStatementMetadata(metadata);
             }
-            catch (Exception ex){
+            catch (final Exception ex){
                 LOG.debug("Error deserializing metadata for statement", ex);
-            }         
+            }
         }
         return statement;
     }
@@ -157,16 +170,17 @@ public class SimpleMongoDBStorageStrategy implements MongoDBStorageStrategy<RyaS
         if (statement.getMetadata() == null){
             statement.setStatementMetadata(StatementMetadata.EMPTY_METADATA);
         }
-        BasicDBObject doc = new BasicDBObject(ID, new String(Hex.encodeHex(bytes)))
+        final BasicDBObject dvObject = DocumentVisibilityAdapter.toDBObject(statement.getColumnVisibility());
+        final BasicDBObject doc = new BasicDBObject(ID, new String(Hex.encodeHex(bytes)))
         .append(SUBJECT, statement.getSubject().getData())
         .append(PREDICATE, statement.getPredicate().getData())
         .append(OBJECT, statement.getObject().getData())
         .append(OBJECT_TYPE, statement.getObject().getDataType().toString())
         .append(CONTEXT, context)
         .append(STATEMENT_METADATA, statement.getMetadata().toString())
+        .append(DOCUMENT_VISIBILITY, dvObject.get(DOCUMENT_VISIBILITY))
         .append(TIMESTAMP, statement.getTimestamp());
         return doc;
-
     }
 
     @Override

--- a/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/document/operators/aggregation/AggregationUtil.java
+++ b/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/document/operators/aggregation/AggregationUtil.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.mongodb.document.operators.aggregation;
+
+import static org.apache.rya.mongodb.document.operators.aggregation.PipelineOperators.redact;
+import static org.apache.rya.mongodb.document.operators.aggregation.SetOperators.anyElementTrue;
+import static org.apache.rya.mongodb.document.operators.aggregation.SetOperators.setIsSubsetNullSafe;
+import static org.apache.rya.mongodb.document.operators.aggregation.VariableOperators.map;
+import static org.apache.rya.mongodb.document.operators.query.ArrayOperators.size;
+import static org.apache.rya.mongodb.document.operators.query.ComparisonOperators.eq;
+import static org.apache.rya.mongodb.document.operators.query.LogicalOperators.or;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.rya.mongodb.MongoDbRdfConstants;
+import org.apache.rya.mongodb.dao.SimpleMongoDBStorageStrategy;
+import org.apache.rya.mongodb.document.operators.aggregation.PipelineOperators.RedactAggregationResult;
+import org.apache.rya.mongodb.document.util.AuthorizationsUtil;
+
+import com.google.common.collect.Lists;
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBObject;
+
+/**
+ * Utility methods for MongoDB aggregation.
+ */
+public final class AggregationUtil {
+    /**
+     * Private constructor to prevent instantiation.
+     */
+    private AggregationUtil() {
+    }
+
+    /**
+     * Creates a MongoDB $redact aggregation pipeline that only include
+     * documents whose document visibility match the provided authorizations.
+     * All other documents are excluded.
+     * @param authorizations the {@link Authorization}s to include in the
+     * $redact. Only documents that match the authorizations will be returned.
+     * @return the {@link List} of {@link DBObject}s that represents the $redact
+     * aggregation pipeline.
+     */
+    public static List<DBObject> createRedactPipeline(final Authorizations authorizations) {
+        if (MongoDbRdfConstants.ALL_AUTHORIZATIONS.equals(authorizations)) {
+            return Lists.newArrayList();
+        }
+
+        final List<String> authList = AuthorizationsUtil.getAuthorizationsStrings(authorizations);
+
+        final String documentVisibilityField = "$" + SimpleMongoDBStorageStrategy.DOCUMENT_VISIBILITY;
+
+        final String mapVariableCursorName = "dvItemCursorTag";
+
+        final BasicDBObject anyElementTrue =
+            anyElementTrue(
+                map(
+                    documentVisibilityField,
+                    mapVariableCursorName,
+                    setIsSubsetNullSafe(
+                        "$$" + mapVariableCursorName,
+                        authList.toArray()
+                    )
+                )
+            );
+
+        // If the field is empty then there are no authorizations required,
+        // so all users should be able to view it when they query.
+        final BasicDBObject isFieldSizeZero =
+            eq(
+                size(documentVisibilityField),
+                0
+            );
+
+        final BasicDBObject orExpression = or(anyElementTrue, isFieldSizeZero);
+
+        final List<DBObject> pipeline = new ArrayList<>();
+        pipeline.add(
+            redact(
+                orExpression,
+                RedactAggregationResult.DESCEND,
+                RedactAggregationResult.PRUNE
+            )
+        );
+
+        return pipeline;
+    }
+}

--- a/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/document/operators/aggregation/PipelineOperators.java
+++ b/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/document/operators/aggregation/PipelineOperators.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.mongodb.document.operators.aggregation;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.rya.mongodb.document.operators.query.ConditionalOperators.cond;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.BasicDBObjectBuilder;
+
+/**
+ * Utility methods for pipeline operators.
+ */
+public final class PipelineOperators {
+    /**
+     * The result that the $redact aggregation resolves to.
+     */
+    public static enum RedactAggregationResult {
+        /**
+         * $redact returns the fields at the current document level, excluding
+         * embedded documents. To include embedded documents and embedded
+         * documents within arrays, apply the $cond expression to the embedded
+         * documents to determine access for these embedded documents.
+         */
+        DESCEND("$$DESCEND"),
+        /**
+         * $redact excludes all fields at this current document/embedded
+         * document level, without further inspection of any of the excluded
+         * fields. This applies even if the excluded field contains embedded
+         * documents that may have different access levels.
+         */
+        PRUNE("$$PRUNE"),
+        /**
+         *  $redact returns or keeps all fields at this current
+         *  document/embedded document level, without further inspection of the
+         *  fields at this level. This applies even if the included field
+         *  contains embedded documents that may have different access levels.
+         */
+        KEEP("$$KEEP");
+
+        private final String resultName;
+
+        /**
+         * Creates a new {@link RedactAggregationResult}.
+         * @param resultName the name of the redact aggregation result.
+         */
+        private RedactAggregationResult(final String resultName) {
+            this.resultName = resultName;
+        }
+
+        @Override
+        public String toString() {
+            return resultName;
+        }
+    }
+
+    /**
+     * Private constructor to prevent instantiation.
+     */
+    private PipelineOperators() {
+    }
+
+    /**
+     * Creates a $redact expression.
+     * @param expression the expression to run redact on.
+     * @param acceptResult the {@link RedactAggregationResult} to return when
+     * the expression passes.
+     * @param rejectResult the {@link RedactAggregationResult} to return when
+     * the expression fails.
+     * @return the $redact expression {@link BasicDBObject}.
+     */
+    public static BasicDBObject redact(final BasicDBObject expression, final RedactAggregationResult acceptResult, final RedactAggregationResult rejectResult) {
+        final BasicDBObjectBuilder builder = BasicDBObjectBuilder.start();
+        return (BasicDBObject) redact(builder, expression, acceptResult, rejectResult).get();
+    }
+
+    /**
+     * Creates a $redact expression.
+     * @param builder the {@link BasicDBObjectBuilder}. (not {@code null})
+     * @param expression the expression to run redact on.
+     * @param acceptResult the {@link RedactAggregationResult} to return when
+     * the expression passes.
+     * @param rejectResult the {@link RedactAggregationResult} to return when
+     * the expression fails.
+     * @return the $redact expression {@link BasicDBObjectBuilder}.
+     */
+    public static BasicDBObjectBuilder redact(final BasicDBObjectBuilder builder, final BasicDBObject expression, final RedactAggregationResult acceptResult, final RedactAggregationResult rejectResult) {
+        checkNotNull(builder);
+        builder.add("$redact", cond(expression, acceptResult.toString(), rejectResult.toString()));
+        return builder;
+    }
+}

--- a/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/document/operators/aggregation/SetOperators.java
+++ b/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/document/operators/aggregation/SetOperators.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.mongodb.document.operators.aggregation;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.rya.mongodb.document.operators.query.ConditionalOperators.ifNull;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.BasicDBObjectBuilder;
+import com.mongodb.DBObject;
+
+/**
+ * Utility methods for MongoDB set operators.
+ */
+public final class SetOperators {
+    /**
+     * Private constructor to prevent instantiation.
+     */
+    private SetOperators() {
+    }
+
+    /**
+     * Checks if the field intersects the set.
+     * @param field the field to check.
+     * @param set the set to check.
+     * @return the $setIntersection expression {@link BasicDBObject}.
+     */
+    public static BasicDBObject setIntersection(final String field, final Object[] set) {
+        final BasicDBObjectBuilder builder = BasicDBObjectBuilder.start();
+        return (BasicDBObject) setIntersection(builder, field, set).get();
+    }
+
+    /**
+     * Checks if the field intersects the set.
+     * @param builder the {@link BasicDBObjectBuilder}. (not {@code null})
+     * @param field the field to check.
+     * @param set the set to check.
+     * @return the $setIntersection expression {@link BasicDBObjectBuilder}.
+     */
+    public static BasicDBObjectBuilder setIntersection(final BasicDBObjectBuilder builder, final String field, final Object[] set) {
+        checkNotNull(builder);
+        builder.add("$setIntersection", Arrays.asList(field, set));
+        return builder;
+    }
+
+    /**
+     * Checks if the expression is a subset of the set.
+     * @param expression the expression to see if it's in the set.
+     * @param set the set to check against.
+     * @return the $setIsSubset expression {@link BasicDBObject}.
+     */
+    public static BasicDBObject setIsSubset(final DBObject expression, final Object[] set) {
+        final BasicDBObjectBuilder builder = BasicDBObjectBuilder.start();
+        return (BasicDBObject) setIsSubset(builder, expression, set).get();
+    }
+
+    /**
+     * Checks if the expression is a subset of the set.
+     * @param builder the {@link BasicDBObjectBuilder}. (not {@code null})
+     * @param expression the expression to see if it's in the set.
+     * @param set the set to check against.
+     * @return the $setIsSubset expression {@link BasicDBObjectBuilder}.
+     */
+    public static BasicDBObjectBuilder setIsSubset(final BasicDBObjectBuilder builder, final DBObject expression, final Object[] set) {
+        checkNotNull(builder);
+        builder.add("$setIsSubset", Arrays.asList(expression, set).toArray(new Object[0]));
+        return builder;
+    }
+
+    /**
+     * Checks if the field is a subset of the set and is safe if the field is
+     * null.
+     * @param field the field to see if it's in the set.
+     * @param set the set to check against.
+     * @return the $setIsSubset expression {@link BasicDBObject}.
+     */
+    public static BasicDBObject setIsSubsetNullSafe(final String field, final Object[] set) {
+        final BasicDBObjectBuilder builder = BasicDBObjectBuilder.start();
+        return (BasicDBObject) setIsSubsetNullSafe(builder, field, set).get();
+    }
+
+    /**
+     * Checks if the field is a subset of the set and is safe if the field is
+     * null.
+     * @param builder the {@link BasicDBObjectBuilder}. (not {@code null})
+     * @param field the field to see if it's in the set.
+     * @param set the set to check against.
+     * @return the $setIsSubset expression {@link BasicDBObjectBuilder}.
+     */
+    public static BasicDBObjectBuilder setIsSubsetNullSafe(final BasicDBObjectBuilder builder, final String field, final Object[] set) {
+        checkNotNull(builder);
+        final Object emptyAccess = Collections.emptyList().toArray();
+        return setIsSubset(builder,
+            ifNull(
+                field,
+                emptyAccess
+            ),
+            set
+        );
+    }
+
+    /**
+     * Checks if any elements from the expression are {@code true}.
+     * @param expression the expression to see if any elements are {@code true}.
+     * @return the $anyElementTrue expression {@link BasicDBObject}.
+     */
+    public static BasicDBObject anyElementTrue(final DBObject expression) {
+        final BasicDBObjectBuilder builder = BasicDBObjectBuilder.start();
+        return (BasicDBObject) anyElementTrue(builder, expression).get();
+    }
+
+    /**
+     * Checks if any elements from the expression are {@code true}.
+     * @param builder the {@link BasicDBObjectBuilder}. (not {@code null})
+     * @param expression the expression to see if any elements are {@code true}.
+     * @return the $anyElementTrue expression {@link BasicDBObjectBuilder}.
+     */
+    public static BasicDBObjectBuilder anyElementTrue(final BasicDBObjectBuilder builder, final DBObject expression) {
+        checkNotNull(builder);
+        builder.add("$anyElementTrue", expression);
+        return builder;
+    }
+}

--- a/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/document/operators/aggregation/VariableOperators.java
+++ b/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/document/operators/aggregation/VariableOperators.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.mongodb.document.operators.aggregation;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.BasicDBObjectBuilder;
+import com.mongodb.DBObject;
+
+/**
+ * Utility methods for variable operators.
+ */
+public final class VariableOperators {
+    /**
+     * Private constructor to prevent instantiation.
+     */
+    private VariableOperators() {
+    }
+
+    /**
+     * Applies an expression to each item in an array and returns an array with
+     * the applied results.
+     * @param input an expression that resolves to an array.
+     * @param as the variable name for the items in the {@code input} array.
+     * The {@code in} expression accesses each item in the {@code input} array
+     * by this variable.
+     * @param in the expression to apply to each item in the {@code input}
+     * array. The expression accesses the item by its variable name.
+     * @return the $map expression {@link BasicDBObject}.
+     */
+    public static BasicDBObject map(final String input, final String as, final DBObject in) {
+        final BasicDBObjectBuilder builder = BasicDBObjectBuilder.start();
+        return (BasicDBObject) map(builder, input, as, in).get();
+    }
+
+    /**
+     * Applies an expression to each item in an array and returns an array with
+     * the applied results.
+     * @param builder the {@link BasicDBObjectBuilder}. (not {@code null})
+     * @param input an expression that resolves to an array.
+     * @param as the variable name for the items in the {@code input} array.
+     * The {@code in} expression accesses each item in the {@code input} array
+     * by this variable.
+     * @param in the expression to apply to each item in the {@code input}
+     * array. The expression accesses the item by its variable name.
+     * @return the $map expression {@link BasicDBObjectBuilder}.
+     */
+    public static BasicDBObjectBuilder map(final BasicDBObjectBuilder builder, final String input, final String as, final DBObject in) {
+        checkNotNull(builder);
+        builder.push("$map")
+            .add("input", input)
+            .add("as", as)
+            .add("in", in);
+        return builder;
+    }
+}

--- a/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/document/operators/query/ArrayOperators.java
+++ b/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/document/operators/query/ArrayOperators.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.mongodb.document.operators.query;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.BasicDBObjectBuilder;
+
+/**
+ * Utility methods for array operators.
+ */
+public final class ArrayOperators {
+    /**
+     * Private constructor to prevent instantiation.
+     */
+    private ArrayOperators() {
+    }
+
+    /**
+     * Creates an $size MongoDB expression.
+     * @param expression the expression to get the size of.
+     * @return the $size expression {@link BasicDBObject}.
+     */
+    public static BasicDBObject size(final Object expression) {
+        final BasicDBObjectBuilder builder = BasicDBObjectBuilder.start();
+        return (BasicDBObject) size(builder, expression).get();
+    }
+
+    /**
+     * Creates an $size MongoDB expression.
+     * @param builder the {@link BasicDBObjectBuilder}. (not {@code null})
+     * @param expression the expression to get the size of.
+     * @return the $size expression {@link BasicDBObjectBuilder}.
+     */
+    public static BasicDBObjectBuilder size(final BasicDBObjectBuilder builder, final Object expression) {
+        checkNotNull(builder);
+        builder.add("$size", expression);
+        return builder;
+    }
+}

--- a/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/document/operators/query/ComparisonOperators.java
+++ b/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/document/operators/query/ComparisonOperators.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.mongodb.document.operators.query;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Arrays;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.BasicDBObjectBuilder;
+
+/**
+ * Utility methods for comparison operators.
+ */
+public final class ComparisonOperators {
+    /**
+     * Private constructor to prevent instantiation.
+     */
+    private ComparisonOperators() {
+    }
+
+    /**
+     * Creates a $gt MongoDB expression.
+     * @param expression the expression.
+     * @param value the value to test if the expression is greater than
+     * @return the $gt expression {@link BasicDBObject}.
+     */
+    public static BasicDBObject gt(final BasicDBObject expression, final Number value) {
+        final BasicDBObjectBuilder builder = BasicDBObjectBuilder.start();
+        return (BasicDBObject) gt(builder, expression, value).get();
+    }
+
+    /**
+     * Creates a $gt MongoDB expression.
+     * @param builder the {@link BasicDBObjectBuilder}. (not {@code null})
+     * @param expression the expression.
+     * @param value the value to test if the expression is greater than
+     * @return the $gt expression {@link BasicDBObjectBuilder}.
+     */
+    public static BasicDBObjectBuilder gt(final BasicDBObjectBuilder builder, final BasicDBObject expression, final Number value) {
+        checkNotNull(builder);
+        builder.add("$gt", Arrays.asList(expression, value));
+        return builder;
+    }
+
+    /**
+     * Creates an $eq MongoDB expression.
+     * @param expression1 the first expression.
+     * @param expression2 the second expression.
+     * @return the $eq expression {@link BasicDBObject}.
+     */
+    public static BasicDBObject eq(final BasicDBObject expression1, final Object expression2) {
+        final BasicDBObjectBuilder builder = BasicDBObjectBuilder.start();
+        return (BasicDBObject) eq(builder, expression1, expression2).get();
+    }
+
+    /**
+     * Creates an $eq MongoDB expression.
+     * @param builder the {@link BasicDBObjectBuilder}. (not {@code null})
+     * @param expression1 the first expression.
+     * @param expression2 the second expression.
+     * @return the $eq expression {@link BasicDBObjectBuilder}.
+     */
+    public static BasicDBObjectBuilder eq(final BasicDBObjectBuilder builder, final BasicDBObject expression1, final Object expression2) {
+        checkNotNull(builder);
+        builder.add("$eq", Arrays.asList(expression1, expression2));
+        return builder;
+    }
+}

--- a/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/document/operators/query/ConditionalOperators.java
+++ b/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/document/operators/query/ConditionalOperators.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.mongodb.document.operators.query;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Arrays;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.BasicDBObjectBuilder;
+
+/**
+ * Utility methods for conditional operators.
+ */
+public final class ConditionalOperators {
+    /**
+     * Private constructor to prevent instantiation.
+     */
+    private ConditionalOperators() {
+    }
+
+    /**
+     * Creates an "if-then-else" MongoDB expression.
+     * @param ifStatement the "if" statement {@link BasicDBObject}.
+     * @param thenResult the {@link Object} to return when the
+     * {@code ifStatement} is {@code true}.
+     * @param elseResult the {@link Object} to return when the
+     * {@code ifStatement} is {@code false}.
+     * @return the "if" expression {@link BasicDBObject}.
+     */
+    public static BasicDBObject ifThenElse(final BasicDBObject ifStatement, final Object thenResult, final Object elseResult) {
+        final BasicDBObjectBuilder builder = BasicDBObjectBuilder.start();
+        return (BasicDBObject) ifThenElse(builder, ifStatement, thenResult, elseResult).get();
+    }
+
+    /**
+     * Creates an "if-then-else" MongoDB expression.
+     * @param builder the {@link BasicDBObjectBuilder}. (not {@code null})
+     * @param ifStatement the "if" statement {@link BasicDBObject}.
+     * @param thenResult the {@link Object} to return when the
+     * {@code ifStatement} is {@code true}.
+     * @param elseResult the {@link Object} to return when the
+     * {@code ifStatement} is {@code false}.
+     * @return the "if" expression {@link BasicDBObjectBuilder}.
+     */
+    public static BasicDBObjectBuilder ifThenElse(final BasicDBObjectBuilder builder, final BasicDBObject ifStatement, final Object thenResult, final Object elseResult) {
+        checkNotNull(builder);
+        builder.add("if", ifStatement);
+        builder.append("then", thenResult);
+        builder.append("else", elseResult);
+        return builder;
+    }
+
+    /**
+     * Checks if the expression is {@code null} and replaces it if it is.
+     * @param expression the expression to {@code null} check.
+     * @param replacementExpression the expression to replace it with if it's
+     * {@code null}.
+     * @return the $ifNull expression {@link BasicDBObject}.
+     */
+    public static BasicDBObject ifNull(final Object expression, final Object replacementExpression) {
+        final BasicDBObjectBuilder builder = BasicDBObjectBuilder.start();
+        return (BasicDBObject) ifNull(builder, expression, replacementExpression).get();
+    }
+
+    /**
+     * Checks if the expression is {@code null} and replaces it if it is.
+     * @param builder the {@link BasicDBObjectBuilder}. (not {@code null})
+     * @param expression the expression to {@code null} check.
+     * @param replacementExpression the expression to replace it with if it's
+     * {@code null}.
+     * @return the $ifNull expression {@link BasicDBObjectBuilder}.
+     */
+    public static BasicDBObjectBuilder ifNull(final BasicDBObjectBuilder builder, final Object expression, final Object replacementExpression) {
+        checkNotNull(builder);
+        builder.add("$ifNull", Arrays.asList(expression, replacementExpression));
+        return builder;
+    }
+
+    /**
+     * Creates an "$cond" MongoDB expression.
+     * @param expression the expression {@link BasicDBObject}.
+     * @param thenResult the {@link Object} to return when the
+     * {@code expression} is {@code true}.
+     * @param elseResult the {@link Object} to return when the
+     * {@code expression} is {@code false}.
+     * @return the $cond expression {@link BasicDBObject}.
+     */
+    public static BasicDBObject cond(final BasicDBObject expression, final Object thenResult, final Object elseResult) {
+        final BasicDBObjectBuilder builder = BasicDBObjectBuilder.start();
+        return (BasicDBObject) cond(builder, expression, thenResult, elseResult).get();
+    }
+
+    /**
+     * Creates an "$cond" MongoDB expression.
+     * @param builder the {@link BasicDBObjectBuilder}. (not {@code null})
+     * @param expression the expression {@link BasicDBObject}.
+     * @param thenResult the {@link Object} to return when the
+     * {@code expression} is {@code true}.
+     * @param elseResult the {@link Object} to return when the
+     * {@code expression} is {@code false}.
+     * @return the $cond expression {@link BasicDBObjectBuilder}.
+     */
+    public static BasicDBObjectBuilder cond(final BasicDBObjectBuilder builder, final BasicDBObject expression, final Object thenResult, final Object elseResult) {
+        checkNotNull(builder);
+        builder.add("$cond", ifThenElse(expression, thenResult, elseResult));
+        return builder;
+    }
+}

--- a/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/document/operators/query/LogicalOperators.java
+++ b/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/document/operators/query/LogicalOperators.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.mongodb.document.operators.query;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.List;
+
+import com.google.common.collect.Lists;
+import com.mongodb.BasicDBObject;
+import com.mongodb.BasicDBObjectBuilder;
+
+/**
+ * Utility methods for logical operators.
+ */
+public final class LogicalOperators {
+    /**
+     * Private constructor to prevent instantiation.
+     */
+    private LogicalOperators() {
+    }
+
+    /**
+     * Creates an $and MongoDB expression.
+     * @param lhs the left-hand side operand.
+     * @param rhs the right-hand side operand.
+     * @param extras any additional operands.
+     * @return the $and expression {@link BasicDBObject}.
+     */
+    public static BasicDBObject and(final BasicDBObject lhs, final BasicDBObject rhs, final BasicDBObject... extras) {
+        final BasicDBObjectBuilder builder = BasicDBObjectBuilder.start();
+        return (BasicDBObject) and(builder, lhs, rhs, extras).get();
+    }
+
+    /**
+     * Creates an $and MongoDB expression.
+     * @param builder the {@link BasicDBObjectBuilder}. (not {@code null})
+     * @param lhs the left-hand side operand.
+     * @param rhs the right-hand side operand.
+     * @param extras any additional operands.
+     * @return the $and expression {@link BasicDBObjectBuilder}.
+     */
+    public static BasicDBObjectBuilder and(final BasicDBObjectBuilder builder, final BasicDBObject lhs, final BasicDBObject rhs, final BasicDBObject... extras) {
+        checkNotNull(builder);
+        final List<BasicDBObject> operands = Lists.newArrayList(lhs, rhs);
+
+        if (extras != null && extras.length > 0) {
+            operands.addAll(Lists.newArrayList(extras));
+        }
+
+        builder.add("$and", operands);
+        return builder;
+    }
+
+    /**
+     * Creates an $or MongoDB expression.
+     * @param lhs the left-hand side operand.
+     * @param rhs the right-hand side operand.
+     * @param extras any additional operands.
+     * @return the $or expression {@link BasicDBObject}.
+     */
+    public static BasicDBObject or(final BasicDBObject lhs, final BasicDBObject rhs, final BasicDBObject... extras) {
+        final BasicDBObjectBuilder builder = BasicDBObjectBuilder.start();
+        return (BasicDBObject) or(builder, lhs, rhs, extras).get();
+    }
+
+    /**
+     * Creates an $or MongoDB expression.
+     * @param builder the {@link BasicDBObjectBuilder}. (not {@code null})
+     * @param lhs the left-hand side operand.
+     * @param rhs the right-hand side operand.
+     * @param extras any additional operands.
+     * @return the $or expression {@link BasicDBObjectBuilder}.
+     */
+    public static BasicDBObjectBuilder or(final BasicDBObjectBuilder builder, final BasicDBObject lhs, final BasicDBObject rhs, final BasicDBObject... extras) {
+        checkNotNull(builder);
+        final List<BasicDBObject> operands = Lists.newArrayList(lhs, rhs);
+
+        if (extras != null && extras.length > 0) {
+            operands.addAll(Lists.newArrayList(extras));
+        }
+
+        builder.add("$or", operands);
+        return builder;
+    }
+}

--- a/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/document/util/AuthorizationsUtil.java
+++ b/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/document/util/AuthorizationsUtil.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.mongodb.document.util;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.accumulo.core.security.Authorizations;
+
+import com.google.common.base.Charsets;
+
+/**
+ * Utility methods for {@link Authorizations}.
+ */
+public final class AuthorizationsUtil {
+    /**
+     * Private constructor to prevent instantiation.
+     */
+    private AuthorizationsUtil() {
+    }
+
+    /**
+    * Gets the authorizations in sorted order.
+    * @param authorizations the {@link Authorizations}.
+    * @return authorizations, each as a string encoded in UTF-8
+    */
+    public static String[] getAuthorizationsStringArray(final Authorizations authorizations) {
+        return getAuthorizationsStrings(authorizations).toArray(new String[0]);
+    }
+
+    /**
+    * Gets the authorizations in sorted order. The returned list is not modifiable.
+    * @param authorizations the {@link Authorizations}
+    * @return authorizations, each as a string encoded in UTF-8
+    */
+    public static List<String> getAuthorizationsStrings(final Authorizations authorizations) {
+        final List<String> copy = new ArrayList<>(authorizations.getAuthorizations().size());
+        for (final byte[] auth : authorizations.getAuthorizations()) {
+            copy.add(new String(auth, Charsets.UTF_8));
+        }
+        return Collections.unmodifiableList(copy);
+    }
+}

--- a/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/document/util/DisjunctiveNormalFormConverter.java
+++ b/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/document/util/DisjunctiveNormalFormConverter.java
@@ -1,0 +1,270 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.mongodb.document.util;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.core.security.ColumnVisibility.Node;
+import org.apache.accumulo.core.security.ColumnVisibility.NodeType;
+import org.apache.commons.lang.StringUtils;
+import org.apache.log4j.Logger;
+import org.apache.rya.mongodb.document.visibility.DocumentVisibility;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.Lists;
+
+/**
+ * Utility for converting document visibility boolean expressions into
+ * Disjunctive Normal Form.
+ */
+public final class DisjunctiveNormalFormConverter {
+    private static final Logger log = Logger.getLogger(DisjunctiveNormalFormConverter.class);
+
+    /**
+     * Private constructor to prevent instantiation.
+     */
+    private DisjunctiveNormalFormConverter() {
+    }
+
+    /**
+     * Creates a new document visibility based on the boolean expression string
+     * that is converted into disjunctive normal form.
+     * @param expression the boolean string expression.
+     * @return the {@link DocumentVisibility} in DNF.
+     */
+    public static DocumentVisibility createDnfDocumentVisibility(final String expression) {
+        return createDnfDocumentVisibility(expression.getBytes(UTF_8));
+    }
+
+    /**
+     * Creates a new document visibility based on the boolean expression that is
+     * converted into disjunctive normal form.
+     * @param expression the boolean expression bytes.
+     * @return the {@link DocumentVisibility} in DNF.
+     */
+    public static DocumentVisibility createDnfDocumentVisibility(final byte[] expression) {
+        final DocumentVisibility documentVisibility = new DocumentVisibility(expression);
+        final DocumentVisibility dnfDv = convertToDisjunctiveNormalForm(documentVisibility);
+        return dnfDv;
+    }
+
+    /**
+     * Creates a document visibility boolean expression string into Disjunctive
+     * Normal Form (DNF).  Expressions use this format in DNF:<pre>
+     * (P1 & P2 & P3 ... Pn) | (Q1 & Q2 ... Qm) ...
+     * </pre>
+     * @param documentVisibility the {@link DocumentVisibility}.
+     * @return a new {@link DocumentVisibility} with its expression in DNF.
+     */
+    public static DocumentVisibility convertToDisjunctiveNormalForm(final DocumentVisibility documentVisibility) {
+        // Find all the terms used in the expression
+        final List<String> terms = findNodeTerms(documentVisibility.getParseTree(), documentVisibility.getExpression());
+        // Create an appropriately sized truth table that has the correct 0's
+        // and 1's in place based on the number of terms.
+        // This size should be [numberOfNumber][2 ^ numberOfTerms].
+        final byte[][] truthTable = createTruthTableInputs(terms);
+
+        // Go through each row in the truth table.
+        // If the row has a 1 for the term then create an Authorization for it
+        // and test if it works.
+        // If the row passes then that means all the terms that were a 1 and
+        // were used can be AND'ed together to pass the expression.
+        // All the rows that pass can be OR'd together.
+        // Disjunction Normal Form: (P1 & P2 & P3 ... Pn) | (Q1 & Q2 ... Qm) ...
+        final List<List<String>> termRowsThatPass = new ArrayList<>();
+        for (final byte[] row : truthTable) {
+            final List<String> termRowToCheck = new ArrayList<>();
+            // If the truth table input is a 1 then include the corresponding
+            // term that it matches.
+            for (int i = 0; i < row.length; i++) {
+                final byte entry = row[i];
+                if (entry == 1) {
+                    termRowToCheck.add(terms.get(i));
+                }
+            }
+
+            final List<String> authList = new ArrayList<>();
+            for (final String auth : termRowToCheck) {
+                String formattedAuth = auth;
+                formattedAuth = StringUtils.removeStart(formattedAuth, "\"");
+                formattedAuth = StringUtils.removeEnd(formattedAuth, "\"");
+                authList.add(formattedAuth);
+            }
+            final Authorizations auths = new Authorizations(authList.toArray(new String[0]));
+            final boolean hasAccess = DocumentVisibilityUtil.doesUserHaveDocumentAccess(auths, documentVisibility, false);
+            if (hasAccess) {
+                boolean alreadyCoveredBySimplerTerms = false;
+                // If one 'AND' group is (A&C) and another is (A&B&C) then we
+                // can drop (A&B&C) since it is already covered by simpler terms
+                // (it's a subset)
+                for (final List<String> existingTermRowThatPassed : termRowsThatPass) {
+                    alreadyCoveredBySimplerTerms = termRowToCheck.containsAll(existingTermRowThatPassed);
+                    if (alreadyCoveredBySimplerTerms) {
+                        break;
+                    }
+                }
+                if (!alreadyCoveredBySimplerTerms) {
+                    termRowsThatPass.add(termRowToCheck);
+                }
+            }
+        }
+
+        // Rebuild the term rows that passed as a document visibility boolean
+        // expression string.
+        final StringBuilder sb = new StringBuilder();
+        boolean isFirst = true;
+        final boolean hasMultipleGroups = termRowsThatPass.size() > 1;
+        for (final List<String> termRowThatPassed : termRowsThatPass) {
+            if (isFirst) {
+                isFirst = false;
+            } else {
+                sb.append("|");
+            }
+            if (hasMultipleGroups && termRowThatPassed.size() > 1) {
+                sb.append("(");
+            }
+            sb.append(Joiner.on("&").join(termRowThatPassed));
+            if (hasMultipleGroups && termRowThatPassed.size() > 1) {
+                sb.append(")");
+            }
+        }
+
+        log.trace(sb.toString());
+        final DocumentVisibility dnfDv = new DocumentVisibility(sb.toString());
+        return dnfDv;
+    }
+
+    /**
+     * Searches a node for all unique terms in its expression and returns them.
+     * Duplicates are not included.
+     * @param node the {@link Node}.
+     * @return an unmodifiable {@link List} of string terms without duplicates.
+     */
+    public static List<String> findNodeTerms(final Node node, final byte[] expression) {
+        final Set<String> terms = new LinkedHashSet<>();
+        if (node.getType() == NodeType.TERM) {
+            final String data = DocumentVisibilityUtil.getTermNodeData(node, expression);
+            terms.add(data);
+        }
+        for (final Node child : node.getChildren()) {
+            switch (node.getType()) {
+                case AND:
+                case OR:
+                    terms.addAll(findNodeTerms(child, expression));
+                    break;
+                default:
+                    break;
+            }
+        }
+        return Collections.unmodifiableList(Lists.newArrayList(terms));
+    }
+
+    /**
+     * Creates the inputs needed to populate a truth table based on the provided
+     * number of terms that the expression uses. So, a node that only has 3
+     * terms will create a 3 x 8 size table:
+     * <pre>
+     * 0 0 0
+     * 0 0 1
+     * 0 1 0
+     * 0 1 1
+     * 1 0 0
+     * 1 0 1
+     * 1 1 0
+     * 1 1 1
+     * </pre>
+     * @param node the {@link Node}.
+     * @return a two-dimensional array of bytes representing the truth table
+     * inputs.  The table will be of size: [termNumber] x [2 ^ termNumber]
+     */
+    public static byte[][] createTruthTableInputs(final Node node, final byte[] expression) {
+        final List<String> terms = findNodeTerms(node, expression);
+        return createTruthTableInputs(terms);
+    }
+
+    /**
+     * Creates the inputs needed to populate a truth table based on the provided
+     * number of terms that the expression uses. So, if there are 3 terms then
+     * it will create a 3 x 8 size table:
+     * <pre>
+     * 0 0 0
+     * 0 0 1
+     * 0 1 0
+     * 0 1 1
+     * 1 0 0
+     * 1 0 1
+     * 1 1 0
+     * 1 1 1
+     * </pre>
+     * @param terms the {@link List} of term strings.
+     * @return a two-dimensional array of bytes representing the truth table
+     * inputs.  The table will be of size: [termNumber] x [2 ^ termNumber]
+     */
+    public static byte[][] createTruthTableInputs(final List<String> terms) {
+        return createTruthTableInputs(terms.size());
+    }
+
+    /**
+     * Creates the inputs needed to populate a truth table based on the provided
+     * number of terms that the expression uses. So, entering 3 for the number
+     * of terms will create a 3 x 8 size table:
+     * <pre>
+     * 0 0 0
+     * 0 0 1
+     * 0 1 0
+     * 0 1 1
+     * 1 0 0
+     * 1 0 1
+     * 1 1 0
+     * 1 1 1
+     * </pre>
+     * @param termNumber the number of terms.
+     * @return a two-dimensional array of bytes representing the truth table
+     * inputs.  The table will be of size: [termNumber] x [2 ^ termNumber]
+     */
+    public static byte[][] createTruthTableInputs(final int termNumber) {
+        final int numColumns = termNumber;
+        final int numRows = (int) Math.pow(2, numColumns);
+        final byte[][] truthTable = new byte[numRows][numColumns];
+
+        for (int row = 0; row < numRows; row++) {
+            for (int col = 0; col < numColumns; col++) {
+                // We're starting from the top-left and going right then down to
+                // the next row. The left-side is of a higher order than the
+                // right-side so adjust accordingly.
+                final int digitOrderPosition = numColumns - 1 - col;
+                final int power = (int) Math.pow(2, digitOrderPosition);
+                final int toggle = (row / power) % 2;
+                truthTable[row][col] = (byte) toggle;
+            }
+        }
+
+        log.trace("Truth table inputs: " + Arrays.deepToString(truthTable));
+
+        return truthTable;
+    }
+}

--- a/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/document/util/DocumentVisibilityConversionException.java
+++ b/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/document/util/DocumentVisibilityConversionException.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.mongodb.document.util;
+
+/**
+ * Exception thrown when document visibility conversion encounters a problem.
+ */
+public class DocumentVisibilityConversionException extends Exception {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Creates a new instance of {@link DocumentVisibilityConversionException} with no
+     * detail message.
+     */
+    public DocumentVisibilityConversionException() {
+        super();
+    }
+
+    /**
+     * Creates a new instance of {@link DocumentVisibilityConversionException} with the
+     * specified detail message.
+     * @param message the detail message.
+     */
+    public DocumentVisibilityConversionException(final String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new instance of {@link DocumentVisibilityConversionException} with the
+     * specified detail message and cause.
+     * @param message the detail message.
+     * @param cause the {@link Throwable} cause.
+     */
+    public DocumentVisibilityConversionException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Creates a new instance of {@link DocumentVisibilityConversionException} with the
+     * specified cause.
+     * @param cause the {@link Throwable} cause.
+     */
+    public DocumentVisibilityConversionException(final Throwable cause) {
+        super(cause);
+    }
+}

--- a/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/document/util/DocumentVisibilityUtil.java
+++ b/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/document/util/DocumentVisibilityUtil.java
@@ -1,0 +1,331 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.mongodb.document.util;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.accumulo.core.data.ByteSequence;
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.core.security.ColumnVisibility.Node;
+import org.apache.accumulo.core.security.ColumnVisibility.NodeType;
+import org.apache.accumulo.core.security.VisibilityEvaluator;
+import org.apache.accumulo.core.security.VisibilityParseException;
+import org.apache.log4j.Logger;
+import org.apache.rya.mongodb.MongoDbRdfConstants;
+import org.apache.rya.mongodb.document.visibility.DocumentVisibility;
+
+import com.google.common.base.Charsets;
+import com.google.common.collect.Lists;
+import com.mongodb.BasicDBList;
+
+/**
+ * Utility methods for converting boolean expressions between a string
+ * representation to a MongoDB-friendly multidimensional array form that can be
+ * used in MongoDB's aggregation set operations.
+ */
+public final class DocumentVisibilityUtil {
+    private static final Logger log = Logger.getLogger(DocumentVisibilityUtil.class);
+
+    /**
+     * Private constructor to prevent instantiation.
+     */
+    private DocumentVisibilityUtil() {
+    }
+
+    /**
+     * Converts a boolean string expression into a multidimensional
+     * array representation of the boolean expression.
+     * @param booleanString the boolean string expression.
+     * @return the multidimensional array representation of the boolean
+     * expression.
+     * @throws DocumentVisibilityConversionException
+     */
+    public static Object[] toMultidimensionalArray(final String booleanString) throws DocumentVisibilityConversionException {
+        final DocumentVisibility dv = new DocumentVisibility(booleanString);
+        return toMultidimensionalArray(dv);
+    }
+
+    /**
+     * Converts a {@link DocumentVisibility} object into a multidimensional
+     * array representation of the boolean expression.
+     * @param dv the {@link DocumentVisibility}. (not {@code null})
+     * @return the multidimensional array representation of the boolean
+     * expression.
+     * @throws DocumentVisibilityConversionException
+     */
+    public static Object[] toMultidimensionalArray(final DocumentVisibility dv) throws DocumentVisibilityConversionException {
+        checkNotNull(dv);
+        final byte[] expression = dv.flatten();
+        final DocumentVisibility flattenedDv = DisjunctiveNormalFormConverter.createDnfDocumentVisibility(expression);
+        final Object[] result = toMultidimensionalArray(flattenedDv.getParseTree(), flattenedDv.getExpression());
+        // If there's only one group then make sure it's wrapped as an array.
+        // (i.e. "A" should be ["A"])
+        if (result.length > 0 && result[0] instanceof String) {
+            final List<Object[]> formattedResult = new ArrayList<>();
+            formattedResult.add(result);
+            return formattedResult.toArray(new Object[0]);
+        }
+        return result;
+    }
+
+    /**
+     * Converts a {@link Node} and its corresponding expression into a
+     * multidimensional array representation of the boolean expression.
+     * @param node the {@link Node}. (not {@code null})
+     * @param expression the expression byte array.
+     * @return the multidimensional array representation of the boolean
+     * expression.
+     * @throws DocumentVisibilityConversionException
+     */
+    public static Object[] toMultidimensionalArray(final Node node, final byte[] expression) throws DocumentVisibilityConversionException {
+        checkNotNull(node);
+        final List<Object> array = new ArrayList<>();
+
+        if (node.getChildren().isEmpty() && node.getType() == NodeType.TERM) {
+            final String data = getTermNodeData(node, expression);
+            array.add(data);
+        }
+
+        log.trace("Children size: " + node.getChildren().size() + " Type: " + node.getType());
+        for (final Node child : node.getChildren()) {
+            switch (child.getType()) {
+                case EMPTY:
+                case TERM:
+                    String data;
+                    if (child.getType() == NodeType.TERM) {
+                        data = getTermNodeData(child, expression);
+                    } else {
+                        data = "";
+                    }
+                    if (node.getType() == NodeType.OR) {
+                        array.add(Lists.newArrayList(data).toArray(new Object[0]));
+                    } else {
+                        array.add(data);
+                    }
+                    break;
+                case OR:
+                case AND:
+                    array.add(toMultidimensionalArray(child, expression));
+                    break;
+                default:
+                    throw new DocumentVisibilityConversionException("Unknown type: " + child.getType());
+            }
+        }
+
+        return array.toArray(new Object[0]);
+    }
+
+    public static String nodeToBooleanString(final Node node, final byte[] expression) throws DocumentVisibilityConversionException {
+        boolean isFirst = true;
+        final StringBuilder sb = new StringBuilder();
+        if (node.getType() == NodeType.TERM) {
+            final String data = getTermNodeData(node, expression);
+            sb.append(data);
+        }
+        if (node.getType() == NodeType.AND) {
+            sb.append("(");
+        }
+        for (final Node child : node.getChildren()) {
+            if (isFirst) {
+                isFirst = false;
+            } else {
+                if (node.getType() == NodeType.OR) {
+                    sb.append("|");
+                } else if (node.getType() == NodeType.AND) {
+                    sb.append("&");
+                }
+            }
+            switch (child.getType()) {
+                case EMPTY:
+                    sb.append("");
+                    break;
+                case TERM:
+                    final String data = getTermNodeData(child, expression);
+                    sb.append(data);
+                    break;
+                case OR:
+                    sb.append("(");
+                    sb.append(nodeToBooleanString(child, expression));
+                    sb.append(")");
+                    break;
+                case AND:
+                    sb.append(nodeToBooleanString(child, expression));
+                    break;
+                default:
+                    throw new DocumentVisibilityConversionException("Unknown type: " + child.getType());
+            }
+        }
+        if (node.getType() == NodeType.AND) {
+            sb.append(")");
+        }
+
+        return sb.toString();
+    }
+
+    /**
+     * Converts a multidimensional array object representation of the document
+     * visibility boolean expression into a string.
+     * @param object the multidimensional array object representing the
+     * document visibility boolean expression.
+     * @return the boolean string expression.
+     */
+    public static String multidimensionalArrayToBooleanString(final Object[] object) {
+        final String booleanString = multidimensionalArrayToBooleanStringInternal(object);
+
+        // Simplify and clean up the formatting.
+        final DocumentVisibility dv = DisjunctiveNormalFormConverter.createDnfDocumentVisibility(booleanString);
+        final byte[] bytes = dv.flatten();
+        final String result = new String(bytes, Charsets.UTF_8);
+
+        return result;
+    }
+
+    private static String multidimensionalArrayToBooleanStringInternal(final Object[] object) {
+        final StringBuilder sb = new StringBuilder();
+
+        int count = 0;
+        boolean isAnd = false;
+        for (final Object child : object) {
+            if (child instanceof String) {
+                isAnd = true;
+                if (count > 0) {
+                    sb.append("&");
+                }
+                sb.append(child);
+            } else if (child instanceof Object[]) {
+                if (count > 0 && isAnd) {
+                    sb.append("&");
+                }
+                final Object[] obj = (Object[]) child;
+                sb.append("(");
+                sb.append(multidimensionalArrayToBooleanStringInternal(obj));
+                sb.append(")");
+            }
+
+            if (object.length > 1 && count + 1 < object.length && !isAnd) {
+                sb.append("|");
+            }
+            count++;
+        }
+
+        return sb.toString();
+    }
+
+    /**
+     * Conditionally adds quotes around a string.
+     * @param data the string to add quotes to.
+     * @param addQuotes {@code true} to add quotes. {@code false} to leave the
+     * string as is.
+     * @return the quoted string if {@code addQuotes} is {@code true}.
+     * Otherwise, returns the string as is.
+     */
+    public static String addQuotes(final String data, final boolean addQuotes) {
+        if (addQuotes) {
+            return "\"" + data + "\"";
+        } else {
+            return data;
+        }
+    }
+
+    /**
+     * Returns the term node's data.
+     * @param node the {@link Node}.
+     * @return the term node's data.
+     */
+    public static String getTermNodeData(final Node node, final byte[] expression) {
+        final boolean isQuotedTerm = expression[node.getTermStart()] == '"';
+        final ByteSequence bs = node.getTerm(expression);
+        final String data = addQuotes(new String(bs.toArray(), Charsets.UTF_8), isQuotedTerm);
+        return data;
+    }
+
+    /**
+     * Checks if the user's authorizations allows them to have access to the
+     * provided document based on its document visibility.
+     * @param authorizations the {@link Authorizations}.
+     * @param documentVisibility the document visibility byte expression.
+     * @return {@code true} if the user has access to the document.
+     * {@code false} otherwise.
+     */
+    public static boolean doesUserHaveDocumentAccess(final Authorizations authorizations, final byte[] documentVisibilityExpression) {
+        final byte[] expression = documentVisibilityExpression != null ? documentVisibilityExpression : MongoDbRdfConstants.EMPTY_DV.getExpression();
+        final DocumentVisibility documentVisibility = new DocumentVisibility(expression);
+        return doesUserHaveDocumentAccess(authorizations, documentVisibility);
+    }
+
+    /**
+     * Checks if the user's authorizations allows them to have access to the
+     * provided document based on its document visibility.
+     * @param authorizations the {@link Authorizations}.
+     * @param documentVisibility the {@link DocumentVisibility}.
+     * @return {@code true} if the user has access to the document.
+     * {@code false} otherwise.
+     */
+    public static boolean doesUserHaveDocumentAccess(final Authorizations authorizations, final DocumentVisibility documentVisibility) {
+        return doesUserHaveDocumentAccess(authorizations, documentVisibility, true);
+    }
+
+    /**
+     * Checks if the user's authorizations allows them to have access to the
+     * provided document based on its document visibility.
+     * @param authorizations the {@link Authorizations}.
+     * @param documentVisibility the {@link DocumentVisibility}.
+     * @param doesEmptyAccessPass {@code true} if an empty authorization pass
+     * allows access to everything. {@code false} otherwise.
+     * @return {@code true} if the user has access to the document.
+     * {@code false} otherwise.
+     */
+    public static boolean doesUserHaveDocumentAccess(final Authorizations authorizations, final DocumentVisibility documentVisibility, final boolean doesEmptyAccessPass) {
+        final Authorizations userAuths = authorizations != null ? authorizations : MongoDbRdfConstants.ALL_AUTHORIZATIONS;
+        final VisibilityEvaluator visibilityEvaluator = new VisibilityEvaluator(userAuths);
+        boolean accept = false;
+        if (doesEmptyAccessPass && MongoDbRdfConstants.ALL_AUTHORIZATIONS.equals(userAuths)) {
+            accept = true;
+        } else {
+            try {
+                accept = visibilityEvaluator.evaluate(documentVisibility);
+            } catch (final VisibilityParseException e) {
+                log.error("Could not parse document visibility.");
+            }
+        }
+
+        return accept;
+    }
+
+    /**
+     * Converts a {@link BasicDBList} into an array of {@link Object}s.
+     * @param basicDbList the {@link BasicDBList} to convert.
+     * @return the array of {@link Object}s.
+     */
+    public static Object[] convertBasicDBListToObjectArray(final BasicDBList basicDbList) {
+        final List<Object> list = new ArrayList<>();
+        final Object[] array = basicDbList.toArray();
+        for (final Object child : array) {
+            if (child instanceof BasicDBList) {
+                list.add(convertBasicDBListToObjectArray((BasicDBList)child));
+            } else {
+                list.add(child);
+            }
+        }
+        return list.toArray(new Object[0]);
+    }
+}

--- a/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/document/visibility/DocumentVisibility.java
+++ b/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/document/visibility/DocumentVisibility.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rya.mongodb.document.visibility;
+
+import org.apache.accumulo.core.security.ColumnVisibility;
+import org.apache.hadoop.io.Text;
+
+/**
+ * Validate the document visibility is a valid expression and set the visibility for a Mutation. See {@link DocumentVisibility#DocumentVisibility(byte[])} for the
+ * definition of an expression.
+ *
+ * <p>
+ * The expression is a sequence of characters from the set [A-Za-z0-9_-.] along with the binary operators "&amp;" and "|" indicating that both operands are
+ * necessary, or the either is necessary. The following are valid expressions for visibility:
+ *
+ * <pre>
+ * A
+ * A|B
+ * (A|B)&amp;(C|D)
+ * orange|(red&amp;yellow)
+ * </pre>
+ *
+ * <p>
+ * The following are not valid expressions for visibility:
+ *
+ * <pre>
+ * A|B&amp;C
+ * A=B
+ * A|B|
+ * A&amp;|B
+ * ()
+ * )
+ * dog|!cat
+ * </pre>
+ *
+ * <p>
+ * In addition to the base set of visibilities, any character can be used in the expression if it is quoted. If the quoted term contains '&quot;' or '\', then
+ * escape the character with '\'. The {@link #quote(String)} method can be used to properly quote and escape terms automatically. The following is an example of
+ * a quoted term:
+ *
+ * <pre>
+ * &quot;A#C&quot; &amp; B
+ * </pre>
+ */
+public class DocumentVisibility extends ColumnVisibility {
+    /**
+     * Creates an empty visibility. Normally, elements with empty visibility can be seen by everyone. Though, one could change this behavior with filters.
+     *
+     * @see #DocumentVisibility(String)
+     */
+    public DocumentVisibility() {
+        super();
+    }
+
+    /**
+     * Creates a document visibility for a Mutation.
+     *
+     * @param expression
+     *          An expression of the rights needed to see this mutation. The expression syntax is defined at the class-level documentation
+     */
+    public DocumentVisibility(final String expression) {
+        super(expression);
+    }
+
+    /**
+     * Creates a document visibility for a Mutation.
+     *
+     * @param expression
+     *          visibility expression
+     * @see #DocumentVisibility(String)
+     */
+    public DocumentVisibility(final Text expression) {
+        super(expression);
+    }
+
+    /**
+     * Creates a document visibility for a Mutation from a string already encoded in UTF-8 bytes.
+     *
+     * @param expression
+     *          visibility expression, encoded as UTF-8 bytes
+     * @see #DocumentVisibility(String)
+     */
+    public DocumentVisibility(final byte[] expression) {
+        super(expression);
+    }
+}

--- a/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/document/visibility/DocumentVisibilityAdapter.java
+++ b/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/document/visibility/DocumentVisibilityAdapter.java
@@ -1,0 +1,143 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.mongodb.document.visibility;
+
+import org.apache.log4j.Logger;
+import org.apache.rya.mongodb.MongoDbRdfConstants;
+import org.apache.rya.mongodb.dao.SimpleMongoDBStorageStrategy;
+import org.apache.rya.mongodb.document.util.DocumentVisibilityConversionException;
+import org.apache.rya.mongodb.document.util.DocumentVisibilityUtil;
+
+import com.mongodb.BasicDBList;
+import com.mongodb.BasicDBObject;
+import com.mongodb.BasicDBObjectBuilder;
+import com.mongodb.DBObject;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Serializes the document visibility field of a Rya Statement for use in
+ * MongoDB.
+ * The {@link DBObject} will look like:
+ * <pre>
+ * {@code
+ * {
+ *   "documentVisibility": &lt;array&gt;,
+ * }
+ * </pre>
+ */
+@DefaultAnnotation(NonNull.class)
+public final class DocumentVisibilityAdapter {
+    private static final Logger log = Logger.getLogger(DocumentVisibilityAdapter.class);
+
+    public static final String DOCUMENT_VISIBILITY_KEY = SimpleMongoDBStorageStrategy.DOCUMENT_VISIBILITY;
+
+    /**
+     * Private constructor to prevent instantiation.
+     */
+    private DocumentVisibilityAdapter() {
+    }
+
+    /**
+     * Serializes a document visibility expression byte array to a MongoDB
+     * {@link DBObject}.
+     * @param expression the document visibility expression byte array to be
+     * serialized.
+     * @return The MongoDB {@link DBObject}.
+     */
+    public static BasicDBObject toDBObject(final byte[] expression) {
+        DocumentVisibility dv;
+        if (expression == null) {
+            dv = MongoDbRdfConstants.EMPTY_DV;
+        } else {
+            dv = new DocumentVisibility(expression);
+        }
+        return toDBObject(dv);
+    }
+
+    /**
+     * Serializes a {@link DocumentVisibility} to a MongoDB {@link DBObject}.
+     * @param documentVisibility the {@link DocumentVisibility} to be
+     * serialized.
+     * @return The MongoDB {@link DBObject}.
+     */
+    public static BasicDBObject toDBObject(final DocumentVisibility documentVisibility) {
+        DocumentVisibility dv;
+        if (documentVisibility == null) {
+            dv = MongoDbRdfConstants.EMPTY_DV;
+        } else {
+            dv = documentVisibility;
+        }
+        Object[] dvArray = null;
+        try {
+            dvArray = DocumentVisibilityUtil.toMultidimensionalArray(dv);
+        } catch (final DocumentVisibilityConversionException e) {
+            log.error("Unable to convert document visibility");
+        }
+
+        final BasicDBObjectBuilder builder = BasicDBObjectBuilder.start();
+        builder.add(DOCUMENT_VISIBILITY_KEY, dvArray);
+        return (BasicDBObject) builder.get();
+    }
+
+    /**
+     * Deserializes a MongoDB {@link DBObject} to a {@link DocumentVisibility}.
+     * @param mongoObj the {@link DBObject} to be deserialized.
+     * @return the {@link DocumentVisibility} object.
+     * @throws MalformedDocumentVisibilityException
+     */
+    public static DocumentVisibility toDocumentVisibility(final DBObject mongoObj) throws MalformedDocumentVisibilityException {
+        try {
+            final BasicDBObject basicObj = (BasicDBObject) mongoObj;
+
+            final Object documentVisibilityObject = basicObj.get(DOCUMENT_VISIBILITY_KEY);
+            Object[] documentVisibilityArray = null;
+            if (documentVisibilityObject instanceof Object[]) {
+                documentVisibilityArray = (Object[]) documentVisibilityObject;
+            } else if (documentVisibilityObject instanceof BasicDBList) {
+                documentVisibilityArray = DocumentVisibilityUtil.convertBasicDBListToObjectArray((BasicDBList) documentVisibilityObject);
+            }
+
+            final String documentVisibilityString = DocumentVisibilityUtil.multidimensionalArrayToBooleanString(documentVisibilityArray);
+            final DocumentVisibility dv = documentVisibilityString == null ? MongoDbRdfConstants.EMPTY_DV : new DocumentVisibility(documentVisibilityString);
+
+            return dv;
+        } catch(final Exception e) {
+            throw new MalformedDocumentVisibilityException("Failed to make Document Visibility from Mongo Object, it is malformed.", e);
+        }
+    }
+
+    /**
+     * Exception thrown when a MongoDB {@link DBObject} is malformed when
+     * attempting to adapt it into a {@link DocumentVisibility}.
+     */
+    public static class MalformedDocumentVisibilityException extends Exception {
+        private static final long serialVersionUID = 1L;
+
+        /**
+         * Creates a new {@link MalformedDocumentVisibilityException}
+         * @param message - The message to be displayed by the exception.
+         * @param e - The source cause of the exception.
+         */
+        public MalformedDocumentVisibilityException(final String message, final Throwable e) {
+            super(message, e);
+        }
+    }
+}

--- a/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/iter/RyaStatementBindingSetCursorIterator.java
+++ b/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/iter/RyaStatementBindingSetCursorIterator.java
@@ -1,5 +1,3 @@
-package org.apache.rya.mongodb.iter;
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -8,9 +6,9 @@ package org.apache.rya.mongodb.iter;
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -18,108 +16,125 @@ package org.apache.rya.mongodb.iter;
  * specific language governing permissions and limitations
  * under the License.
  */
+package org.apache.rya.mongodb.iter;
 
-
-import info.aduna.iteration.CloseableIteration;
-
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map.Entry;
 
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.log4j.Logger;
 import org.apache.rya.api.RdfCloudTripleStoreUtils;
 import org.apache.rya.api.domain.RyaStatement;
 import org.apache.rya.api.persist.RyaDAOException;
 import org.apache.rya.mongodb.dao.MongoDBStorageStrategy;
-
+import org.apache.rya.mongodb.document.operators.aggregation.AggregationUtil;
 import org.openrdf.query.BindingSet;
 
 import com.google.common.collect.Multimap;
+import com.mongodb.AggregationOutput;
+import com.mongodb.BasicDBObject;
 import com.mongodb.DBCollection;
-import com.mongodb.DBCursor;
 import com.mongodb.DBObject;
 
+import info.aduna.iteration.CloseableIteration;
+
 public class RyaStatementBindingSetCursorIterator implements CloseableIteration<Entry<RyaStatement, BindingSet>, RyaDAOException> {
+    private static final Logger log = Logger.getLogger(RyaStatementBindingSetCursorIterator.class);
 
-	private DBCollection coll;
-	private Multimap<DBObject, BindingSet> rangeMap;
-	private Iterator<DBObject> queryIterator;
-	private Long maxResults;
-	private DBCursor resultCursor;
-	private RyaStatement currentStatement;
-	private Collection<BindingSet> currentBindingSetCollection;
-	private Iterator<BindingSet> currentBindingSetIterator;
-	private MongoDBStorageStrategy strategy;
+    private final DBCollection coll;
+    private final Multimap<DBObject, BindingSet> rangeMap;
+    private final Iterator<DBObject> queryIterator;
+    private Long maxResults;
+    private Iterator<DBObject> resultsIterator;
+    private RyaStatement currentStatement;
+    private Collection<BindingSet> currentBindingSetCollection;
+    private Iterator<BindingSet> currentBindingSetIterator;
+    private final MongoDBStorageStrategy<RyaStatement> strategy;
+    private final Authorizations auths;
 
-	public RyaStatementBindingSetCursorIterator(DBCollection coll,
-			Multimap<DBObject, BindingSet> rangeMap, MongoDBStorageStrategy strategy) {
-		this.coll = coll;
-		this.rangeMap = rangeMap;
-		this.queryIterator = rangeMap.keySet().iterator();
-		this.strategy = strategy;
-	}
+    public RyaStatementBindingSetCursorIterator(final DBCollection coll,
+            final Multimap<DBObject, BindingSet> rangeMap, final MongoDBStorageStrategy<RyaStatement> strategy, final Authorizations auths) {
+        this.coll = coll;
+        this.rangeMap = rangeMap;
+        this.queryIterator = rangeMap.keySet().iterator();
+        this.strategy = strategy;
+        this.auths = auths;
+    }
 
-	@Override
-	public boolean hasNext() {
-		if (!currentBindingSetIteratorIsValid()) {
-			findNextResult();
-		}
-		return currentBindingSetIteratorIsValid();
-	}
+    @Override
+    public boolean hasNext() {
+        if (!currentBindingSetIteratorIsValid()) {
+            findNextResult();
+        }
+        return currentBindingSetIteratorIsValid();
+    }
 
-	@Override
-	public Entry<RyaStatement, BindingSet> next() {
-		if (!currentBindingSetIteratorIsValid()) {
-			findNextResult();
-		}
-		if (currentBindingSetIteratorIsValid()) {
-			BindingSet currentBindingSet = currentBindingSetIterator.next();
-			return new RdfCloudTripleStoreUtils.CustomEntry<RyaStatement, BindingSet>(currentStatement, currentBindingSet);
-		}
-		return null;
-	}
-	
-	private boolean currentBindingSetIteratorIsValid() {
-		return (currentBindingSetIterator != null) && currentBindingSetIterator.hasNext();
-	}
+    @Override
+    public Entry<RyaStatement, BindingSet> next() {
+        if (!currentBindingSetIteratorIsValid()) {
+            findNextResult();
+        }
+        if (currentBindingSetIteratorIsValid()) {
+            final BindingSet currentBindingSet = currentBindingSetIterator.next();
+            return new RdfCloudTripleStoreUtils.CustomEntry<RyaStatement, BindingSet>(currentStatement, currentBindingSet);
+        }
+        return null;
+    }
 
-	private void findNextResult() {
-		if (!currentResultCursorIsValid()) {
-			findNextValidResultCursor();
-		}
-		if (currentResultCursorIsValid()) {
-			// convert to Rya Statement
-			DBObject queryResult = resultCursor.next();
-			currentStatement = strategy.deserializeDBObject(queryResult);
-			currentBindingSetIterator = currentBindingSetCollection.iterator();
-		}
-	}
+    private boolean currentBindingSetIteratorIsValid() {
+        return (currentBindingSetIterator != null) && currentBindingSetIterator.hasNext();
+    }
 
-	private void findNextValidResultCursor() {
-		while (queryIterator.hasNext()){
-			DBObject currentQuery = queryIterator.next();
-			resultCursor = coll.find(currentQuery);
-			currentBindingSetCollection = rangeMap.get(currentQuery);
-			if (resultCursor.hasNext()) return;
-		}
-	}
-	
-	private boolean currentResultCursorIsValid() {
-		return (resultCursor != null) && resultCursor.hasNext();
-	}
+    private void findNextResult() {
+        if (!currentResultCursorIsValid()) {
+            findNextValidResultCursor();
+        }
+        if (currentResultCursorIsValid()) {
+            // convert to Rya Statement
+            final DBObject queryResult = resultsIterator.next();
+            currentStatement = strategy.deserializeDBObject(queryResult);
+            currentBindingSetIterator = currentBindingSetCollection.iterator();
+        }
+    }
+
+    private void findNextValidResultCursor() {
+        while (queryIterator.hasNext()){
+            final DBObject currentQuery = queryIterator.next();
+            currentBindingSetCollection = rangeMap.get(currentQuery);
+            // Executing redact aggregation to only return documents the user
+            // has access to.
+            final List<DBObject> pipeline = new ArrayList<>();
+            pipeline.add(new BasicDBObject("$match", currentQuery));
+            pipeline.addAll(AggregationUtil.createRedactPipeline(auths));
+            log.debug(pipeline);
+            final AggregationOutput output = coll.aggregate(pipeline);
+            resultsIterator = output.results().iterator();
+            if (resultsIterator.hasNext()) {
+                break;
+            }
+        }
+    }
+
+    private boolean currentResultCursorIsValid() {
+        return (resultsIterator != null) && resultsIterator.hasNext();
+    }
 
 
-	public void setMaxResults(Long maxResults) {
-		this.maxResults = maxResults;
-	}
+    public void setMaxResults(final Long maxResults) {
+        this.maxResults = maxResults;
+    }
 
-	@Override
-	public void close() throws RyaDAOException {
-		// TODO don't know what to do here
-	}
+    @Override
+    public void close() throws RyaDAOException {
+        // TODO don't know what to do here
+    }
 
-	@Override
-	public void remove() throws RyaDAOException {
-		next();
-	}
+    @Override
+    public void remove() throws RyaDAOException {
+        next();
+    }
 
 }

--- a/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/iter/RyaStatementCursorIterator.java
+++ b/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/iter/RyaStatementCursorIterator.java
@@ -1,5 +1,3 @@
-package org.apache.rya.mongodb.iter;
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -8,9 +6,9 @@ package org.apache.rya.mongodb.iter;
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -18,87 +16,100 @@ package org.apache.rya.mongodb.iter;
  * specific language governing permissions and limitations
  * under the License.
  */
+package org.apache.rya.mongodb.iter;
 
-
-import info.aduna.iteration.CloseableIteration;
-
+import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.Map.Entry;
+import java.util.List;
 import java.util.Set;
 
-import org.apache.rya.api.RdfCloudTripleStoreUtils;
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.log4j.Logger;
 import org.apache.rya.api.domain.RyaStatement;
 import org.apache.rya.api.persist.RyaDAOException;
 import org.apache.rya.mongodb.dao.MongoDBStorageStrategy;
+import org.apache.rya.mongodb.document.operators.aggregation.AggregationUtil;
 
-import org.calrissian.mango.collect.CloseableIterable;
-import org.openrdf.query.BindingSet;
-
+import com.mongodb.AggregationOutput;
+import com.mongodb.BasicDBObject;
 import com.mongodb.DBCollection;
-import com.mongodb.DBCursor;
 import com.mongodb.DBObject;
 
+import info.aduna.iteration.CloseableIteration;
+
 public class RyaStatementCursorIterator implements CloseableIteration<RyaStatement, RyaDAOException> {
+    private static final Logger log = Logger.getLogger(RyaStatementCursorIterator.class);
 
-	private DBCollection coll;
-	private Iterator<DBObject> queryIterator;
-	private DBCursor currentCursor;
-	private MongoDBStorageStrategy strategy;
-	private Long maxResults;
+    private final DBCollection coll;
+    private final Iterator<DBObject> queryIterator;
+    private Iterator<DBObject> resultsIterator;
+    private final MongoDBStorageStrategy<RyaStatement> strategy;
+    private Long maxResults;
+    private final Authorizations auths;
 
-	public RyaStatementCursorIterator(DBCollection coll, Set<DBObject> queries, MongoDBStorageStrategy strategy) {
-		this.coll = coll;
-		this.queryIterator = queries.iterator();
-		this.strategy = strategy;
-	}
+    public RyaStatementCursorIterator(final DBCollection coll, final Set<DBObject> queries, final MongoDBStorageStrategy<RyaStatement> strategy, final Authorizations auths) {
+        this.coll = coll;
+        this.queryIterator = queries.iterator();
+        this.strategy = strategy;
+        this.auths = auths;
+    }
 
-	@Override
-	public boolean hasNext() {
-		if (!currentCursorIsValid()) {
-			findNextValidCursor();
-		}
-		return currentCursorIsValid();
-	}
+    @Override
+    public boolean hasNext() {
+        if (!currentCursorIsValid()) {
+            findNextValidCursor();
+        }
+        return currentCursorIsValid();
+    }
 
-	@Override
-	public RyaStatement next() {
-		if (!currentCursorIsValid()) {
-			findNextValidCursor();
-		}
-		if (currentCursorIsValid()) {
-			// convert to Rya Statement
-			DBObject queryResult = currentCursor.next();
-			RyaStatement statement = strategy.deserializeDBObject(queryResult);
-			return statement;
-		}
-		return null;
-	}
-	
-	private void findNextValidCursor() {
-		while (queryIterator.hasNext()){
-			DBObject currentQuery = queryIterator.next();
-			currentCursor = coll.find(currentQuery);
-			if (currentCursor.hasNext()) break;
-		}
-	}
-	
-	private boolean currentCursorIsValid() {
-		return (currentCursor != null) && currentCursor.hasNext();
-	}
+    @Override
+    public RyaStatement next() {
+        if (!currentCursorIsValid()) {
+            findNextValidCursor();
+        }
+        if (currentCursorIsValid()) {
+            // convert to Rya Statement
+            final DBObject queryResult = resultsIterator.next();
+            final RyaStatement statement = strategy.deserializeDBObject(queryResult);
+            return statement;
+        }
+        return null;
+    }
+
+    private void findNextValidCursor() {
+        while (queryIterator.hasNext()){
+            final DBObject currentQuery = queryIterator.next();
+
+            // Executing redact aggregation to only return documents the user
+            // has access to.
+            final List<DBObject> pipeline = new ArrayList<>();
+            pipeline.add(new BasicDBObject("$match", currentQuery));
+            pipeline.addAll(AggregationUtil.createRedactPipeline(auths));
+            log.debug(pipeline);
+            final AggregationOutput output = coll.aggregate(pipeline);
+            resultsIterator = output.results().iterator();
+            if (resultsIterator.hasNext()) {
+                break;
+            }
+        }
+    }
+
+    private boolean currentCursorIsValid() {
+        return (resultsIterator != null) && resultsIterator.hasNext();
+    }
 
 
-	public void setMaxResults(Long maxResults) {
-		this.maxResults = maxResults;
-	}
+    public void setMaxResults(final Long maxResults) {
+        this.maxResults = maxResults;
+    }
 
-	@Override
-	public void close() throws RyaDAOException {
-		// TODO don't know what to do here
-	}
+    @Override
+    public void close() throws RyaDAOException {
+        // TODO don't know what to do here
+    }
 
-	@Override
-	public void remove() throws RyaDAOException {
-		next();
-	}
-
+    @Override
+    public void remove() throws RyaDAOException {
+        next();
+    }
 }

--- a/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/MongoDBRyaDAOIT.java
+++ b/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/MongoDBRyaDAOIT.java
@@ -18,25 +18,32 @@ package org.apache.rya.mongodb;
  * under the License.
  */
 
+import static org.apache.rya.mongodb.dao.SimpleMongoDBStorageStrategy.DOCUMENT_VISIBILITY;
 import static org.apache.rya.mongodb.dao.SimpleMongoDBStorageStrategy.TIMESTAMP;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 
+import org.apache.accumulo.core.security.Authorizations;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.rya.api.RdfCloudTripleStoreConfiguration;
 import org.apache.rya.api.domain.RyaStatement;
 import org.apache.rya.api.domain.RyaStatement.RyaStatementBuilder;
 import org.apache.rya.api.domain.RyaURI;
 import org.apache.rya.api.persist.RyaDAOException;
+import org.apache.rya.api.persist.query.RyaQuery;
+import org.apache.rya.mongodb.document.util.AuthorizationsUtil;
+import org.apache.rya.mongodb.document.visibility.DocumentVisibility;
+import org.bson.Document;
+import org.calrissian.mango.collect.CloseableIterable;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.mongodb.DB;
-import com.mongodb.DBCollection;
-import com.mongodb.DBObject;
 import com.mongodb.MongoException;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
 
 public class MongoDBRyaDAOIT extends MongoRyaTestBase {
 
@@ -45,23 +52,24 @@ public class MongoDBRyaDAOIT extends MongoRyaTestBase {
 
     @Before
     public void setUp() throws IOException, RyaDAOException{
-           final Configuration conf = new Configuration();
-            conf.set(MongoDBRdfConfiguration.MONGO_DB_NAME, "test");
-            conf.set(MongoDBRdfConfiguration.MONGO_COLLECTION_PREFIX, "rya_");
-            conf.set(RdfCloudTripleStoreConfiguration.CONF_TBL_PREFIX, "rya_");
-            configuration = new MongoDBRdfConfiguration(conf);
-            final int port = mongoClient.getServerAddressList().get(0).getPort();
-            configuration.set(MongoDBRdfConfiguration.MONGO_INSTANCE_PORT, Integer.toString(port));
-            dao = new MongoDBRyaDAO(configuration, mongoClient);
+        final Configuration conf = new Configuration();
+        conf.set(MongoDBRdfConfiguration.MONGO_DB_NAME, "test");
+        conf.set(MongoDBRdfConfiguration.MONGO_COLLECTION_PREFIX, "rya_");
+        conf.set(RdfCloudTripleStoreConfiguration.CONF_TBL_PREFIX, "rya_");
+        configuration = new MongoDBRdfConfiguration(conf);
+        configuration.setAuths("A", "B", "C");
+        final int port = mongoClient.getServerAddressList().get(0).getPort();
+        configuration.set(MongoDBRdfConfiguration.MONGO_INSTANCE_PORT, Integer.toString(port));
+        dao = new MongoDBRyaDAO(configuration, mongoClient);
     }
 
     @Test
     public void testDeleteWildcard() throws RyaDAOException {
         final RyaStatementBuilder builder = new RyaStatementBuilder();
         builder.setPredicate(new RyaURI("http://temp.com"));
+        builder.setColumnVisibility(new DocumentVisibility("A").flatten());
         dao.delete(builder.build(), configuration);
     }
-
 
     @Test
     public void testAdd() throws RyaDAOException, MongoException, IOException {
@@ -69,16 +77,18 @@ public class MongoDBRyaDAOIT extends MongoRyaTestBase {
         builder.setPredicate(new RyaURI("http://temp.com"));
         builder.setSubject(new RyaURI("http://subject.com"));
         builder.setObject(new RyaURI("http://object.com"));
+        builder.setColumnVisibility(new DocumentVisibility("B").flatten());
 
-        final DB db = mongoClient.getDB(configuration.get(MongoDBRdfConfiguration.MONGO_DB_NAME));
-        final DBCollection coll = db.getCollection(configuration.getTriplesCollectionName());
+        final MongoDatabase db = mongoClient.getDatabase(configuration.get(MongoDBRdfConfiguration.MONGO_DB_NAME));
+        final MongoCollection<Document> coll = db.getCollection(configuration.getTriplesCollectionName());
 
         dao.add(builder.build());
 
         assertEquals(coll.count(),1);
 
-        final DBObject dbo = coll.findOne();
-        assertTrue(dbo.containsField(TIMESTAMP));
+        final Document dbo = coll.find().first();
+        assertTrue(dbo.containsKey(DOCUMENT_VISIBILITY));
+        assertTrue(dbo.containsKey(TIMESTAMP));
     }
 
     @Test
@@ -87,9 +97,10 @@ public class MongoDBRyaDAOIT extends MongoRyaTestBase {
         builder.setPredicate(new RyaURI("http://temp.com"));
         builder.setSubject(new RyaURI("http://subject.com"));
         builder.setObject(new RyaURI("http://object.com"));
+        builder.setColumnVisibility(new DocumentVisibility("C").flatten());
         final RyaStatement statement = builder.build();
-        final DB db = mongoClient.getDB(configuration.get(MongoDBRdfConfiguration.MONGO_DB_NAME));
-        final DBCollection coll = db.getCollection(configuration.getTriplesCollectionName());
+        final MongoDatabase db = mongoClient.getDatabase(configuration.get(MongoDBRdfConfiguration.MONGO_DB_NAME));
+        final MongoCollection<Document> coll = db.getCollection(configuration.getTriplesCollectionName());
 
         dao.add(statement);
 
@@ -108,10 +119,11 @@ public class MongoDBRyaDAOIT extends MongoRyaTestBase {
         builder.setSubject(new RyaURI("http://subject.com"));
         builder.setObject(new RyaURI("http://object.com"));
         builder.setContext(new RyaURI("http://context.com"));
+        builder.setColumnVisibility(new DocumentVisibility("A&B&C").flatten());
         final RyaStatement statement = builder.build();
 
-        final DB db = mongoClient.getDB(configuration.get(MongoDBRdfConfiguration.MONGO_DB_NAME));
-        final DBCollection coll = db.getCollection(configuration.getTriplesCollectionName());
+        final MongoDatabase db = mongoClient.getDatabase(configuration.get(MongoDBRdfConfiguration.MONGO_DB_NAME));
+        final MongoCollection<Document> coll = db.getCollection(configuration.getTriplesCollectionName());
 
         dao.add(statement);
 
@@ -126,5 +138,407 @@ public class MongoDBRyaDAOIT extends MongoRyaTestBase {
         dao.delete(query, configuration);
 
         assertEquals(coll.count(),1);
+    }
+
+    @Test
+    public void testVisibility() throws RyaDAOException, MongoException, IOException {
+        // Doc requires "A" and user has "B" = User CANNOT view
+        assertFalse(testVisibilityStatement("A", new Authorizations("B")));
+
+        // Doc requires "A" and user has "A" = User can view
+        assertTrue(testVisibilityStatement("A", new Authorizations("A")));
+
+        // Doc requires "A" and "B" and user has "A" and "B" = User can view
+        assertTrue(testVisibilityStatement("A&B", new Authorizations("A", "B")));
+
+        // Doc requires "A" or "B" and user has "A" and "B" = User can view
+        assertTrue(testVisibilityStatement("A|B", new Authorizations("A", "B")));
+
+        // Doc requires "A" and user has "A" and "B" = User can view
+        assertTrue(testVisibilityStatement("A", new Authorizations("A", "B")));
+
+        // Doc requires "A" and user has "A" and "B" and "C" = User can view
+        assertTrue(testVisibilityStatement("A", new Authorizations("A", "B", "C")));
+
+        // Doc requires "A" and "B" and user has "A" = User CANNOT view
+        assertFalse(testVisibilityStatement("A&B", new Authorizations("A")));
+
+        // Doc requires "A" and "B" and user has "B" = User CANNOT view
+        assertFalse(testVisibilityStatement("A&B", new Authorizations("B")));
+
+        // Doc requires "A" and "B" and user has "C" = User CANNOT view
+        assertFalse(testVisibilityStatement("A&B", new Authorizations("C")));
+
+        // Doc requires "A" and "B" and "C" and user has "A" and "B" and "C" = User can view
+        assertTrue(testVisibilityStatement("A&B&C", new Authorizations("A", "B", "C")));
+
+        // Doc requires "A" and "B" and "C" and user has "A" and "B" = User CANNOT view
+        assertFalse(testVisibilityStatement("A&B&C", new Authorizations("A", "B")));
+
+        // Doc requires "A" and "B" and "C" and user has "A" = User CANNOT view
+        assertFalse(testVisibilityStatement("A&B&C", new Authorizations("A")));
+
+        // Doc requires "A" and "B" and "C" and user has "B" = User CANNOT view
+        assertFalse(testVisibilityStatement("A&B&C", new Authorizations("B")));
+
+        // Doc requires "A" and "B" and "C" and user has "C" = User CANNOT view
+        assertFalse(testVisibilityStatement("A&B&C", new Authorizations("C")));
+
+        // Doc requires "A" and "B" and user has "A" and "B" and "C" = User can view
+        assertTrue(testVisibilityStatement("A&B", new Authorizations("A", "B", "C")));
+
+        // Doc requires "A" or "B" and user has "A" = User can view
+        assertTrue(testVisibilityStatement("A|B", new Authorizations("A")));
+
+        // Doc requires "A" or "B" and user has "B" = User can view
+        assertTrue(testVisibilityStatement("A|B", new Authorizations("B")));
+
+        // Doc requires "A" or "B" and user has "C" = User CANNOT view
+        assertFalse(testVisibilityStatement("A|B", new Authorizations("C")));
+
+        // Doc requires "A" or "B" or "C" and user has "A" and "B" and "C" = User can view
+        assertTrue(testVisibilityStatement("A|B|C", new Authorizations("A", "B", "C")));
+
+        // Doc requires "A" or "B" or "C" and user has "A" and "B" = User can view
+        assertTrue(testVisibilityStatement("A|B|C", new Authorizations("A", "B")));
+
+        // Doc requires "A" or "B" or "C" and user has "A" = User can view
+        assertTrue(testVisibilityStatement("A|B|C", new Authorizations("A")));
+
+        // Doc requires "A" or "B" or "C" and user has "B" = User can view
+        assertTrue(testVisibilityStatement("A|B|C", new Authorizations("B")));
+
+        // Doc requires "A" or "B" or "C" and user has "C" = User can view
+        assertTrue(testVisibilityStatement("A|B|C", new Authorizations("C")));
+
+        // Doc requires "A" or "B" and user has "A" and "B" and "C" = User can view
+        assertTrue(testVisibilityStatement("A|B", new Authorizations("A", "B", "C")));
+
+        // Doc requires "A" and user has ALL_AUTHORIZATIONS = User can view
+        assertTrue(testVisibilityStatement("A", MongoDbRdfConstants.ALL_AUTHORIZATIONS));
+
+        // Doc requires "A" and "B" and user has ALL_AUTHORIZATIONS = User can view
+        assertTrue(testVisibilityStatement("A&B", MongoDbRdfConstants.ALL_AUTHORIZATIONS));
+
+        // Doc requires "A" or "B" and user has ALL_AUTHORIZATIONS = User can view
+        assertTrue(testVisibilityStatement("A|B", MongoDbRdfConstants.ALL_AUTHORIZATIONS));
+
+        // Doc has no requirement and user has ALL_AUTHORIZATIONS = User can view
+        assertTrue(testVisibilityStatement("", MongoDbRdfConstants.ALL_AUTHORIZATIONS));
+
+        // Doc has no requirement and user has "A" = User can view
+        assertTrue(testVisibilityStatement("", new Authorizations("A")));
+
+        // Doc has no requirement and user has "A" and "B" = User can view
+        assertTrue(testVisibilityStatement("", new Authorizations("A", "B")));
+
+        // Doc requires "A" or ("B" and "C") and user has "A" = User can view
+        assertTrue(testVisibilityStatement("A|(B&C)", new Authorizations("A")));
+
+        // Doc requires "A" or ("B" and "C") and user has "B" and "C" = User can view
+        assertTrue(testVisibilityStatement("A|(B&C)", new Authorizations("B", "C")));
+
+        // Doc requires "A" or ("B" and "C") and user has "B" = User CANNOT view
+        assertFalse(testVisibilityStatement("A|(B&C)", new Authorizations("B")));
+
+        // Doc requires "A" or ("B" and "C") and user has "C" = User CANNOT view
+        assertFalse(testVisibilityStatement("A|(B&C)", new Authorizations("C")));
+
+        // Doc requires "A" and ("B" or "C") and user has "A" and "B" = User can view
+        assertTrue(testVisibilityStatement("A&(B|C)", new Authorizations("A", "B")));
+
+        // Doc requires "A" and ("B" or "C") and user has "A" and "B" = User can view
+        assertTrue(testVisibilityStatement("A&(B|C)", new Authorizations("A", "C")));
+
+        // Doc requires "A" and ("B" or "C") and user has "B" and "C" = User CANNOT view
+        assertFalse(testVisibilityStatement("A&(B|C)", new Authorizations("B", "C")));
+
+        // Doc requires "A" and ("B" or "C") and user has "A" = User CANNOT view
+        assertFalse(testVisibilityStatement("A&(B|C)", new Authorizations("A")));
+
+        // Doc requires "A" and ("B" or "C") and user has "B" = User CANNOT view
+        assertFalse(testVisibilityStatement("A&(B|C)", new Authorizations("B")));
+
+        // Doc requires "A" and ("B" or "C") and user has "C" = User can view
+        assertFalse(testVisibilityStatement("A&(B|C)", new Authorizations("C")));
+
+        // Doc requires ("A" and "B") or ("C" and "D") and user has "A" = User CANNOT view
+        assertFalse(testVisibilityStatement("(A&B)|(C&D)", new Authorizations("A")));
+
+        // Doc requires ("A" and "B") or ("C" and "D") and user has "B" = User CANNOT view
+        assertFalse(testVisibilityStatement("(A&B)|(C&D)", new Authorizations("B")));
+
+        // Doc requires ("A" and "B") or ("C" and "D") and user has "C" = User CANNOT view
+        assertFalse(testVisibilityStatement("(A&B)|(C&D)", new Authorizations("C")));
+
+        // Doc requires ("A" and "B") or ("C" and "D") and user has "D" = User CANNOT view
+        assertFalse(testVisibilityStatement("(A&B)|(C&D)", new Authorizations("D")));
+
+        // Doc requires ("A" and "B") or ("C" and "D") and user has "E" = User CANNOT view
+        assertFalse(testVisibilityStatement("(A&B)|(C&D)", new Authorizations("E")));
+
+        // Doc requires ("A" and "B") or ("C" and "D") and user has "A" and "B" = User can view
+        assertTrue(testVisibilityStatement("(A&B)|(C&D)", new Authorizations("A", "B")));
+
+        // Doc requires ("A" and "B") or ("C" and "D") and user has "C" and "D" = User can view
+        assertTrue(testVisibilityStatement("(A&B)|(C&D)", new Authorizations("C", "D")));
+
+        // Doc requires ("A" and "B") or ("C" and "D") and user has "A" and "B" and "E" = User can view
+        assertTrue(testVisibilityStatement("(A&B)|(C&D)", new Authorizations("A", "B", "E")));
+
+        // Doc requires ("A" and "B") or ("C" and "D") and user has "C" and "D" and "E" = User can view
+        assertTrue(testVisibilityStatement("(A&B)|(C&D)", new Authorizations("C", "D", "E")));
+
+        // Doc requires ("A" and "B") or ("C" and "D") and user has "A" and "C" = User CANNOT view
+        assertFalse(testVisibilityStatement("(A&B)|(C&D)", new Authorizations("A", "C")));
+
+        // Doc requires ("A" and "B") or ("C" and "D") and user has "A" and "D" = User CANNOT view
+        assertFalse(testVisibilityStatement("(A&B)|(C&D)", new Authorizations("A", "D")));
+
+        // Doc requires ("A" and "B") or ("C" and "D") and user has "B" and "C" = User CANNOT view
+        assertFalse(testVisibilityStatement("(A&B)|(C&D)", new Authorizations("B", "C")));
+
+        // Doc requires ("A" and "B") or ("C" and "D") and user has "B" and "D" = User CANNOT view
+        assertFalse(testVisibilityStatement("(A&B)|(C&D)", new Authorizations("B", "D")));
+
+        // Doc requires ("A" and "B") or ("C" and "D") and user has "A" and "B" and "C" = User can view
+        assertTrue(testVisibilityStatement("(A&B)|(C&D)", new Authorizations("A", "B", "C")));
+
+        // Doc requires ("A" and "B") or ("C" and "D") and user has "A" and "B" and "C" = User can view
+        assertTrue(testVisibilityStatement("(A&B)|(C&D)", new Authorizations("A", "B", "D")));
+
+        // Doc requires ("A" and "B") or ("C" and "D") and user has "A" and "C" and "D" = User can view
+        assertTrue(testVisibilityStatement("(A&B)|(C&D)", new Authorizations("A", "C", "D")));
+
+        // Doc requires ("A" and "B") or ("C" and "D") and user has "B" and "C" and "D" = User can view
+        assertTrue(testVisibilityStatement("(A&B)|(C&D)", new Authorizations("B", "C", "D")));
+
+        // Doc requires ("A" and "B") or ("C" and "D") and user has "B" and "C" and "D" and "E"= User can view
+        assertTrue(testVisibilityStatement("(A&B)|(C&D)", new Authorizations("B", "C", "D", "E")));
+
+        // Doc requires ("A" and "B") or ("C" and "D") and user has "A" and "B" and "C" and "D" = User can view
+        assertTrue(testVisibilityStatement("(A&B)|(C&D)", new Authorizations("A", "B", "C", "D")));
+
+        // Doc requires ("A" and "B") or ("C" and "D") and user has "A" and "B" and "C" and "D" and "E" = User can view
+        assertTrue(testVisibilityStatement("(A&B)|(C&D)", new Authorizations("A", "B", "C", "D", "E")));
+
+        // Doc requires ("A" or "B") and ("C" or "D") and user has "A" = User CANNOT view
+        assertFalse(testVisibilityStatement("(A|B)&(C|D)", new Authorizations("A")));
+
+        // Doc requires ("A" or "B") and ("C" or "D") and user has "B" = User CANNOT view
+        assertFalse(testVisibilityStatement("(A|B)&(C|D)", new Authorizations("B")));
+
+        // Doc requires ("A" or "B") and ("C" or "D") and user has "C" = User CANNOT view
+        assertFalse(testVisibilityStatement("(A|B)&(C|D)", new Authorizations("C")));
+
+        // Doc requires ("A" or "B") and ("C" or "D") and user has "D" = User CANNOT view
+        assertFalse(testVisibilityStatement("(A|B)&(C|D)", new Authorizations("D")));
+
+        // Doc requires ("A" or "B") and ("C" or "D") and user has "E" = User CANNOT view
+        assertFalse(testVisibilityStatement("(A|B)&(C|D)", new Authorizations("E")));
+
+        // Doc requires ("A" or "B") and ("C" or "D") and user has "A" and "B" = User CANNOT view
+        assertFalse(testVisibilityStatement("(A|B)&(C|D)", new Authorizations("A", "B")));
+
+        // Doc requires ("A" or "B") and ("C" or "D") and user has "C" and "D" = User CANNOT view
+        assertFalse(testVisibilityStatement("(A|B)&(C|D)", new Authorizations("C", "D")));
+
+        // Doc requires ("A" or "B") and ("C" or "D") and user has "A" and "B" and "E" = User CANNOT view
+        assertFalse(testVisibilityStatement("(A|B)&(C|D)", new Authorizations("A", "B", "E")));
+
+        // Doc requires ("A" or "B") and ("C" or "D") and user has "C" and "D" and "E" = User CANNOT view
+        assertFalse(testVisibilityStatement("(A|B)&(C|D)", new Authorizations("C", "D", "E")));
+
+        // Doc requires ("A" or "B") and ("C" or "D") and user has "A" and "C" = User can view
+        assertTrue(testVisibilityStatement("(A|B)&(C|D)", new Authorizations("A", "C")));
+
+        // Doc requires ("A" or "B") and ("C" or "D") and user has "A" and "D" = User can view
+        assertTrue(testVisibilityStatement("(A|B)&(C|D)", new Authorizations("A", "D")));
+
+        // Doc requires ("A" or "B") and ("C" or "D") and user has "B" and "C" = User can view
+        assertTrue(testVisibilityStatement("(A|B)&(C|D)", new Authorizations("B", "C")));
+
+        // Doc requires ("A" or "B") and ("C" or "D") and user has "B" and "D" = User can view
+        assertTrue(testVisibilityStatement("(A|B)&(C|D)", new Authorizations("B", "D")));
+
+        // Doc requires ("A" or "B") and ("C" or "D") and user has "B" and "D" and "E" = User can view
+        assertTrue(testVisibilityStatement("(A|B)&(C|D)", new Authorizations("B", "D", "E")));
+
+        // Doc requires ("A" or "B") and ("C" or "D") and user has "A" and "B" and "C" = User can view
+        assertTrue(testVisibilityStatement("(A|B)&(C|D)", new Authorizations("A", "B", "C")));
+
+        // Doc requires ("A" or "B") and ("C" or "D") and user has "A" and "B" and "C" = User can view
+        assertTrue(testVisibilityStatement("(A|B)&(C|D)", new Authorizations("A", "B", "D")));
+
+        // Doc requires ("A" or "B") and ("C" or "D") and user has "A" and "C" and "D" = User can view
+        assertTrue(testVisibilityStatement("(A|B)&(C|D)", new Authorizations("A", "C", "D")));
+
+        // Doc requires ("A" or "B") and ("C" or "D") and user has "B" and "C" and "D" = User can view
+        assertTrue(testVisibilityStatement("(A|B)&(C|D)", new Authorizations("B", "C", "D")));
+
+        // Doc requires ("A" or "B") and ("C" or "D") and user has "B" and "C" and "D" and "E"= User can view
+        assertTrue(testVisibilityStatement("(A|B)&(C|D)", new Authorizations("B", "C", "D", "E")));
+
+        // Doc requires ("A" or "B") and ("C" or "D") and user has "A" and "B" and "C" and "D" = User can view
+        assertTrue(testVisibilityStatement("(A|B)&(C|D)", new Authorizations("A", "B", "C", "D")));
+
+        // Doc requires ("A" or "B") and ("C" or "D") and user has "A" and "B" and "C" and "D" and "E" = User can view
+        assertTrue(testVisibilityStatement("(A|B)&(C|D)", new Authorizations("A", "B", "C", "D", "E")));
+
+        // Doc requires "(A|B)&(C|(D&E))" and user has "A" and "C" = User can view
+        assertTrue(testVisibilityStatement("(A|B)&(C|(D&E))", new Authorizations("A", "C")));
+
+        // Doc requires "(A|B)&(C|(D&E))" and user has "B" and "C" = User can view
+        assertTrue(testVisibilityStatement("(A|B)&(C|(D&E))", new Authorizations("B", "C")));
+
+        // Doc requires "(A|B)&(C|(D&E))" and user has "A" and "D" and "E" = User can view
+        assertTrue(testVisibilityStatement("(A|B)&(C|(D&E))", new Authorizations("A", "D", "E")));
+
+        // Doc requires "(A|B)&(C|(D&E))" and user has "B" and "D" and "E" = User can view
+        assertTrue(testVisibilityStatement("(A|B)&(C|(D&E))", new Authorizations("B", "D", "E")));
+
+        // Doc requires "(A|B)&(C|(D&E))" and user has "A" = User CANNOT view
+        assertFalse(testVisibilityStatement("(A|B)&(C|(D&E))", new Authorizations("A")));
+
+        // Doc requires "(A|B)&(C|(D&E))" and user has "B" = User CANNOT view
+        assertFalse(testVisibilityStatement("(A|B)&(C|(D&E))", new Authorizations("B")));
+
+        // Doc requires "(A|B)&(C|(D&E))" and user has "C" = User CANNOT view
+        assertFalse(testVisibilityStatement("(A|B)&(C|(D&E))", new Authorizations("C")));
+
+        // Doc requires "(A|B)&(C|(D&E))" and user has "D" = User CANNOT view
+        assertFalse(testVisibilityStatement("(A|B)&(C|(D&E))", new Authorizations("D")));
+
+        // Doc requires "(A|B)&(C|(D&E))" and user has "E" = User CANNOT view
+        assertFalse(testVisibilityStatement("(A|B)&(C|(D&E))", new Authorizations("E")));
+
+        // Doc requires "(A|B)&(C|(D&E))" and user has "D" and "E" = User CANNOT view
+        assertFalse(testVisibilityStatement("(A|B)&(C|(D&E))", new Authorizations("D", "E")));
+
+        // Doc requires "(A|B)&(C|(D&E))" and user has "A" and "D" = User CANNOT view
+        assertFalse(testVisibilityStatement("(A|B)&(C|(D&E))", new Authorizations("A", "D")));
+
+        // Doc requires "(A|B)&(C|(D&E))" and user has "B" and "E" = User CANNOT view
+        assertFalse(testVisibilityStatement("(A|B)&(C|(D&E))", new Authorizations("B", "E")));
+
+        // Doc requires "A|(B&C&(D|E))" and user has "A" = User can view
+        assertTrue(testVisibilityStatement("A|(B&C&(D|E))", new Authorizations("A")));
+
+        // Doc requires "A|(B&C&(D|E))" and user has "B" and "C" and "D" = User can view
+        assertTrue(testVisibilityStatement("A|(B&C&(D|E))", new Authorizations("B", "C", "D")));
+
+        // Doc requires "A|(B&C&(D|E))" and user has "B" and "C" and "E" = User can view
+        assertTrue(testVisibilityStatement("A|(B&C&(D|E))", new Authorizations("B", "C", "E")));
+
+        // Doc requires "A|(B&C&(D|E))" and user has "B" = User CANNOT view
+        assertFalse(testVisibilityStatement("A|(B&C&(D|E))", new Authorizations("B")));
+
+        // Doc requires "A|(B&C&(D|E))" and user has "C" = User CANNOT view
+        assertFalse(testVisibilityStatement("A|(B&C&(D|E))", new Authorizations("C")));
+
+        // Doc requires "A|(B&C&(D|E))" and user has "D" = User CANNOT view
+        assertFalse(testVisibilityStatement("A|(B&C&(D|E))", new Authorizations("D")));
+
+        // Doc requires "A|(B&C&(D|E))" and user has "E" = User CANNOT view
+        assertFalse(testVisibilityStatement("A|(B&C&(D|E))", new Authorizations("E")));
+
+        // Doc requires "A|(B&C&(D|E))" and user has "B" and "C" = User CANNOT view
+        assertFalse(testVisibilityStatement("A|(B&C&(D|E))", new Authorizations("B", "C")));
+
+        // Doc requires "A|(B&C&(D|E))" and user has "D" and "E" = User CANNOT view
+        assertFalse(testVisibilityStatement("A|(B&C&(D|E))", new Authorizations("D", "E")));
+
+        // Doc requires "A|B|C|D|(E&F&G&H)" and user has "A" = User can view
+        assertTrue(testVisibilityStatement("A|B|C|D|(E&F&G&H)", new Authorizations("A")));
+
+        // Doc requires "A|B|C|D|(E&F&G&H)" and user has "E" = User CANNOT view
+        assertFalse(testVisibilityStatement("A|B|C|D|(E&F&G&H)", new Authorizations("E")));
+
+        // Doc requires "A|B|C|D|(E&F&G&H)" and user has "E" and "F" = User CANNOT view
+        assertFalse(testVisibilityStatement("A|B|C|D|(E&F&G&H)", new Authorizations("E", "F")));
+
+        // Doc requires "A|B|C|D|(E&F&G&H)" and user has "I" = User CANNOT view
+        assertFalse(testVisibilityStatement("A|B|C|D|(E&F&G&H)", new Authorizations("I")));
+
+        // Doc requires "A|B|C|D|(E&F&G&H)" and user has "A" and "I" = User can view
+        assertTrue(testVisibilityStatement("A|B|C|D|(E&F&G&H)", new Authorizations("A", "I")));
+
+        // Doc requires "A|B|C|D|(E&F&G&H)" and user has "E" and "F" and "G" and "H" = User can view
+        assertTrue(testVisibilityStatement("A|B|C|D|(E&F&G&H)", new Authorizations("E", "F", "G", "H")));
+
+        // Doc requires "A|B|C|D|(E&F&G&H)" and user has "E" and "F" and "G" and "H" and "I" = User can view
+        assertTrue(testVisibilityStatement("A|B|C|D|(E&F&G&H)", new Authorizations("E", "F", "G", "H", "I")));
+
+        // Doc has no requirement and user has ALL_AUTHORIZATIONS = User can view
+        assertTrue(testVisibilityStatement(null, MongoDbRdfConstants.ALL_AUTHORIZATIONS));
+
+        // Doc has no requirement and user has "A" = User can view
+        assertTrue(testVisibilityStatement(null, new Authorizations("A")));
+
+        // Doc has no requirement and user has "A" and "B" = User can view
+        assertTrue(testVisibilityStatement(null, new Authorizations("A", "B")));
+
+        // Doc has no requirement and user has no authorizations = User can view
+        assertTrue(testVisibilityStatement(null, null));
+
+        // Doc has no requirement and user has no authorizations = User can view
+        assertTrue(testVisibilityStatement("", null));
+
+        // Doc requires "A" and user has no authorizations = User can view
+        assertTrue(testVisibilityStatement("A", null));
+
+        // Doc requires "A" and "B" and user has no authorizations = User can view
+        assertTrue(testVisibilityStatement("A&B", null));
+
+        // Doc requires "A" or "B" and user has no authorizations = User can view
+        assertTrue(testVisibilityStatement("A|B", null));
+    }
+
+    /**
+     * Generates a test statement with the provided document visibility to
+     * determine if the specified user authorization can view the statement.
+     * @param documentVisibility the document visibility boolean expression
+     * string.
+     * @param userAuthorizations the user authorization strings.
+     * @return {@code true} if provided authorization could access the document
+     * in the collection. {@code false} otherwise.
+     * @throws RyaDAOException
+     */
+    private boolean testVisibilityStatement(final String documentVisibility, final Authorizations userAuthorizations) throws RyaDAOException {
+        final MongoDatabase db = mongoClient.getDatabase(configuration.get(MongoDBRdfConfiguration.MONGO_DB_NAME));
+        final MongoCollection<Document> coll = db.getCollection(configuration.getTriplesCollectionName());
+
+        final RyaStatement statement = buildVisibilityTestRyaStatement(documentVisibility);
+
+        dao.getConf().setAuths(AuthorizationsUtil.getAuthorizationsStringArray(Authorizations.EMPTY));
+        dao.add(statement);
+        dao.getConf().setAuths(AuthorizationsUtil.getAuthorizationsStringArray(userAuthorizations != null ? userAuthorizations : Authorizations.EMPTY));
+
+        assertEquals(coll.count(), 1);
+
+        final MongoDBQueryEngine queryEngine = (MongoDBQueryEngine) dao.getQueryEngine();
+        queryEngine.setConf(configuration);
+        final CloseableIterable<RyaStatement> iter = queryEngine.query(new RyaQuery(statement));
+
+        // Check if user has authorization to view document based on its visibility
+        final boolean hasNext = iter.iterator().hasNext();
+
+        // Reset
+        dao.delete(statement, configuration);
+        assertEquals(coll.count(), 0);
+        dao.getConf().setAuths(AuthorizationsUtil.getAuthorizationsStringArray(Authorizations.EMPTY));
+
+        return hasNext;
+    }
+
+    private static RyaStatement buildVisibilityTestRyaStatement(final String documentVisibility) {
+        final RyaStatementBuilder builder = new RyaStatementBuilder();
+        builder.setPredicate(new RyaURI("http://temp.com"));
+        builder.setSubject(new RyaURI("http://subject.com"));
+        builder.setObject(new RyaURI("http://object.com"));
+        builder.setContext(new RyaURI("http://context.com"));
+        builder.setColumnVisibility(documentVisibility != null ? documentVisibility.getBytes() : null);
+        final RyaStatement statement = builder.build();
+        return statement;
     }
 }

--- a/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/MongoDBRyaDAOTest.java
+++ b/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/MongoDBRyaDAOTest.java
@@ -28,67 +28,68 @@ import org.apache.rya.api.domain.RyaStatement;
 import org.apache.rya.api.domain.RyaStatement.RyaStatementBuilder;
 import org.apache.rya.api.domain.RyaURI;
 import org.apache.rya.api.persist.RyaDAOException;
+import org.bson.Document;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.mongodb.DB;
-import com.mongodb.DBCollection;
 import com.mongodb.MongoException;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
 
 public class MongoDBRyaDAOTest extends MongoRyaTestBase {
 
-	private MongoDBRyaDAO dao;
-	private MongoDBRdfConfiguration configuration;
+    private MongoDBRyaDAO dao;
+    private MongoDBRdfConfiguration configuration;
 
-	@Before
-	public void setUp() throws IOException, RyaDAOException{
-		final Configuration conf = new Configuration();
+    @Before
+    public void setUp() throws IOException, RyaDAOException{
+        final Configuration conf = new Configuration();
         conf.set(MongoDBRdfConfiguration.MONGO_DB_NAME, "test");
         conf.set(MongoDBRdfConfiguration.MONGO_COLLECTION_PREFIX, "rya_");
         conf.set(RdfCloudTripleStoreConfiguration.CONF_TBL_PREFIX, "rya_");
         configuration = new MongoDBRdfConfiguration(conf);
         final int port = mongoClient.getServerAddressList().get(0).getPort();
         configuration.set(MongoDBRdfConfiguration.MONGO_INSTANCE_PORT, ""+port);
-		dao = new MongoDBRyaDAO(configuration, mongoClient);
-	}
+        dao = new MongoDBRyaDAO(configuration, mongoClient);
+    }
 
 
-	@Test
-	public void testDeleteWildcard() throws RyaDAOException {
-		final RyaStatementBuilder builder = new RyaStatementBuilder();
-		builder.setPredicate(new RyaURI("http://temp.com"));
-		dao.delete(builder.build(), configuration);
-	}
+    @Test
+    public void testDeleteWildcard() throws RyaDAOException {
+        final RyaStatementBuilder builder = new RyaStatementBuilder();
+        builder.setPredicate(new RyaURI("http://temp.com"));
+        dao.delete(builder.build(), configuration);
+    }
 
 
-	@Test
-	public void testAdd() throws RyaDAOException, MongoException, IOException {
-		final RyaStatementBuilder builder = new RyaStatementBuilder();
-		builder.setPredicate(new RyaURI("http://temp.com"));
-		builder.setSubject(new RyaURI("http://subject.com"));
-		builder.setObject(new RyaURI("http://object.com"));
+    @Test
+    public void testAdd() throws RyaDAOException, MongoException, IOException {
+        final RyaStatementBuilder builder = new RyaStatementBuilder();
+        builder.setPredicate(new RyaURI("http://temp.com"));
+        builder.setSubject(new RyaURI("http://subject.com"));
+        builder.setObject(new RyaURI("http://object.com"));
 
-		final DB db = mongoClient.getDB(configuration.get(MongoDBRdfConfiguration.MONGO_DB_NAME));
-        final DBCollection coll = db.getCollection(configuration.getTriplesCollectionName());
+        final MongoDatabase db = mongoClient.getDatabase(configuration.get(MongoDBRdfConfiguration.MONGO_DB_NAME));
+        final MongoCollection<Document> coll = db.getCollection(configuration.getTriplesCollectionName());
 
-		dao.add(builder.build());
+        dao.add(builder.build());
 
         assertEquals(coll.count(),1);
 
-	}
+    }
 
-	@Test
-	public void testDelete() throws RyaDAOException, MongoException, IOException {
-		final RyaStatementBuilder builder = new RyaStatementBuilder();
-		builder.setPredicate(new RyaURI("http://temp.com"));
-		builder.setSubject(new RyaURI("http://subject.com"));
-		builder.setObject(new RyaURI("http://object.com"));
-		final RyaStatement statement = builder.build();
+    @Test
+    public void testDelete() throws RyaDAOException, MongoException, IOException {
+        final RyaStatementBuilder builder = new RyaStatementBuilder();
+        builder.setPredicate(new RyaURI("http://temp.com"));
+        builder.setSubject(new RyaURI("http://subject.com"));
+        builder.setObject(new RyaURI("http://object.com"));
+        final RyaStatement statement = builder.build();
 
-		final DB db = mongoClient.getDB(configuration.get(MongoDBRdfConfiguration.MONGO_DB_NAME));
-        final DBCollection coll = db.getCollection(configuration.getTriplesCollectionName());
+        final MongoDatabase db = mongoClient.getDatabase(configuration.get(MongoDBRdfConfiguration.MONGO_DB_NAME));
+        final MongoCollection<Document> coll = db.getCollection(configuration.getTriplesCollectionName());
 
-		dao.add(statement);
+        dao.add(statement);
 
         assertEquals(coll.count(),1);
 
@@ -96,34 +97,32 @@ public class MongoDBRyaDAOTest extends MongoRyaTestBase {
 
         assertEquals(coll.count(),0);
 
-	}
+    }
 
-	@Test
-	public void testDeleteWildcardSubjectWithContext() throws RyaDAOException, MongoException, IOException {
-		final RyaStatementBuilder builder = new RyaStatementBuilder();
-		builder.setPredicate(new RyaURI("http://temp.com"));
-		builder.setSubject(new RyaURI("http://subject.com"));
-		builder.setObject(new RyaURI("http://object.com"));
-		builder.setContext(new RyaURI("http://context.com"));
-		final RyaStatement statement = builder.build();
+    @Test
+    public void testDeleteWildcardSubjectWithContext() throws RyaDAOException, MongoException, IOException {
+        final RyaStatementBuilder builder = new RyaStatementBuilder();
+        builder.setPredicate(new RyaURI("http://temp.com"));
+        builder.setSubject(new RyaURI("http://subject.com"));
+        builder.setObject(new RyaURI("http://object.com"));
+        builder.setContext(new RyaURI("http://context.com"));
+        final RyaStatement statement = builder.build();
 
-		final DB db = mongoClient.getDB(configuration.get(MongoDBRdfConfiguration.MONGO_DB_NAME));
-        final DBCollection coll = db.getCollection(configuration.getTriplesCollectionName());
+        final MongoDatabase db = mongoClient.getDatabase(configuration.get(MongoDBRdfConfiguration.MONGO_DB_NAME));
+        final MongoCollection<Document> coll = db.getCollection(configuration.getTriplesCollectionName());
 
-		dao.add(statement);
+        dao.add(statement);
 
         assertEquals(coll.count(),1);
 
-		final RyaStatementBuilder builder2 = new RyaStatementBuilder();
-		builder2.setPredicate(new RyaURI("http://temp.com"));
-		builder2.setObject(new RyaURI("http://object.com"));
-		builder2.setContext(new RyaURI("http://context3.com"));
-		final RyaStatement query = builder2.build();
+        final RyaStatementBuilder builder2 = new RyaStatementBuilder();
+        builder2.setPredicate(new RyaURI("http://temp.com"));
+        builder2.setObject(new RyaURI("http://object.com"));
+        builder2.setContext(new RyaURI("http://context3.com"));
+        final RyaStatement query = builder2.build();
 
         dao.delete(query, configuration);
 
         assertEquals(coll.count(),1);
-
-	}
-
+    }
 }

--- a/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/document/util/DisjunctiveNormalFormConverterTest.java
+++ b/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/document/util/DisjunctiveNormalFormConverterTest.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.mongodb.document.util;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.apache.accumulo.core.security.ColumnVisibility.Node;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.rya.mongodb.document.visibility.DocumentVisibility;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * Tests the methods of {@link DisjunctiveNormalFormConverter}.
+ */
+public class DisjunctiveNormalFormConverterTest {
+    private static final ImmutableList<Pair<String, String>> INPUT_AND_EXPECTED_BOOLEAN_EXPRESSIONS =
+        ImmutableList.of(
+            Pair.of("A", "A"),
+            Pair.of("A&B", "A&B"),
+            Pair.of("A|B", "A|B"),
+            Pair.of("A&(B|C)", "(A&B)|(A&C)"),
+            Pair.of("A|(B&C)", "A|(B&C)"),
+            Pair.of("HCS|(FDW&TGE&(TS|BX))", "HCS|(BX&FDW&TGE)|(FDW&TGE&TS)")
+        );
+
+    /**
+     * Test truth table with a {@code null} {@link List}.
+     */
+    @Test (expected=NullPointerException.class)
+    public void testTruthTableNullList() {
+        final List<String> list = null;
+        DisjunctiveNormalFormConverter.createTruthTableInputs(list);
+    }
+
+    /**
+     * Test truth table with a {@code null} {@link Node}.
+     */
+    @Test (expected=NullPointerException.class)
+    public void testTruthTableNullNode() {
+        final Node node = null;
+        final byte[] expression = new DocumentVisibility("A").getExpression();
+        DisjunctiveNormalFormConverter.createTruthTableInputs(node, expression);
+    }
+
+    /**
+     * Test truth table with a {@code null} expression.
+     */
+    @Test (expected=NullPointerException.class)
+    public void testTruthTableNullExpression() {
+        final Node node = new DocumentVisibility("A").getParseTree();
+        final byte[] expression = null;
+        DisjunctiveNormalFormConverter.createTruthTableInputs(node, expression);
+    }
+
+    /**
+     * Test truth table with 0 inputs.
+     */
+    @Test
+    public void testTruthTableSize() {
+        final byte[][] truthTable = DisjunctiveNormalFormConverter.createTruthTableInputs(0);
+        final byte[][] expected =
+            {
+                {}
+            };
+        assertArrayEquals(expected, truthTable);
+    }
+
+    /**
+     * Test truth table with 1 inputs
+     */
+    @Test
+    public void testTruthTableSize1() {
+        final byte[][] truthTable = DisjunctiveNormalFormConverter.createTruthTableInputs(1);
+        final byte[][] expected=
+            {
+                {0},
+                {1}
+            };
+        assertArrayEquals(expected, truthTable);
+    }
+
+    /**
+     * Test truth table with 2 inputs from a list..
+     */
+    @Test
+    public void testTruthTableSize2FromList() {
+        final byte[][] truthTable = DisjunctiveNormalFormConverter.createTruthTableInputs(ImmutableList.of("A", "B"));
+        final byte[][] expected =
+            {
+                {0, 0},
+                {0, 1},
+                {1, 0},
+                {1, 1}
+            };
+        assertArrayEquals(expected, truthTable);
+    }
+
+    /**
+     * Test truth table with 3 inputs from a node.
+     */
+    @Test
+    public void testTruthTableSize3FromNode() {
+        final DocumentVisibility dv = new DocumentVisibility("(A&B)|(A&C)");
+        final byte[][] truthTable = DisjunctiveNormalFormConverter.createTruthTableInputs(dv.getParseTree(), dv.getExpression());
+        final byte[][] expected =
+            {
+                {0, 0, 0},
+                {0, 0, 1},
+                {0, 1, 0},
+                {0, 1, 1},
+                {1, 0, 0},
+                {1, 0, 1},
+                {1, 1, 0},
+                {1, 1, 1}
+            };
+        assertArrayEquals(expected, truthTable);
+    }
+
+    /**
+     * Test ability to convert expressions into Disjunctive Normal Form.
+     */
+    @Test
+    public void testConvertToDnf() {
+        for (final Pair<String, String> pair : INPUT_AND_EXPECTED_BOOLEAN_EXPRESSIONS) {
+            final String input = pair.getLeft();
+            final String expected = pair.getRight();
+
+            final DocumentVisibility inputDv = new DocumentVisibility(input);
+            final DocumentVisibility resultDv = DisjunctiveNormalFormConverter.convertToDisjunctiveNormalForm(inputDv);
+
+            assertEquals(expected, new String(resultDv.flatten()));
+        }
+    }
+}

--- a/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/document/util/DocumentVisibilityUtilTest.java
+++ b/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/document/util/DocumentVisibilityUtilTest.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.mongodb.document.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.Arrays;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.log4j.Logger;
+import org.apache.rya.mongodb.document.visibility.DocumentVisibility;
+import org.junit.Test;
+
+import com.google.common.base.Charsets;
+import com.google.common.collect.ImmutableSet;
+
+/**
+ * Tests the methods of {@link DocumentVisibilityUtil}.
+ */
+public class DocumentVisibilityUtilTest {
+    private static final Logger log = Logger.getLogger(DocumentVisibilityUtilTest.class);
+
+    private static final ImmutableSet<Pair<String, String>> INPUT_AND_EXPECTED_BOOLEAN_EXPRESSIONS =
+        ImmutableSet.copyOf(Arrays.asList(
+            Pair.of("", ""),
+            Pair.of("A", "A"),
+            Pair.of("\"A\"", "\"A\""),
+            Pair.of("(A)", "A"),
+            Pair.of("A|B", "A|B"),
+            Pair.of("(A)|(B)|(C)", "A|B|C"),
+            Pair.of("(A|B)", "A|B"),
+            Pair.of("A|B|C", "A|B|C"),
+            Pair.of("(A|B|C)", "A|B|C"),
+            Pair.of("A&B", "A&B"),
+            Pair.of("(A&B)", "A&B"),
+            Pair.of("A&B&C", "A&B&C"),
+            Pair.of("(A&B&C)", "A&B&C"),
+            Pair.of("(A&B)|(C&D)", "(A&B)|(C&D)"),
+            Pair.of("A&(B|C)", "(A&B)|(A&C)"),
+            Pair.of("(A&B)|C", "C|(A&B)"),
+            Pair.of("A|(B&C)", "A|(B&C)"),
+            Pair.of("(A|B)&C", "(A&C)|(B&C)"),
+            Pair.of("(A&B)&(C|D)", "(A&B&C)|(A&B&D)"),
+            Pair.of("(A|B)|(C&D)", "A|B|(C&D)"),
+            Pair.of("(A|B)&(C|D)", "(A&C)|(A&D)|(B&C)|(B&D)"),
+            Pair.of("(A|B)&(C|(D&E))", "(A&C)|(B&C)|(A&D&E)|(B&D&E)"),
+            Pair.of("G|(FDW&TGE)", "G|(FDW&TGE)"),
+            Pair.of("HCS|(FDW&TGE&(TS|BX))", "HCS|(BX&FDW&TGE)|(FDW&TGE&TS)"),
+            Pair.of("\"A&B\"", "\"A&B\""),
+            Pair.of("\"A\"&\"B\"", "\"A\"&\"B\""),
+            Pair.of("\"A\"|\"B\"", "\"A\"|\"B\""),
+            Pair.of("\"A#C\"&B", "\"A#C\"&B"),
+            Pair.of("\"A#C\"&\"B+D\"", "\"A#C\"&\"B+D\""),
+            Pair.of("(A|C)&(B|C)", "C|(A&B)"),
+            Pair.of("(A&B)|(A&C)", "(A&B)|(A&C)")
+
+        ));
+
+    private static final ImmutableSet<String> INVALID_BOOLEAN_EXPRESSIONS =
+        ImmutableSet.of(
+            "A|B&C",
+            "A=B",
+            "A|B|",
+            "A&|B",
+            "()",
+            ")",
+            "dog|!cat"
+        );
+
+    @Test
+    public void testGoodExpressions() throws DocumentVisibilityConversionException {
+        int count = 1;
+        for (final Pair<String, String> pair : INPUT_AND_EXPECTED_BOOLEAN_EXPRESSIONS) {
+            final String booleanExpression = pair.getLeft();
+            final String expected = pair.getRight();
+            log.info("Valid Test: " + count);
+            log.info("Original: " + booleanExpression);
+
+            // Convert to multidimensional array
+            final DocumentVisibility dv = new DocumentVisibility(booleanExpression);
+            final Object[] multidimensionalArray = DocumentVisibilityUtil.toMultidimensionalArray(dv);
+            log.info("Array   : " + Arrays.deepToString(multidimensionalArray));
+
+            // Convert multidimensional array back to string
+            final String booleanStringResult = DocumentVisibilityUtil.multidimensionalArrayToBooleanString(multidimensionalArray);
+            log.info("Result  : " + booleanStringResult);
+
+            // Compare results
+            assertEquals(expected, booleanStringResult);
+            log.info("===========================");
+            count++;
+        }
+    }
+
+    @Test
+    public void testBadExpressions() {
+        int count = 1;
+        for (final String booleanExpression : INVALID_BOOLEAN_EXPRESSIONS) {
+            log.info("Invalid Test: " + count);
+            try {
+                log.info("Original: " + booleanExpression);
+                // Convert to multidimensional array
+                final DocumentVisibility dv = new DocumentVisibility(booleanExpression);
+                final Object[] multidimensionalArray = DocumentVisibilityUtil.toMultidimensionalArray(dv);
+                log.info("Array   : " + Arrays.deepToString(multidimensionalArray));
+
+                // Convert multidimensional array back to string
+                final String booleanString = DocumentVisibilityUtil.multidimensionalArrayToBooleanString(multidimensionalArray);
+                log.info("Result  : " + booleanString);
+
+                // Compare results
+                final String expected = new String(dv.flatten(), Charsets.UTF_8);
+                assertEquals(expected, booleanString);
+                fail("Bad expression passed.");
+            } catch (final Exception e) {
+                // Expected
+            }
+            log.info("===========================");
+            count++;
+        }
+    }
+}

--- a/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/document/visibility/DocumentVisibilityAdapterTest.java
+++ b/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/document/visibility/DocumentVisibilityAdapterTest.java
@@ -1,0 +1,167 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.mongodb.document.visibility;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.rya.mongodb.MongoDbRdfConstants;
+import org.apache.rya.mongodb.document.visibility.DocumentVisibilityAdapter.MalformedDocumentVisibilityException;
+import org.junit.Test;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.util.JSON;
+
+/**
+ * Tests the methods of {@link DocumentVisibilityAdapter}.
+ */
+public class DocumentVisibilityAdapterTest {
+    @Test
+    public void testToDBObject() {
+        final DocumentVisibility dv = new DocumentVisibility("A");
+        final BasicDBObject dbObject = DocumentVisibilityAdapter.toDBObject(dv);
+        final BasicDBObject expected = (BasicDBObject) JSON.parse(
+            "{" +
+                "documentVisibility : [[\"A\"]]" +
+            "}"
+        );
+        assertEquals(expected, dbObject);
+    }
+
+    @Test
+    public void testToDBObject_and() {
+        final DocumentVisibility dv = new DocumentVisibility("A&B&C");
+        final BasicDBObject dbObject = DocumentVisibilityAdapter.toDBObject(dv);
+        final BasicDBObject expected = (BasicDBObject) JSON.parse(
+            "{" +
+                "documentVisibility : [[\"A\", \"B\", \"C\"]]" +
+            "}"
+        );
+        assertEquals(expected, dbObject);
+    }
+
+    @Test
+    public void testToDBObject_or() {
+        final DocumentVisibility dv = new DocumentVisibility("A|B|C");
+        final BasicDBObject dbObject = DocumentVisibilityAdapter.toDBObject(dv);
+        final BasicDBObject expected = (BasicDBObject) JSON.parse(
+            "{" +
+                "documentVisibility : [[\"C\"], [\"B\"], [\"A\"]]" +
+            "}"
+        );
+        assertEquals(expected, dbObject);
+    }
+
+    @Test
+    public void testToDBObject_Expression() {
+        final DocumentVisibility dv = new DocumentVisibility("A&B&C");
+        final BasicDBObject dbObject = DocumentVisibilityAdapter.toDBObject(dv.getExpression());
+        final BasicDBObject expected = (BasicDBObject) JSON.parse(
+            "{" +
+                "documentVisibility : [[\"A\", \"B\", \"C\"]]" +
+            "}"
+        );
+        assertEquals(expected, dbObject);
+    }
+
+    @Test
+    public void testToDBObject_nullExpression() {
+        final BasicDBObject dbObject = DocumentVisibilityAdapter.toDBObject((byte[])null);
+        final BasicDBObject expected = (BasicDBObject) JSON.parse(
+            "{" +
+                "documentVisibility : []" +
+            "}"
+        );
+        assertEquals(expected, dbObject);
+    }
+
+    @Test
+    public void testToDBObject_nullDocumentVisibility() {
+        final BasicDBObject dbObject = DocumentVisibilityAdapter.toDBObject((DocumentVisibility)null);
+        final BasicDBObject expected = (BasicDBObject) JSON.parse(
+            "{" +
+                "documentVisibility : []" +
+            "}"
+        );
+        assertEquals(expected, dbObject);
+    }
+
+    @Test
+    public void testToDBObject_emptyDocumentVisibility() {
+        final BasicDBObject dbObject = DocumentVisibilityAdapter.toDBObject(MongoDbRdfConstants.EMPTY_DV);
+        final BasicDBObject expected = (BasicDBObject) JSON.parse(
+            "{" +
+                "documentVisibility : []" +
+            "}"
+        );
+        assertEquals(expected, dbObject);
+    }
+
+    @Test
+    public void testToDocumentVisibility() throws MalformedDocumentVisibilityException {
+        final BasicDBObject dbObject = (BasicDBObject) JSON.parse(
+            "{" +
+                "documentVisibility : [\"A\"]" +
+            "}"
+        );
+        final DocumentVisibility dv = DocumentVisibilityAdapter.toDocumentVisibility(dbObject);
+        final DocumentVisibility expected = new DocumentVisibility("A");
+        assertEquals(expected, dv);
+    }
+
+    @Test
+    public void testToDocumentVisibility_and() throws MalformedDocumentVisibilityException {
+        final BasicDBObject dbObject = (BasicDBObject) JSON.parse(
+            "{" +
+                "documentVisibility : [\"A\", \"B\", \"C\"]" +
+            "}"
+        );
+        final DocumentVisibility dv = DocumentVisibilityAdapter.toDocumentVisibility(dbObject);
+        final DocumentVisibility expected = new DocumentVisibility("A&B&C");
+        assertEquals(expected, dv);
+    }
+
+    @Test
+    public void testToDocumentVisibility_or() throws MalformedDocumentVisibilityException {
+        final BasicDBObject dbObject = (BasicDBObject) JSON.parse(
+            "{" +
+                "documentVisibility : [[\"A\"], [\"B\"], [\"C\"]]" +
+            "}"
+        );
+        final DocumentVisibility dv = DocumentVisibilityAdapter.toDocumentVisibility(dbObject);
+        final DocumentVisibility expected = new DocumentVisibility("A|B|C");
+        assertEquals(expected, dv);
+    }
+
+    @Test
+    public void testToDocumentVisibility_empty() throws MalformedDocumentVisibilityException {
+        final BasicDBObject dbObject = (BasicDBObject) JSON.parse(
+            "{" +
+                "documentVisibility : []" +
+            "}"
+        );
+        final DocumentVisibility dv = DocumentVisibilityAdapter.toDocumentVisibility(dbObject);
+        final DocumentVisibility expected = MongoDbRdfConstants.EMPTY_DV;
+        assertEquals(expected, dv);
+    }
+
+    @Test (expected=MalformedDocumentVisibilityException.class)
+    public void testToDocumentVisibility_null() throws MalformedDocumentVisibilityException {
+        DocumentVisibilityAdapter.toDocumentVisibility(null);
+    }
+}


### PR DESCRIPTION
## Description
This adds a new field to each document called documentVisibility which
uses a boolean expression to determine if the user can access the document.
The boolean expression is in Disjunctive Normal Formal so that the expression's grouping is simplified enough that MongoDB can run Set operations on it to determine if
the document is viewable.  The expression is stored as an array in MongoDB.

The classes in the package "org.apache.rya.mongodb.document.visibility" are pretty much a copy of the classes that are used by "org.apache.accumulo.core.security.ColumnVisibility" so we don't need to have an Accumulo dependency in a MongoDB component.  If anyone is against that then let me know.

### Tests
Unit Tests

### Links
[Jira](https://issues.apache.org/jira/browse/RYA-119)

### Checklist
- [x] Code Review
- [x] Squash Commits

#### People To Review
@pujav65 
@amihalik 
@isper3at 
@DLotts