### PR TITLE
RYA-278 Fixes AccumuloLoadStatements::loadTurtleFile test

### DIFF
--- a/extras/indexing/src/test/java/org/apache/rya/api/client/accumulo/AccumuloLoadStatementsFileIT.java
+++ b/extras/indexing/src/test/java/org/apache/rya/api/client/accumulo/AccumuloLoadStatementsFileIT.java
@@ -116,11 +116,16 @@ public class AccumuloLoadStatementsFileIT extends AccumuloITBase {
             final Statement statement = RyaToRdfConversions.convertStatement(ryaStatement);
 
             // Filter out the rya version statement if it is present.
-            if(!statement.getPredicate().equals( vf.createURI("urn:mvm.rya/2012/05#version") )) {
+            if(!isRyaMetadataStatement(vf, statement)) {
                 statements.add( statement );
             }
         }
 
         assertEquals(expected, statements);
+    }
+
+    private boolean isRyaMetadataStatement(ValueFactory vf, Statement statement) {
+        return statement.getPredicate().equals( vf.createURI("urn:org.apache.rya/2012/05#version") ) ||
+                statement.getPredicate().equals( vf.createURI("urn:org.apache.rya/2012/05#rts") );
     }
 }


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

  http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
## Description
Ignores `org.apache.rya` predicates rather than `mvm.rya` predicates to filter out rya version metadata.  This update appears to have been overlooked when the URIs were changed.

### Tests
No additional tests were written as this fixes an existing test.

### Links
[Jira](https://issues.apache.org/jira/browse/RYA-278)

### Checklist
- [ ] Code Review
- [x] Squash Commits

#### People To Reivew
@amihalik @pujav65 
