### PR TITLE
Rya 271 rya.indexing IndexingFunctionRegistry does not allow custom functions

### DIFF
--- a/extras/indexing/src/main/java/org/apache/rya/indexing/IndexingFunctionRegistry.java
+++ b/extras/indexing/src/main/java/org/apache/rya/indexing/IndexingFunctionRegistry.java
@@ -73,18 +73,22 @@ public class IndexingFunctionRegistry {
     
     
     public static Var getResultVarFromFunctionCall(URI function, List<ValueExpr> args) {
-        
         FUNCTION_TYPE type = SEARCH_FUNCTIONS.get(function);
-        
-        switch(type) {
-        case GEO: 
-            return findBinaryResultVar(args);
-        case FREETEXT:
-            return findLiteralResultVar(args);
-        case TEMPORAL:
-            return findBinaryResultVar(args);
-        default:
-            return null;
+        if (type == null) {
+        	return findBinaryResultVar(args);
+        }
+        else {
+	        switch(type) {
+	        case GEO: 
+	            return findBinaryResultVar(args);
+	        case FREETEXT:
+	            return findLiteralResultVar(args);
+	        case TEMPORAL:
+	            return findBinaryResultVar(args);
+	        default:
+	            //return null;
+	        	return findBinaryResultVar(args);
+	        }
         }
         
     }
@@ -106,18 +110,20 @@ public class IndexingFunctionRegistry {
     
     
     private static Var findBinaryResultVar(List<ValueExpr> args) {
-     
+    	Var retval = null;
         if (args.size() >= 2) {
             ValueExpr arg1 = args.get(0);
             ValueExpr arg2 = args.get(1);
-            if (isUnboundVariable(arg1) && isConstant(arg2))
-                return (Var) arg1;
-            else if (isUnboundVariable(arg2) && isConstant(arg1))
-                return (Var) arg2;
+            
+            if (isUnboundVariable(arg1) && isConstant(arg2)) {
+                retval = (Var) arg1;
+            }
+            else if (isUnboundVariable(arg2) && isConstant(arg1)) {
+                retval = (Var) arg2;
+            }
         }
-        return null;
+        return retval;
     }
-    
     
     private static Var findLiteralResultVar(List<ValueExpr> args) {
         if (args.size() >= 2) {
@@ -128,7 +134,5 @@ public class IndexingFunctionRegistry {
         }
         return null;
     }
-    
-    
     
 }

--- a/extras/indexing/src/test/java/org/apache/rya/indexing/accumulo/customfunction/AccumuloCustomSparqlFunctionTest.java
+++ b/extras/indexing/src/test/java/org/apache/rya/indexing/accumulo/customfunction/AccumuloCustomSparqlFunctionTest.java
@@ -1,0 +1,96 @@
+package org.apache.rya.indexing.accumulo.customfunction;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Set;
+
+import org.apache.rya.accumulo.AccumuloRdfConfiguration;
+import org.apache.rya.indexing.accumulo.ConfigUtils;
+import org.apache.rya.indexing.accumulo.freetext.SimpleTokenizer;
+import org.apache.rya.indexing.accumulo.freetext.Tokenizer;
+import org.apache.rya.sail.config.RyaSailFactory;
+import org.junit.Before;
+import org.junit.Test;
+import org.openrdf.model.Value;
+import org.openrdf.query.BindingSet;
+import org.openrdf.query.MalformedQueryException;
+import org.openrdf.query.QueryLanguage;
+import org.openrdf.query.TupleQuery;
+import org.openrdf.query.TupleQueryResult;
+import org.openrdf.repository.Repository;
+import org.openrdf.repository.sail.SailRepository;
+import org.openrdf.sail.Sail;
+
+import org.junit.*;
+
+import org.openrdf.repository.RepositoryConnection;
+import org.openrdf.repository.RepositoryException;
+
+public class AccumuloCustomSparqlFunctionTest {
+	private AccumuloRdfConfiguration conf;
+	private Repository repository = null;
+	private Sail sail = null;
+	private RepositoryConnection conn = null;
+	
+
+	@Before
+    public void before() throws Exception {
+        conf = new AccumuloRdfConfiguration();
+        conf.setBoolean(ConfigUtils.USE_MOCK_INSTANCE, true);
+        conf.set(ConfigUtils.CLOUDBASE_USER, "USERNAME");
+        conf.set(ConfigUtils.CLOUDBASE_PASSWORD, "PASS");
+        conf.set(ConfigUtils.CLOUDBASE_AUTHS, "U");
+        conf.setClass(ConfigUtils.TOKENIZER_CLASS, SimpleTokenizer.class, Tokenizer.class);
+        conf.setTablePrefix("triplestore_");
+        
+        this.sail = RyaSailFactory.getInstance(conf);
+        this.repository = new SailRepository(this.sail);
+        this.conn = this.repository.getConnection();
+        
+    }
+	
+	@Test
+	public void customFunction() {
+		String sql = "" 
+				+ "PREFIX fn: <http://example.org#> "
+				+ "select (fn:mycustomfucnction() as ?res1) (str(fn:mycustomfucnction('Rya')) as ?res2) "
+				+ "where {}";
+		try {
+			TupleQuery query = this.conn.prepareTupleQuery(QueryLanguage.SPARQL, sql);
+		
+			TupleQueryResult qres = query.evaluate();
+			ArrayList<HashMap<String, Value>> reslist = new ArrayList<HashMap<String, Value>>();
+			while (qres.hasNext()) {
+				BindingSet b = qres.next();
+				Set<String> names = b.getBindingNames();
+				HashMap<String, Value> hm = new HashMap<String, Value>();
+				for (Object n : names) {
+					hm.put(
+							(String) n, 
+							b.getValue((String) n)
+					);
+				}
+				reslist.add(hm);
+				
+				if (hm.containsKey("res1")) {
+					Assert.assertEquals(hm.get("res1").stringValue(), "Hello");
+				}
+				else {
+					Assert.fail("'res1' is not in result set.");
+				}
+				
+				if (hm.containsKey("res2")) {
+					Assert.assertEquals(hm.get("res2").stringValue(), "Hello, Rya");
+				}
+				else {
+					Assert.fail("'res2' is not in result set");
+				}
+			} 
+		}
+		catch (Exception ex) {
+			Assert.fail(ex.getMessage());
+		}
+		 
+				
+	}
+}

--- a/extras/indexing/src/test/java/org/apache/rya/indexing/accumulo/customfunction/CustomSparqlFunction.java
+++ b/extras/indexing/src/test/java/org/apache/rya/indexing/accumulo/customfunction/CustomSparqlFunction.java
@@ -1,0 +1,25 @@
+package org.apache.rya.indexing.accumulo.customfunction;
+
+import org.openrdf.model.Value;
+import org.openrdf.model.ValueFactory;
+import org.openrdf.query.algebra.evaluation.ValueExprEvaluationException;
+import org.openrdf.query.algebra.evaluation.function.Function;
+
+public class CustomSparqlFunction implements Function {
+
+	@Override
+	public Value evaluate(ValueFactory valueFactory, Value... arg1) throws ValueExprEvaluationException {
+		if (arg1.length == 1) {
+			return valueFactory.createLiteral("Hello, " + arg1[0].stringValue());
+		} else {
+			return valueFactory.createLiteral("Hello");
+		}
+	}
+
+	@Override
+	public String getURI() {
+		// TODO Auto-generated method stub
+		return "http://example.org#mycustomfucnction";
+	}
+
+}

--- a/extras/indexing/src/test/resources/META-INF/services/org.openrdf.query.algebra.evaluation.function.Function
+++ b/extras/indexing/src/test/resources/META-INF/services/org.openrdf.query.algebra.evaluation.function.Function
@@ -1,0 +1,1 @@
+org.apache.rya.indexing.accumulo.customfunction.CustomSparqlFunction


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

  http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
## Description
>What Changed?
Addresses  https://issues.apache.org/jira/browse/RYA-271

Modified IndexingFunctionRegistry.getResultVarFromFunctionCall to allow for functions of any FUNCTION_TYPE, as follows:

FUNCTION_TYPE type = SEARCH_FUNCTIONS.get(function);
if (type == null)
{ return findBinaryResultVar(args); }
else {
... 

### Tests

org.apache.rya.indexing.accumulo.customfunction
  AccumuloCustomSparqlFunctionTest.java  - unit test
  CustomSparqlFunction.java - custom function implementation

Custom function registration in:
src/test/resources/META-INF/services/org.openrdf.query.algebra.evaluation.function.Function
  
Created a custom function http://example.org#mycustomfucnction. 
Using following SPARQL to test:

PREFIX fn: <http://example.org#> 
select (fn:mycustomfucnction() as ?res1) (str(fn:mycustomfucnction('Rya')) as ?res2) 
where {}

### Links
[Jira]( https://issues.apache.org/jira/browse/RYA-271)

### Checklist
- [ ] Code Review
- [ ] Squash Commits

#### People To Reivew

