### PR TITLE
Rya 222

### DIFF
--- a/extras/indexing/src/main/java/org/apache/rya/indexing/external/fluo/FluoPcjUpdater.java
+++ b/extras/indexing/src/main/java/org/apache/rya/indexing/external/fluo/FluoPcjUpdater.java
@@ -22,17 +22,14 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Collection;
 
-import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
-import edu.umd.cs.findbugs.annotations.NonNull;
-
+import org.apache.fluo.api.client.FluoClient;
 import org.apache.log4j.Logger;
+import org.apache.rya.api.domain.RyaStatement;
 import org.apache.rya.indexing.pcj.fluo.api.InsertTriples;
 import org.apache.rya.indexing.pcj.update.PrecomputedJoinUpdater;
 
-import com.google.common.base.Optional;
-
-import org.apache.fluo.api.client.FluoClient;
-import org.apache.rya.api.domain.RyaStatement;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * Updates the PCJ indices by forwarding the statement additions/removals to
@@ -47,24 +44,21 @@ public class FluoPcjUpdater implements PrecomputedJoinUpdater {
 
     private final FluoClient fluoClient;
     private final InsertTriples insertTriples = new InsertTriples();
-    private final String statementVis;
 
     /**
      * Constructs an instance of {@link FluoPcjUpdater}.
      *
      * @param fluoClient - A connection to the Fluo table new statements will be
      *   inserted into and deleted from. (not null)
-     * @param statementVis - The visibility label that will be applied to all
      *   statements that are inserted via the Fluo PCJ updater. (not null)
      */
-    public FluoPcjUpdater(final FluoClient fluoClient, final String statementVis) {
+    public FluoPcjUpdater(final FluoClient fluoClient) {
         this.fluoClient = checkNotNull(fluoClient);
-        this.statementVis = checkNotNull(statementVis);
     }
 
     @Override
     public void addStatements(final Collection<RyaStatement> statements) throws PcjUpdateException {
-        insertTriples.insert(fluoClient, statements, Optional.of(statementVis));
+        insertTriples.insert(fluoClient, statements);
     }
 
     @Override

--- a/extras/indexing/src/main/java/org/apache/rya/indexing/external/fluo/FluoPcjUpdaterSupplier.java
+++ b/extras/indexing/src/main/java/org/apache/rya/indexing/external/fluo/FluoPcjUpdaterSupplier.java
@@ -25,22 +25,20 @@ import static org.apache.rya.indexing.external.fluo.FluoPcjUpdaterConfig.ACCUMUL
 import static org.apache.rya.indexing.external.fluo.FluoPcjUpdaterConfig.ACCUMULO_USERNAME;
 import static org.apache.rya.indexing.external.fluo.FluoPcjUpdaterConfig.ACCUMULO_ZOOKEEPERS;
 import static org.apache.rya.indexing.external.fluo.FluoPcjUpdaterConfig.FLUO_APP_NAME;
-import static org.apache.rya.indexing.external.fluo.FluoPcjUpdaterConfig.STATEMENT_VISIBILITY;
+
 import org.apache.fluo.api.client.FluoClient;
 import org.apache.fluo.api.client.FluoFactory;
 import org.apache.fluo.api.config.FluoConfiguration;
-
-import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
-import edu.umd.cs.findbugs.annotations.NonNull;
-
+import org.apache.hadoop.conf.Configuration;
 import org.apache.rya.indexing.external.PrecomputedJoinIndexerConfig;
 import org.apache.rya.indexing.external.PrecomputedJoinIndexerConfig.PrecomputedJoinUpdaterType;
-
-import org.apache.hadoop.conf.Configuration;
 import org.apache.rya.indexing.pcj.update.PrecomputedJoinUpdater;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Supplier;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * Creates instances of {@link FluoPcjUpdater} using the values found in a {@link Configuration}.
@@ -81,7 +79,6 @@ public class FluoPcjUpdaterSupplier implements Supplier<PrecomputedJoinUpdater> 
         checkArgument(fluoUpdaterConfig.getAccumuloInstance().isPresent(), "Missing configuration: " + ACCUMULO_INSTANCE);
         checkArgument(fluoUpdaterConfig.getAccumuloUsername().isPresent(), "Missing configuration: " + ACCUMULO_USERNAME);
         checkArgument(fluoUpdaterConfig.getAccumuloPassword().isPresent(), "Missing configuration: " + ACCUMULO_PASSWORD);
-        checkArgument(fluoUpdaterConfig.getStatementVisibility().isPresent(), "Missing configuration: " + STATEMENT_VISIBILITY);
 
         // Fluo configuration values.
         final FluoConfiguration fluoClientConfig = new FluoConfiguration();
@@ -95,7 +92,6 @@ public class FluoPcjUpdaterSupplier implements Supplier<PrecomputedJoinUpdater> 
         fluoClientConfig.setAccumuloPassword( fluoUpdaterConfig.getAccumuloPassword().get() );
 
         final FluoClient fluoClient = FluoFactory.newClient(fluoClientConfig);
-        final String statementVisibilities = fluoUpdaterConfig.getStatementVisibility().get();
-        return new FluoPcjUpdater(fluoClient, statementVisibilities);
+        return new FluoPcjUpdater(fluoClient);
     }
 }

--- a/extras/rya.benchmark/src/main/java/org/apache/rya/benchmark/query/PCJOptimizerBenchmark.java
+++ b/extras/rya.benchmark/src/main/java/org/apache/rya/benchmark/query/PCJOptimizerBenchmark.java
@@ -16,6 +16,24 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+/**
+ll * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.rya.benchmark.query;
 
 import static com.google.common.base.Preconditions.checkArgument;

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/JoinResultUpdater.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/JoinResultUpdater.java
@@ -151,7 +151,8 @@ public class JoinResultUpdater {
 
         // Get the Binding strings
         final String childBindingSetString = valueConverter.convert(childBindingSet, childVarOrder);
-        final String[] childBindingStrings = FluoStringConverter.toBindingStrings(childBindingSetString);
+        String[] childBindingArray = childBindingSetString.split("\u0001");
+        final String[] childBindingStrings = FluoStringConverter.toBindingStrings(childBindingArray[0]);
 
         // Create the prefix that will be used to scan for binding sets of the sibling node.
         // This prefix includes the sibling Node ID and the common variable values from

--- a/extras/rya.pcj.fluo/pcj.fluo.client/src/main/java/org/apache/rya/indexing/pcj/fluo/client/command/NewQueryCommand.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.client/src/main/java/org/apache/rya/indexing/pcj/fluo/client/command/NewQueryCommand.java
@@ -21,17 +21,26 @@ package org.apache.rya.indexing.pcj.fluo.client.command;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+import org.apache.accumulo.core.client.AccumuloException;
+import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.security.Authorizations;
 import org.apache.commons.io.IOUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.rya.accumulo.AccumuloRdfConfiguration;
+import org.apache.rya.accumulo.query.AccumuloRyaQueryEngine;
+import org.apache.rya.api.persist.RyaDAOException;
 import org.apache.rya.indexing.pcj.fluo.api.CreatePcj;
 import org.apache.rya.indexing.pcj.fluo.client.PcjAdminClientCommand;
 import org.apache.rya.indexing.pcj.fluo.client.util.ParsedQueryRequest;
@@ -124,12 +133,14 @@ public class NewQueryCommand implements PcjAdminClientCommand {
             final String pcjId = pcjStorage.createPcj(sparql);
 
             // Tell the Fluo PCJ Updater app to maintain the PCJ.
-            createPcj.withRyaIntegration(pcjId, pcjStorage, fluo, rya);
+            createPcj.withRyaIntegration(pcjId, pcjStorage, fluo, accumulo, ryaTablePrefix);
 
-        } catch (MalformedQueryException | SailException | QueryEvaluationException | PcjException e) {
+        } catch (MalformedQueryException | SailException | QueryEvaluationException | PcjException | RyaDAOException e) {
             throw new ExecutionException("Could not create and load historic matches into the the Fluo app for the query.", e);
         }
 
         log.trace("Finished executing the New Query Command.");
     }
+  
+    
 }

--- a/extras/rya.pcj.fluo/pcj.fluo.demo/src/main/java/org/apache/rya/indexing/pcj/fluo/demo/FluoAndHistoricPcjsDemo.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.demo/src/main/java/org/apache/rya/indexing/pcj/fluo/demo/FluoAndHistoricPcjsDemo.java
@@ -47,9 +47,11 @@ import com.google.common.collect.Sets;
 
 import org.apache.fluo.api.client.FluoClient;
 import org.apache.fluo.api.mini.MiniFluo;
+import org.apache.rya.accumulo.query.AccumuloRyaQueryEngine;
 import org.apache.rya.api.domain.RyaStatement;
 import org.apache.rya.api.domain.RyaType;
 import org.apache.rya.api.domain.RyaURI;
+import org.apache.rya.api.persist.RyaDAOException;
 import org.apache.rya.api.resolver.RyaToRdfConversions;
 import org.apache.rya.rdftriplestore.RyaSailRepository;
 
@@ -177,9 +179,9 @@ public class FluoAndHistoricPcjsDemo implements Demo {
             pcjId = pcjStorage.createPcj(sparql);
 
             // Tell the Fluo app to maintain it.
-            new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, ryaRepo);
+            new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, accumuloConn, ryaTablePrefix);
 
-        } catch (MalformedQueryException | SailException | QueryEvaluationException | PcjException e) {
+        } catch (MalformedQueryException | SailException | QueryEvaluationException | PcjException | RyaDAOException e) {
             throw new DemoExecutionException("Error while using Fluo to compute and export historic matches, so the demo can not continue. Exiting.", e);
         }
 

--- a/extras/rya.pcj.fluo/pcj.fluo.integration/src/test/java/org/apache/rya/indexing/pcj/fluo/api/GetPcjMetadataIT.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.integration/src/test/java/org/apache/rya/indexing/pcj/fluo/api/GetPcjMetadataIT.java
@@ -26,6 +26,7 @@ import java.util.Set;
 
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
+import org.apache.rya.api.persist.RyaDAOException;
 import org.apache.rya.indexing.pcj.fluo.ITBase;
 import org.apache.rya.indexing.pcj.fluo.api.GetPcjMetadata.NotInAccumuloException;
 import org.apache.rya.indexing.pcj.fluo.api.GetPcjMetadata.NotInFluoException;
@@ -49,7 +50,7 @@ import com.google.common.collect.Sets;
 public class GetPcjMetadataIT extends ITBase {
 
     @Test
-    public void getMetadataByQueryId() throws RepositoryException, MalformedQueryException, SailException, QueryEvaluationException, PcjException, NotInFluoException, NotInAccumuloException {
+    public void getMetadataByQueryId() throws RepositoryException, MalformedQueryException, SailException, QueryEvaluationException, PcjException, NotInFluoException, NotInAccumuloException, RyaDAOException {
         final String sparql =
                 "SELECT ?x " +
                   "WHERE { " +
@@ -62,7 +63,7 @@ public class GetPcjMetadataIT extends ITBase {
         final String pcjId = pcjStorage.createPcj(sparql);
 
         // Tell the Fluo app to maintain the PCJ.
-        new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, ryaRepo);
+        new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, accumuloConn, RYA_INSTANCE_NAME);
 
         // Fetch the PCJ's Metadata through the GetPcjMetadata interactor.
         final String queryId = new ListQueryIds().listQueryIds(fluoClient).get(0);
@@ -75,7 +76,7 @@ public class GetPcjMetadataIT extends ITBase {
     }
 
     @Test
-    public void getAllMetadata() throws MalformedQueryException, SailException, QueryEvaluationException, PcjException, NotInFluoException, NotInAccumuloException, AccumuloException, AccumuloSecurityException {
+    public void getAllMetadata() throws MalformedQueryException, SailException, QueryEvaluationException, PcjException, NotInFluoException, NotInAccumuloException, AccumuloException, AccumuloSecurityException, RyaDAOException {
 
         final CreatePcj createPcj = new CreatePcj();
 
@@ -89,7 +90,7 @@ public class GetPcjMetadataIT extends ITBase {
                   "?x <http://worksAt> <http://Chipotle>." +
                 "}";
         final String q1PcjId = pcjStorage.createPcj(q1Sparql);
-        createPcj.withRyaIntegration(q1PcjId, pcjStorage, fluoClient, ryaRepo);
+        createPcj.withRyaIntegration(q1PcjId, pcjStorage, fluoClient, accumuloConn, RYA_INSTANCE_NAME);
 
         final String q2Sparql =
                 "SELECT ?x ?y " +
@@ -98,7 +99,7 @@ public class GetPcjMetadataIT extends ITBase {
                   "?y <http://worksAt> <http://Chipotle>." +
                 "}";
         final String q2PcjId = pcjStorage.createPcj(q2Sparql);
-        createPcj.withRyaIntegration(q2PcjId, pcjStorage, fluoClient, ryaRepo);
+        createPcj.withRyaIntegration(q2PcjId, pcjStorage, fluoClient, accumuloConn, RYA_INSTANCE_NAME);
 
         // Ensure the command returns the correct metadata.
         final Set<PcjMetadata> expected = new HashSet<>();

--- a/extras/rya.pcj.fluo/pcj.fluo.integration/src/test/java/org/apache/rya/indexing/pcj/fluo/api/GetQueryReportIT.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.integration/src/test/java/org/apache/rya/indexing/pcj/fluo/api/GetQueryReportIT.java
@@ -26,6 +26,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.rya.api.domain.RyaStatement;
 import org.apache.rya.indexing.pcj.fluo.ITBase;
 import org.apache.rya.indexing.pcj.fluo.api.GetQueryReport.QueryReport;
 import org.apache.rya.indexing.pcj.fluo.app.query.FluoQuery;
@@ -37,8 +38,6 @@ import org.junit.Test;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.Sets;
-
-import org.apache.rya.api.domain.RyaStatement;
 
 /**
  * Integration tests the methods of {@link GetQueryReportl}.
@@ -79,7 +78,7 @@ public class GetQueryReportIT extends ITBase {
         final String pcjId = pcjStorage.createPcj(sparql);
 
         // Tell the Fluo app to maintain the PCJ.
-        new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, ryaRepo);
+        new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, accumuloConn, RYA_INSTANCE_NAME);
 
         // Stream the data into Fluo.
         new InsertTriples().insert(fluoClient, streamedTriples, Optional.<String>absent());

--- a/extras/rya.pcj.fluo/pcj.fluo.integration/src/test/java/org/apache/rya/indexing/pcj/fluo/integration/CreateDeleteIT.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.integration/src/test/java/org/apache/rya/indexing/pcj/fluo/integration/CreateDeleteIT.java
@@ -84,7 +84,7 @@ public class CreateDeleteIT extends ITBase {
         final String pcjId = pcjStorage.createPcj(sparql);
 
         // Tell the Fluo app to maintain the PCJ.
-        new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, ryaRepo);
+        new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, accumuloConn, RYA_INSTANCE_NAME);
 
         // Verify the end results of the query match the expected results.
         fluo.waitForObservers();

--- a/extras/rya.pcj.fluo/pcj.fluo.integration/src/test/java/org/apache/rya/indexing/pcj/fluo/integration/InputIT.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.integration/src/test/java/org/apache/rya/indexing/pcj/fluo/integration/InputIT.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertTrue;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.apache.rya.api.domain.RyaStatement;
 import org.apache.rya.indexing.pcj.fluo.ITBase;
 import org.apache.rya.indexing.pcj.fluo.api.CreatePcj;
 import org.apache.rya.indexing.pcj.fluo.api.InsertTriples;
@@ -37,8 +38,6 @@ import org.openrdf.query.impl.BindingImpl;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.Sets;
-
-import org.apache.rya.api.domain.RyaStatement;
 
 /**
  * Performs integration tests over the Fluo application geared towards various types of input.
@@ -90,7 +89,7 @@ public class InputIT extends ITBase {
         final String pcjId = pcjStorage.createPcj(sparql);
 
         // Tell the Fluo app to maintain the PCJ.
-        new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, ryaRepo);
+        new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, accumuloConn, RYA_INSTANCE_NAME);
 
         // Verify the end results of the query match the expected results.
         fluo.waitForObservers();
@@ -137,7 +136,7 @@ public class InputIT extends ITBase {
         final String pcjId = pcjStorage.createPcj(sparql);
 
         // Tell the Fluo app to maintain the PCJ.
-        new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, ryaRepo);
+        new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, accumuloConn, RYA_INSTANCE_NAME);
 
         // Ensure the query has no results yet.
         fluo.waitForObservers();
@@ -189,7 +188,7 @@ public class InputIT extends ITBase {
         final String pcjId = pcjStorage.createPcj(sparql);
 
         // Tell the Fluo app to maintain the PCJ.
-        new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, ryaRepo);
+        new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, accumuloConn, RYA_INSTANCE_NAME);
 
         // Ensure Alice is a match.
         fluo.waitForObservers();
@@ -254,7 +253,7 @@ public class InputIT extends ITBase {
         final String pcjId = pcjStorage.createPcj(sparql);
 
         // Tell the Fluo app to maintain the PCJ.
-        new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, ryaRepo);
+        new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, accumuloConn, RYA_INSTANCE_NAME);
 
         // Ensure Alice is a match.
         fluo.waitForObservers();

--- a/extras/rya.pcj.fluo/pcj.fluo.integration/src/test/java/org/apache/rya/indexing/pcj/fluo/integration/QueryIT.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.integration/src/test/java/org/apache/rya/indexing/pcj/fluo/integration/QueryIT.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertEquals;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.apache.rya.api.domain.RyaStatement;
 import org.apache.rya.indexing.pcj.fluo.ITBase;
 import org.apache.rya.indexing.pcj.fluo.api.CreatePcj;
 import org.apache.rya.indexing.pcj.fluo.api.InsertTriples;
@@ -37,8 +38,6 @@ import org.openrdf.query.impl.BindingImpl;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.Sets;
-
-import org.apache.rya.api.domain.RyaStatement;
 
 /**
  * Performs integration tests over the Fluo application geared towards various query structures.
@@ -84,7 +83,7 @@ public class QueryIT extends ITBase {
         final String pcjId = pcjStorage.createPcj(sparql);
 
         // Tell the Fluo app to maintain the PCJ.
-        new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, ryaRepo);
+        new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, accumuloConn, RYA_INSTANCE_NAME);
 
         // Stream the data into Fluo.
         new InsertTriples().insert(fluoClient, streamedTriples, Optional.<String>absent());
@@ -170,7 +169,7 @@ public class QueryIT extends ITBase {
         final String pcjId = pcjStorage.createPcj(sparql);
 
         // Tell the Fluo app to maintain the PCJ.
-        new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, ryaRepo);
+        new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, accumuloConn, RYA_INSTANCE_NAME);
 
         // Stream the data into Fluo.
         new InsertTriples().insert(fluoClient, streamedTriples, Optional.<String>absent());
@@ -235,7 +234,7 @@ public class QueryIT extends ITBase {
         final String pcjId = pcjStorage.createPcj(sparql);
 
         // Tell the Fluo app to maintain the PCJ.
-        new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, ryaRepo);
+        new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, accumuloConn, RYA_INSTANCE_NAME);
 
         // Stream the data into Fluo.
         new InsertTriples().insert(fluoClient, streamedTriples, Optional.<String>absent());
@@ -283,7 +282,7 @@ public class QueryIT extends ITBase {
         final String pcjId = pcjStorage.createPcj(sparql);
 
         // Tell the Fluo app to maintain the PCJ.
-        new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, ryaRepo);
+        new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, accumuloConn, RYA_INSTANCE_NAME);
 
         // Stream the data into Fluo.
         new InsertTriples().insert(fluoClient, streamedTriples, Optional.<String>absent());

--- a/extras/rya.pcj.fluo/pcj.fluo.integration/src/test/java/org/apache/rya/indexing/pcj/fluo/integration/RyaExportIT.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.integration/src/test/java/org/apache/rya/indexing/pcj/fluo/integration/RyaExportIT.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertEquals;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.apache.rya.api.domain.RyaStatement;
 import org.apache.rya.indexing.pcj.fluo.ITBase;
 import org.apache.rya.indexing.pcj.fluo.api.CreatePcj;
 import org.apache.rya.indexing.pcj.fluo.api.InsertTriples;
@@ -35,8 +36,6 @@ import org.openrdf.query.impl.BindingImpl;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.Sets;
-
-import org.apache.rya.api.domain.RyaStatement;
 
 /**
  * Performs integration tests over the Fluo application geared towards Rya PCJ exporting.
@@ -99,7 +98,7 @@ public class RyaExportIT extends ITBase {
         final String pcjId = pcjStorage.createPcj(sparql);
 
         // Tell the Fluo app to maintain the PCJ.
-        new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, ryaRepo);
+        new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, accumuloConn, RYA_INSTANCE_NAME);
 
         // Stream the data into Fluo.
         new InsertTriples().insert(fluoClient, streamedTriples, Optional.<String>absent());

--- a/extras/rya.pcj.fluo/pcj.fluo.integration/src/test/java/org/apache/rya/indexing/pcj/fluo/integration/RyaInputIncrementalUpdateIT.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.integration/src/test/java/org/apache/rya/indexing/pcj/fluo/integration/RyaInputIncrementalUpdateIT.java
@@ -23,9 +23,11 @@ import static org.junit.Assert.assertEquals;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.apache.fluo.api.client.FluoClient;
+import org.apache.rya.accumulo.AccumuloRyaDAO;
+import org.apache.rya.indexing.external.PrecomputedJoinIndexer;
 import org.apache.rya.indexing.pcj.fluo.ITBase;
 import org.apache.rya.indexing.pcj.fluo.api.CreatePcj;
-import org.apache.rya.indexing.pcj.fluo.app.IncUpdateDAO;
 import org.apache.rya.indexing.pcj.storage.PrecomputedJoinStorage;
 import org.apache.rya.indexing.pcj.storage.accumulo.AccumuloPcjStorage;
 import org.apache.rya.indexing.pcj.update.PrecomputedJoinUpdater;
@@ -37,10 +39,6 @@ import org.openrdf.query.impl.BindingImpl;
 import org.openrdf.repository.RepositoryConnection;
 
 import com.google.common.collect.Sets;
-
-import org.apache.fluo.api.client.FluoClient;
-import org.apache.rya.accumulo.AccumuloRyaDAO;
-import org.apache.rya.indexing.external.PrecomputedJoinIndexer;
 
 
 /**
@@ -91,7 +89,7 @@ public class RyaInputIncrementalUpdateIT extends ITBase {
         final String pcjId = pcjStorage.createPcj(sparql);
 
         // Tell the Fluo app to maintain the PCJ.
-        new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, ryaRepo);
+        new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, accumuloConn, RYA_INSTANCE_NAME);
 
         // Verify the end results of the query match the expected results.
         fluo.waitForObservers();
@@ -142,7 +140,7 @@ public class RyaInputIncrementalUpdateIT extends ITBase {
         final String pcjId = pcjStorage.createPcj(sparql);
 
         // Tell the Fluo app to maintain the PCJ.
-        new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, ryaRepo);
+        new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, accumuloConn, RYA_INSTANCE_NAME);
 
         fluo.waitForObservers();
 
@@ -191,7 +189,7 @@ public class RyaInputIncrementalUpdateIT extends ITBase {
         final String pcjId = pcjStorage.createPcj(sparql);
 
         // Tell the Fluo app to maintain the PCJ.
-        new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, ryaRepo);
+        new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, accumuloConn, RYA_INSTANCE_NAME);
 
         fluo.waitForObservers();
 

--- a/extras/rya.pcj.fluo/pcj.fluo.integration/src/test/java/org/apache/rya/indexing/pcj/fluo/integration/StreamingTestIT.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.integration/src/test/java/org/apache/rya/indexing/pcj/fluo/integration/StreamingTestIT.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.indexing.pcj.fluo.integration;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.log4j.Logger;
+import org.apache.rya.accumulo.AccumuloRdfConfiguration;
+import org.apache.rya.indexing.accumulo.ConfigUtils;
+import org.apache.rya.indexing.pcj.fluo.ITBase;
+import org.apache.rya.indexing.pcj.fluo.api.CreatePcj;
+import org.apache.rya.indexing.pcj.storage.PrecomputedJoinStorage;
+import org.apache.rya.indexing.pcj.storage.accumulo.AccumuloPcjStorage;
+import org.apache.rya.indexing.pcj.storage.accumulo.PcjTables;
+import org.apache.rya.sail.config.RyaSailFactory;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openrdf.model.Resource;
+import org.openrdf.model.Statement;
+import org.openrdf.model.impl.LiteralImpl;
+import org.openrdf.model.impl.StatementImpl;
+import org.openrdf.model.impl.URIImpl;
+import org.openrdf.query.BindingSet;
+import org.openrdf.repository.RepositoryException;
+import org.openrdf.repository.sail.SailRepository;
+import org.openrdf.repository.sail.SailRepositoryConnection;
+import org.openrdf.sail.Sail;
+import org.openrdf.sail.SailException;
+
+
+public class StreamingTestIT extends ITBase {
+
+	private static final Logger log = Logger.getLogger(ITBase.class);
+	private static String query = "select ?name ?uuid where {   ?uuid <http://pred1> ?name ; <http://pred2> \"literal\".}";
+	private static String uuidPrefix = "http://uuid_";
+	private static String name = "number_";
+	private static String pred1 = "http://pred1";
+	private static String pred2 = "http://pred2";
+	
+	private PcjTables pcjTables = new PcjTables();
+	private String pcjTableName;
+	
+	private Sail sail;
+	private SailRepository repo;
+	private SailRepositoryConnection conn;
+	
+	
+	@Before
+	public void init() throws Exception {
+		AccumuloRdfConfiguration conf = makeConfig(instanceName, zookeepers);
+		conf.set(ConfigUtils.CLOUDBASE_AUTHS, "U");
+		sail =  RyaSailFactory.getInstance(conf);
+		repo = new SailRepository(sail);
+		conn = repo.getConnection();
+	}
+	
+	@After
+	public void close() throws RepositoryException, SailException {
+		conn.close();
+		repo.shutDown();
+		sail.shutDown();
+	}
+	
+	
+	@Test
+	public void testRandomStreamingIngest() throws Exception {
+		
+		pcjTableName = createPcj(query);
+		log.info("Adding Join Pairs...");
+		addRandomQueryStatementPairs(100);
+		Assert.assertEquals(100, countPcjs());
+		
+	}
+	
+	private String createPcj(String pcj) throws Exception {
+		accumuloConn.securityOperations().changeUserAuthorizations("root", new Authorizations("U"));
+	    // Create the PCJ table.
+        final PrecomputedJoinStorage pcjStorage = new AccumuloPcjStorage(accumuloConn, RYA_INSTANCE_NAME);
+        final String pcjId = pcjStorage.createPcj(pcj);
+		new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, ryaRepo);
+		String tableName = RYA_INSTANCE_NAME + "INDEX_" + pcjId;
+		
+		return tableName;
+	}
+	
+	private void addRandomQueryStatementPairs(int numPairs) throws Exception {
+
+		Set<Statement> statementPairs = new HashSet<>();
+		for (int i = 0; i < numPairs; i++) {
+			String uri = uuidPrefix + UUID.randomUUID().toString();
+			Statement statement1 = new StatementImpl(new URIImpl(uri), new URIImpl(pred1),
+					new LiteralImpl(name + (i + 1)));
+			Statement statement2 = new StatementImpl(new URIImpl(uri), new URIImpl(pred2), new LiteralImpl("literal"));
+			statementPairs.add(statement1);
+			statementPairs.add(statement2);
+		}
+		conn.add(statementPairs, new Resource[0]);
+		fluo.waitForObservers();
+	}
+	
+	private int countPcjs() throws Exception {
+		Iterable<BindingSet> bindingsets = pcjTables.listResults(accumuloConn, pcjTableName, new Authorizations("U"));
+		int count = 0;
+		for (BindingSet bs : bindingsets) {
+//			System.out.println(bs);
+			count++;
+		}
+//		IncUpdateDAO.printAll(fluoClient);
+		return count;
+	}
+	
+	
+}

--- a/extras/rya.pcj.fluo/pcj.fluo.integration/src/test/java/org/apache/rya/indexing/pcj/fluo/integration/StreamingTestIT.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.integration/src/test/java/org/apache/rya/indexing/pcj/fluo/integration/StreamingTestIT.java
@@ -98,7 +98,7 @@ public class StreamingTestIT extends ITBase {
 	    // Create the PCJ table.
         final PrecomputedJoinStorage pcjStorage = new AccumuloPcjStorage(accumuloConn, RYA_INSTANCE_NAME);
         final String pcjId = pcjStorage.createPcj(pcj);
-		new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, ryaRepo);
+        new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, accumuloConn, RYA_INSTANCE_NAME);
 		String tableName = RYA_INSTANCE_NAME + "INDEX_" + pcjId;
 		
 		return tableName;

--- a/extras/rya.pcj.fluo/pcj.fluo.integration/src/test/java/org/apache/rya/indexing/pcj/fluo/visibility/HistoricStreamingVisibilityIT.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.integration/src/test/java/org/apache/rya/indexing/pcj/fluo/visibility/HistoricStreamingVisibilityIT.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.indexing.pcj.fluo.visibility;
+
+import java.io.UnsupportedEncodingException;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.rya.accumulo.AccumuloRdfConfiguration;
+import org.apache.rya.accumulo.AccumuloRyaDAO;
+import org.apache.rya.api.RdfCloudTripleStoreConfiguration;
+import org.apache.rya.api.domain.RyaStatement;
+import org.apache.rya.api.resolver.RdfToRyaConversions;
+import org.apache.rya.indexing.accumulo.ConfigUtils;
+import org.apache.rya.indexing.pcj.fluo.ITBase;
+import org.apache.rya.indexing.pcj.fluo.api.CreatePcj;
+import org.apache.rya.indexing.pcj.storage.PrecomputedJoinStorage;
+import org.apache.rya.indexing.pcj.storage.accumulo.AccumuloPcjStorage;
+import org.junit.Assert;
+import org.junit.Test;
+import org.openrdf.model.Statement;
+import org.openrdf.model.impl.URIImpl;
+import org.openrdf.query.BindingSet;
+import org.openrdf.query.impl.BindingImpl;
+
+import com.google.common.collect.Sets;
+
+/**
+ * Performs integration tests over the Fluo application geared towards various types of input.
+ * <p>
+ * These tests are being ignore so that they will not run as unit tests while building the application.
+ */
+public class HistoricStreamingVisibilityIT extends ITBase {
+
+    /**
+     * Ensure historic matches are included in the result.
+     */
+    @Test
+    public void historicResults() throws Exception {
+        // A query that finds people who talk to Eve and work at Chipotle.
+        final String sparql =
+              "SELECT ?x " +
+                "WHERE { " +
+                "?x <http://talksTo> <http://Eve>. " +
+                "?x <http://worksAt> <http://Chipotle>." +
+              "}";
+        
+        accumuloConn.securityOperations().changeUserAuthorizations(ACCUMULO_USER, new Authorizations("U","V","W"));
+        AccumuloRyaDAO dao = new AccumuloRyaDAO();
+        dao.setConnector(accumuloConn);
+        dao.setConf(makeConfig());
+        dao.init();
+
+        // Triples that are loaded into Rya before the PCJ is created.
+        final Set<RyaStatement> historicTriples = Sets.newHashSet(
+                makeRyaStatement(makeStatement("http://Alice", "http://talksTo", "http://Eve"),"U"),
+                makeRyaStatement(makeStatement("http://Bob", "http://talksTo", "http://Eve"),"V"),
+                makeRyaStatement(makeStatement("http://Charlie", "http://talksTo", "http://Eve"),"W"),
+
+                makeRyaStatement(makeStatement("http://Eve", "http://helps", "http://Kevin"), "U"),
+
+                makeRyaStatement(makeStatement("http://Bob", "http://worksAt", "http://Chipotle"), "W"),
+                makeRyaStatement(makeStatement("http://Charlie", "http://worksAt", "http://Chipotle"), "V"),
+                makeRyaStatement(makeStatement("http://Eve", "http://worksAt", "http://Chipotle"), "U"),
+                makeRyaStatement(makeStatement("http://David", "http://worksAt", "http://Chipotle"), "V"));
+
+        dao.add(historicTriples.iterator());
+        dao.flush();
+        
+        // The expected results of the SPARQL query once the PCJ has been computed.
+        final Set<BindingSet> expected = new HashSet<>();
+        expected.add(makeBindingSet(
+                new BindingImpl("x", new URIImpl("http://Bob"))));
+        expected.add(makeBindingSet(
+                new BindingImpl("x", new URIImpl("http://Charlie"))));
+        
+        // Create the PCJ table.
+        final PrecomputedJoinStorage pcjStorage = new AccumuloPcjStorage(accumuloConn, RYA_INSTANCE_NAME);
+        final String pcjId = pcjStorage.createPcj(sparql);
+
+        new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, accumuloConn, RYA_INSTANCE_NAME);
+
+        // Verify the end results of the query match the expected results.
+        fluo.waitForObservers();
+        Set<BindingSet> results = Sets.newHashSet(pcjStorage.listResults(pcjId));
+        Assert.assertEquals(expected, results);
+    }
+    
+    
+    private AccumuloRdfConfiguration makeConfig() {
+        final AccumuloRdfConfiguration conf = new AccumuloRdfConfiguration();
+        conf.setTablePrefix(RYA_INSTANCE_NAME);
+        // Accumulo connection information.
+        conf.set(ConfigUtils.CLOUDBASE_USER, ACCUMULO_USER);
+        conf.set(ConfigUtils.CLOUDBASE_PASSWORD, ACCUMULO_PASSWORD);
+        conf.set(ConfigUtils.CLOUDBASE_INSTANCE, instanceName);
+        conf.set(ConfigUtils.CLOUDBASE_ZOOKEEPERS, zookeepers);
+        conf.set(RdfCloudTripleStoreConfiguration.CONF_QUERY_AUTH, "U,V,W");
+
+        return conf;
+    }
+    
+    
+    private static RyaStatement makeRyaStatement(Statement statement, String visibility) throws UnsupportedEncodingException {
+    	
+    	RyaStatement ryaStatement = RdfToRyaConversions.convertStatement(statement);
+    	ryaStatement.setColumnVisibility(visibility.getBytes("UTF-8"));
+    	return ryaStatement;
+    	
+    }
+
+
+}


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

  http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
## Description
>What Changed?
Historical results were being ingested into Fluo without column visibilities.  I fixed that.  Also,
the FluoUpdater was being created with it's own visibility, which it appended to the RyaStatements as it added them to Fluo.  This was wrong in a couple of ways.  First, it was using authorizations for it's visibility, which is incorrect.  Secondly, as it is ingesting RyaStatements, it should just use the visibility of the RyaStatement and not overwrite it's own when inserting into Fluo.  I modified the InsertTriples class to read the visibility from the RyaStatement and use that as the visibility when writing to Fluo.  The FluoUpdater now uses the modified InsertTriples class to write RyaStatements with the visibility assigned to the statement.

### Tests
I created an integration test to test that historical results are being added with visibilities.  I fixed another test that broke which tests whether streamed triples are being assigned their visbilities from the RyaStatement.

### Links
[Jira](https://issues.apache.org/jira/browse/RYA-222)

### Checklist
- [ ] Code Review
- [X] Squash Commits

#### People To Reivew
Aaron Mihalik, Puja Valiyil, Andrew Smith
