### PR TITLE
Fix rat issue

### DIFF
--- a/extras/rya.pcj.fluo/pom.xml
+++ b/extras/rya.pcj.fluo/pom.xml
@@ -74,6 +74,24 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+		<groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+            </plugin>
         </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.rat</groupId>
+                        <artifactId>apache-rat-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <!--  Trivial listing of classes to be loaded via SPI -->
+                                <exclude>**/resources/META-INF/services/**</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 </project>


### PR DESCRIPTION
Moved the rat exclude up into the pcj fluo parent pom
so Function gets ignored regardless of profile.

## Description
>What Changed?
Moved rat exclude up one pom.

### Tests
>Coverage?
Ran build locally with geo profile and without

### Links
N/A

### Checklist
- [ ] Code Review
- [x] Squash Commits

#### People To Reivew
@pujav65 
@amihalik 
