### PR TITLE
RYA-266 Added calls to init() where-ever the Accumulo temporal indexer is used for storing

### DIFF
--- a/extras/indexing/src/test/java/org/apache/rya/indexing/accumulo/freetext/AccumuloFreeTextIndexerTest.java
+++ b/extras/indexing/src/test/java/org/apache/rya/indexing/accumulo/freetext/AccumuloFreeTextIndexerTest.java
@@ -93,6 +93,8 @@ public class AccumuloFreeTextIndexerTest {
     public void testSearch() throws Exception {
         try (AccumuloFreeTextIndexer f = new AccumuloFreeTextIndexer()) {
             f.setConf(conf);
+            f.setMultiTableBatchWriter(ConfigUtils.createMultitableBatchWriter(conf));
+            f.init();
 
             ValueFactory vf = new ValueFactoryImpl();
 
@@ -134,6 +136,8 @@ public class AccumuloFreeTextIndexerTest {
     public void testDelete() throws Exception {
         try (AccumuloFreeTextIndexer f = new AccumuloFreeTextIndexer()) {
             f.setConf(conf);
+            f.setMultiTableBatchWriter(ConfigUtils.createMultitableBatchWriter(conf));
+            f.init();
 
             ValueFactory vf = new ValueFactoryImpl();
 
@@ -187,6 +191,8 @@ public class AccumuloFreeTextIndexerTest {
 
         try (AccumuloFreeTextIndexer f = new AccumuloFreeTextIndexer()) {
             f.setConf(conf);
+            f.setMultiTableBatchWriter(ConfigUtils.createMultitableBatchWriter(conf));
+            f.init();
 
             // These should not be stored because they are not in the predicate list
             f.storeStatement(new RyaStatement(new RyaURI("foo:subj1"), new RyaURI(RDFS.LABEL.toString()), new RyaType("invalid")));
@@ -222,6 +228,8 @@ public class AccumuloFreeTextIndexerTest {
     public void testContextSearch() throws Exception {
         try (AccumuloFreeTextIndexer f = new AccumuloFreeTextIndexer()) {
             f.setConf(conf);
+            f.setMultiTableBatchWriter(ConfigUtils.createMultitableBatchWriter(conf));
+            f.init();
 
             ValueFactory vf = new ValueFactoryImpl();
             URI subject = new URIImpl("foo:subj");

--- a/mapreduce/src/main/java/org/apache/rya/accumulo/mr/RyaOutputFormat.java
+++ b/mapreduce/src/main/java/org/apache/rya/accumulo/mr/RyaOutputFormat.java
@@ -45,9 +45,6 @@ import org.apache.hadoop.mapreduce.RecordWriter;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.lib.output.NullOutputFormat;
 import org.apache.log4j.Logger;
-import org.openrdf.model.Statement;
-import org.openrdf.model.vocabulary.XMLSchema;
-
 import org.apache.rya.accumulo.AccumuloRdfConfiguration;
 import org.apache.rya.accumulo.AccumuloRdfConstants;
 import org.apache.rya.accumulo.AccumuloRyaDAO;
@@ -64,6 +61,8 @@ import org.apache.rya.indexing.accumulo.ConfigUtils;
 import org.apache.rya.indexing.accumulo.entity.EntityCentricIndex;
 import org.apache.rya.indexing.accumulo.freetext.AccumuloFreeTextIndexer;
 import org.apache.rya.indexing.accumulo.temporal.AccumuloTemporalIndexer;
+import org.openrdf.model.Statement;
+import org.openrdf.model.vocabulary.XMLSchema;
 
 /**
  * {@link OutputFormat} that uses Rya, the {@link GeoIndexer}, the
@@ -216,12 +215,22 @@ public class RyaOutputFormat extends OutputFormat<Writable, RyaStatementWritable
         return freeText;
     }
 
-    private static TemporalIndexer getTemporalIndexer(Configuration conf) {
+    private static TemporalIndexer getTemporalIndexer(Configuration conf) throws IOException {
         if (!conf.getBoolean(ENABLE_TEMPORAL, true)) {
             return null;
         }
         AccumuloTemporalIndexer temporal = new AccumuloTemporalIndexer();
         temporal.setConf(conf);
+        Connector connector;
+        try {
+            connector = ConfigUtils.getConnector(conf);
+        } catch (AccumuloException | AccumuloSecurityException e) {
+            throw new IOException("Error when attempting to create a connection for writing the temporal index.", e);
+        }
+        MultiTableBatchWriter mtbw = connector.createMultiTableBatchWriter(new BatchWriterConfig());
+        temporal.setConnector(connector);
+        temporal.setMultiTableBatchWriter(mtbw);
+        temporal.init();
         return temporal;
     }
 

--- a/mapreduce/src/test/java/org/apache/rya/accumulo/mr/RyaOutputFormatTest.java
+++ b/mapreduce/src/test/java/org/apache/rya/accumulo/mr/RyaOutputFormatTest.java
@@ -5,7 +5,9 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.accumulo.core.client.BatchWriterConfig;
 import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.client.MultiTableBatchWriter;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.mapreduce.AccumuloOutputFormat;
 import org.apache.accumulo.core.client.mock.MockInstance;
@@ -17,15 +19,6 @@ import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.RecordWriter;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.openrdf.model.Statement;
-import org.openrdf.model.ValueFactory;
-import org.openrdf.model.impl.ValueFactoryImpl;
-import org.openrdf.model.vocabulary.XMLSchema;
-
-import info.aduna.iteration.CloseableIteration;
 import org.apache.rya.accumulo.AccumuloRdfConfiguration;
 import org.apache.rya.accumulo.AccumuloRyaDAO;
 import org.apache.rya.api.domain.RyaStatement;
@@ -43,6 +36,15 @@ import org.apache.rya.indexing.accumulo.freetext.AccumuloFreeTextIndexer;
 import org.apache.rya.indexing.accumulo.freetext.SimpleTokenizer;
 import org.apache.rya.indexing.accumulo.freetext.Tokenizer;
 import org.apache.rya.indexing.accumulo.temporal.AccumuloTemporalIndexer;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openrdf.model.Statement;
+import org.openrdf.model.ValueFactory;
+import org.openrdf.model.impl.ValueFactoryImpl;
+import org.openrdf.model.vocabulary.XMLSchema;
+
+import info.aduna.iteration.CloseableIteration;
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -235,6 +237,11 @@ public class RyaOutputFormatTest {
         }
         final AccumuloTemporalIndexer temporal = new AccumuloTemporalIndexer();
         temporal.setConf(conf);
+        Connector connector = ConfigUtils.getConnector(conf);
+        MultiTableBatchWriter mtbw = connector.createMultiTableBatchWriter(new BatchWriterConfig());
+        temporal.setConnector(connector);
+        temporal.setMultiTableBatchWriter(mtbw);
+        temporal.init();
         final Set<Statement> empty = new HashSet<>();
         final Set<Statement> head = new HashSet<>();
         final Set<Statement> tail = new HashSet<>();


### PR DESCRIPTION
## Description
The dao manages multitable batch writer, but that was not being used, so writers might never be flushed.
Temporal indexing writes nothing to it's table name: [prefix]temporal.
It does seem to work for a mock instance. It might also work for a large ingest since it would force a flush.
See the parent RYA-72 https://issues.apache.org/jira/browse/RYA-72 for an explanation.


### Tests
Repaired tests.  No new tests.

### Links
[Jira](https://issues.apache.org/jira/browse/RYA-266)

### Checklist
- [ ] Code Review

#### People To Reivew
People that know indexing, or know RyaOutputFormatTest
