### PR TITLE
F/rya 67 faster integration tests

### DIFF
--- a/dao/accumulo.rya/pom.xml
+++ b/dao/accumulo.rya/pom.xml
@@ -129,6 +129,9 @@ under the License.
                         <artifactId>maven-shade-plugin</artifactId>
                         <executions>
                             <execution>
+                                <goals>
+                                    <goal>shade</goal>
+                                </goals>
                                 <configuration>
                                     <transformers>
                                         <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />

--- a/dao/accumulo.rya/src/test/java/org/apache/rya/accumulo/AccumuloITBase.java
+++ b/dao/accumulo.rya/src/test/java/org/apache/rya/accumulo/AccumuloITBase.java
@@ -18,8 +18,6 @@
  */
 package org.apache.rya.accumulo;
 
-import java.io.IOException;
-
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.Connector;
@@ -27,9 +25,8 @@ import org.apache.accumulo.minicluster.MiniAccumuloCluster;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.apache.zookeeper.ClientCnxn;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 
 /**
  * Boilerplate code for a unit test that uses a {@link MiniAccumuloCluster}.
@@ -39,24 +36,15 @@ import org.junit.BeforeClass;
  */
 public class AccumuloITBase {
 
-    // Managed the MiniAccumuloCluster
-    private MiniAccumuloClusterInstance cluster = null;
+    private static MiniAccumuloClusterInstance cluster = MiniAccumuloSingleton.getInstance();
+
+    @Rule
+    public RyaTestInstanceRule testInstance = new RyaTestInstanceRule(false);
+
 
     @BeforeClass
     public static void killLoudLogs() {
         Logger.getLogger(ClientCnxn.class).setLevel(Level.ERROR);
-    }
-
-    @Before
-    public void initCluster() throws IOException, InterruptedException, AccumuloException, AccumuloSecurityException {
-        cluster = new MiniAccumuloClusterInstance();
-        cluster.startMiniAccumulo();
-    }
-
-
-    @After
-    public void tearDownCluster() throws IOException, InterruptedException {
-        cluster.stopMiniAccumulo();
     }
 
     /**
@@ -102,4 +90,9 @@ public class AccumuloITBase {
     public Connector getConnector() throws AccumuloException, AccumuloSecurityException {
         return cluster.getConnector();
     }
+
+    public String getRyaInstanceName() {
+        return testInstance.getRyaInstanceName();
+    }
+
 }

--- a/dao/accumulo.rya/src/test/java/org/apache/rya/accumulo/AccumuloRyaITBase.java
+++ b/dao/accumulo.rya/src/test/java/org/apache/rya/accumulo/AccumuloRyaITBase.java
@@ -18,31 +18,7 @@
  */
 package org.apache.rya.accumulo;
 
-import java.io.IOException;
-import java.util.Date;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import org.apache.accumulo.core.client.AccumuloException;
-import org.apache.accumulo.core.client.AccumuloSecurityException;
-import org.apache.accumulo.core.client.TableNotFoundException;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-
-import com.google.common.base.Optional;
-
-import org.apache.rya.accumulo.instance.AccumuloRyaInstanceDetailsRepository;
-import org.apache.rya.api.instance.RyaDetails;
-import org.apache.rya.api.instance.RyaDetails.EntityCentricIndexDetails;
-import org.apache.rya.api.instance.RyaDetails.FreeTextIndexDetails;
-import org.apache.rya.api.instance.RyaDetails.GeoIndexDetails;
-import org.apache.rya.api.instance.RyaDetails.JoinSelectivityDetails;
-import org.apache.rya.api.instance.RyaDetails.PCJIndexDetails;
-import org.apache.rya.api.instance.RyaDetails.ProspectorDetails;
-import org.apache.rya.api.instance.RyaDetails.TemporalIndexDetails;
-import org.apache.rya.api.instance.RyaDetailsRepository;
-import org.apache.rya.api.instance.RyaDetailsRepository.AlreadyInitializedException;
-import org.apache.rya.api.instance.RyaDetailsRepository.RyaDetailsRepositoryException;
+import org.junit.Rule;
 
 /**
  * Contains boilerplate code for spinning up a Mini Accumulo Cluster and initializing
@@ -51,59 +27,20 @@ import org.apache.rya.api.instance.RyaDetailsRepository.RyaDetailsRepositoryExce
  */
 public class AccumuloRyaITBase {
 
-    // Managed the MiniAccumuloCluster
-    private static final MiniAccumuloClusterInstance cluster = new MiniAccumuloClusterInstance();
-
-    // Manage the Rya instances that are hosted on the cluster
-    protected static final AtomicInteger ryaInstanceNameCounter = new AtomicInteger(1);
-    private String ryaInstanceName;
-
-    @BeforeClass
-    public static void initCluster() throws IOException, InterruptedException, AccumuloException, AccumuloSecurityException {
-        cluster.startMiniAccumulo();
-    }
-
-    @Before
-    public void prepareForNextTest() throws AccumuloException, AccumuloSecurityException, TableNotFoundException, AlreadyInitializedException, RyaDetailsRepositoryException {
-        // Get the next Rya instance name.
-        ryaInstanceName = "testInstance" + ryaInstanceNameCounter.getAndIncrement() + "_";
-
-        // Create Rya Details for the instance name.
-        final RyaDetailsRepository detailsRepo = new AccumuloRyaInstanceDetailsRepository(cluster.getConnector(), ryaInstanceName);
-
-        final RyaDetails details = RyaDetails.builder()
-                .setRyaInstanceName(ryaInstanceName)
-                .setRyaVersion("0.0.0.0")
-                .setFreeTextDetails( new FreeTextIndexDetails(true) )
-                .setEntityCentricIndexDetails( new EntityCentricIndexDetails(true) )
-              //RYA-215                .setGeoIndexDetails( new GeoIndexDetails(true) )
-                .setTemporalIndexDetails( new TemporalIndexDetails(true) )
-                .setPCJIndexDetails(
-                        PCJIndexDetails.builder()
-                            .setEnabled(true) )
-                .setJoinSelectivityDetails( new JoinSelectivityDetails( Optional.<Date>absent() ) )
-                .setProspectorDetails( new ProspectorDetails( Optional.<Date>absent() ))
-                .build();
-
-        detailsRepo.initialize(details);
-    }
-
-    @AfterClass
-    public static void tearDownCluster() throws IOException, InterruptedException {
-        cluster.stopMiniAccumulo();
-    }
+    @Rule
+    public RyaTestInstanceRule testInstance = new RyaTestInstanceRule(true);
 
     /**
      * @return The {@link MiniAccumuloClusterInstance} used by the tests.
      */
     public MiniAccumuloClusterInstance getClusterInstance() {
-        return cluster;
+        return MiniAccumuloSingleton.getInstance();
     }
 
     /**
      * @return The name of the Rya instance that is being used for the current test.
      */
     public String getRyaInstanceName() {
-        return ryaInstanceName;
+        return testInstance.getRyaInstanceName();
     }
 }

--- a/dao/accumulo.rya/src/test/java/org/apache/rya/accumulo/MiniAccumuloSingleton.java
+++ b/dao/accumulo.rya/src/test/java/org/apache/rya/accumulo/MiniAccumuloSingleton.java
@@ -1,0 +1,84 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.accumulo;
+
+import org.apache.accumulo.core.client.AccumuloException;
+import org.apache.accumulo.core.client.AccumuloSecurityException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+public final class MiniAccumuloSingleton {
+
+    public static MiniAccumuloClusterInstance getInstance() {
+        return InstanceHolder.SINGLETON.instance;
+    }
+
+    private MiniAccumuloSingleton() {
+        // hiding implicit default constructor
+    }
+
+    private enum InstanceHolder {
+
+        SINGLETON;
+
+        private final Logger log;
+        private final MiniAccumuloClusterInstance instance;
+
+        InstanceHolder() {
+            this.log = LoggerFactory.getLogger(MiniAccumuloSingleton.class);
+            this.instance = new MiniAccumuloClusterInstance();
+            try {
+                this.instance.startMiniAccumulo();
+
+                // JUnit does not have an overall lifecycle event for tearing down
+                // this kind of resource, but shutdown hooks work alright in practice
+                // since this should only be used during testing
+
+                // The only other alternative for lifecycle management is to use a
+                // suite lifecycle to enclose the tests that need this resource.
+                // In practice this becomes unwieldy.
+
+                Runtime.getRuntime().addShutdownHook(new Thread() {
+                    @Override
+                    public void run() {
+                        try {
+                            InstanceHolder.this.instance.stopMiniAccumulo();
+                        } catch (Throwable t) {
+                            // logging frameworks will likely be shut down
+                            t.printStackTrace(System.err);
+                        }
+                    }
+                });
+
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                log.error("Interrupted while starting mini accumulo", e);
+            } catch (IOException | AccumuloException | AccumuloSecurityException e) {
+                log.error("Unexpected error while starting mini accumulo", e);
+            } catch (Throwable e) {
+                // catching throwable because failure to construct an enum
+                // instance will lead to another error being thrown downstream
+                log.error("Unexpected throwable while starting mini accumulo", e);
+            }
+        }
+    }
+
+}

--- a/dao/accumulo.rya/src/test/java/org/apache/rya/accumulo/RyaTestInstanceRule.java
+++ b/dao/accumulo.rya/src/test/java/org/apache/rya/accumulo/RyaTestInstanceRule.java
@@ -1,0 +1,94 @@
+package org.apache.rya.accumulo;
+
+import com.google.common.base.Optional;
+import org.apache.rya.accumulo.instance.AccumuloRyaInstanceDetailsRepository;
+import org.apache.rya.api.client.Install.InstallConfiguration;
+import org.apache.rya.api.client.RyaClient;
+import org.apache.rya.api.instance.RyaDetails;
+import org.apache.rya.api.instance.RyaDetails.EntityCentricIndexDetails;
+import org.apache.rya.api.instance.RyaDetails.FreeTextIndexDetails;
+import org.apache.rya.api.instance.RyaDetails.JoinSelectivityDetails;
+import org.apache.rya.api.instance.RyaDetails.PCJIndexDetails;
+import org.apache.rya.api.instance.RyaDetails.ProspectorDetails;
+import org.apache.rya.api.instance.RyaDetails.TemporalIndexDetails;
+import org.apache.rya.api.instance.RyaDetailsRepository;
+import org.junit.rules.ExternalResource;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+public class RyaTestInstanceRule extends ExternalResource {
+
+    private static final MiniAccumuloClusterInstance cluster = MiniAccumuloSingleton.getInstance();
+    private static final AtomicInteger ryaInstanceNameCounter = new AtomicInteger(1);
+    private static final AtomicInteger userId = new AtomicInteger(1);
+
+    private final boolean install;
+    private String ryaInstanceName;
+
+    public RyaTestInstanceRule(boolean install) {
+        this.install = install;
+    }
+
+    public String getRyaInstanceName() {
+        if (ryaInstanceName == null) {
+            throw new IllegalStateException("Cannot get rya instance name outside of a test execution.");
+        }
+        return ryaInstanceName;
+    }
+
+    public String createUniqueUser() {
+        int id = userId.getAndIncrement();
+        return "user_" + id;
+    }
+
+    @Override
+    protected void before() throws Throwable {
+
+        // Get the next Rya instance name.
+        ryaInstanceName = "testInstance_" + ryaInstanceNameCounter.getAndIncrement();
+
+        if (install) {
+            // Create Rya Details for the instance name.
+            final RyaDetailsRepository detailsRepo = new AccumuloRyaInstanceDetailsRepository(cluster.getConnector(), ryaInstanceName);
+
+            final RyaDetails details = RyaDetails.builder()
+                    .setRyaInstanceName(ryaInstanceName)
+                    .setRyaVersion("0.0.0.0")
+                    .setFreeTextDetails(new FreeTextIndexDetails(true))
+                    .setEntityCentricIndexDetails(new EntityCentricIndexDetails(true))
+                    //RYA-215                .setGeoIndexDetails( new GeoIndexDetails(true) )
+                    .setTemporalIndexDetails(new TemporalIndexDetails(true))
+                    .setPCJIndexDetails(PCJIndexDetails.builder().setEnabled(true))
+                    .setJoinSelectivityDetails(new JoinSelectivityDetails(Optional.absent()))
+                    .setProspectorDetails(new ProspectorDetails(Optional.absent()))
+                    .build();
+
+            detailsRepo.initialize(details);
+        }
+    }
+
+    @Override
+    protected void after() {
+        ryaInstanceName = null;
+        // TODO consider teardown of instance (probably requires additional features)
+    }
+
+}

--- a/dao/accumulo.rya/src/test/java/org/apache/rya/accumulo/instance/AccumuloRyaDetailsRepositoryIT.java
+++ b/dao/accumulo.rya/src/test/java/org/apache/rya/accumulo/instance/AccumuloRyaDetailsRepositoryIT.java
@@ -56,7 +56,7 @@ public class AccumuloRyaDetailsRepositoryIT extends AccumuloITBase {
 
     @Test
     public void initializeAndGet() throws AccumuloException, AccumuloSecurityException, AlreadyInitializedException, RyaDetailsRepositoryException {
-        final String instanceName = "testInstance";
+        final String instanceName = getRyaInstanceName();
 
         // Create the metadata object the repository will be initialized with.
         final RyaDetails details = RyaDetails.builder()
@@ -98,7 +98,7 @@ public class AccumuloRyaDetailsRepositoryIT extends AccumuloITBase {
 
     @Test(expected = AlreadyInitializedException.class)
     public void initialize_alreadyInitialized() throws AlreadyInitializedException, RyaDetailsRepositoryException, AccumuloException, AccumuloSecurityException {
-        final String instanceName = "testInstance";
+        final String instanceName = getRyaInstanceName();
 
         // Create the metadata object the repository will be initialized with.
         final RyaDetails details = RyaDetails.builder()
@@ -139,7 +139,7 @@ public class AccumuloRyaDetailsRepositoryIT extends AccumuloITBase {
     public void getRyaInstance_notInitialized() throws AccumuloException, AccumuloSecurityException, NotInitializedException, RyaDetailsRepositoryException {
         // Setup the repository that will be tested using a mini instance of Accumulo.
         final Connector connector = getClusterInstance().getConnector();
-        final RyaDetailsRepository repo = new AccumuloRyaInstanceDetailsRepository(connector, "testInstance");
+        final RyaDetailsRepository repo = new AccumuloRyaInstanceDetailsRepository(connector, getRyaInstanceName());
 
         // Try to fetch the details from the uninitialized repository.
         repo.getRyaInstanceDetails();
@@ -147,7 +147,7 @@ public class AccumuloRyaDetailsRepositoryIT extends AccumuloITBase {
 
     @Test
     public void isInitialized_true() throws AccumuloException, AccumuloSecurityException, AlreadyInitializedException, RyaDetailsRepositoryException {
-        final String instanceName = "testInstance";
+        final String instanceName = getRyaInstanceName();
 
         // Create the metadata object the repository will be initialized with.
         final RyaDetails details = RyaDetails.builder()
@@ -176,7 +176,7 @@ public class AccumuloRyaDetailsRepositoryIT extends AccumuloITBase {
         // Setup the repository that will be tested using a mini instance of Accumulo.
         final MiniAccumuloClusterInstance clusterInstance = getClusterInstance();
         final Connector connector = clusterInstance.getConnector();
-        final RyaDetailsRepository repo = new AccumuloRyaInstanceDetailsRepository(connector, "testInstance");
+        final RyaDetailsRepository repo = new AccumuloRyaInstanceDetailsRepository(connector, instanceName);
 
         // Initialize the repository
         repo.initialize(details);
@@ -189,7 +189,7 @@ public class AccumuloRyaDetailsRepositoryIT extends AccumuloITBase {
     public void isInitialized_false() throws AccumuloException, AccumuloSecurityException, RyaDetailsRepositoryException {
         // Setup the repository that will be tested using a mock instance of Accumulo.
         final Connector connector = getClusterInstance().getConnector();
-        final RyaDetailsRepository repo = new AccumuloRyaInstanceDetailsRepository(connector, "testInstance");
+        final RyaDetailsRepository repo = new AccumuloRyaInstanceDetailsRepository(connector, getRyaInstanceName());
 
         // Ensure the repository reports that is has not been initialized.
         assertFalse( repo.isInitialized() );
@@ -197,7 +197,7 @@ public class AccumuloRyaDetailsRepositoryIT extends AccumuloITBase {
 
     @Test
     public void update() throws AlreadyInitializedException, RyaDetailsRepositoryException, AccumuloException, AccumuloSecurityException {
-        final String instanceName = "testInstance";
+        final String instanceName = getRyaInstanceName();
 
         // Create the metadata object the repository will be initialized with.
         final RyaDetails details = RyaDetails.builder()
@@ -225,7 +225,7 @@ public class AccumuloRyaDetailsRepositoryIT extends AccumuloITBase {
 
         // Setup the repository that will be tested using a mini instance of Accumulo.
         final Connector connector = getClusterInstance().getConnector();
-        final RyaDetailsRepository repo = new AccumuloRyaInstanceDetailsRepository(connector, "testInstance");
+        final RyaDetailsRepository repo = new AccumuloRyaInstanceDetailsRepository(connector, instanceName);
 
         // Initialize the repository
         repo.initialize(details);
@@ -245,7 +245,7 @@ public class AccumuloRyaDetailsRepositoryIT extends AccumuloITBase {
 
     @Test(expected = ConcurrentUpdateException.class)
     public void update_outOfDate() throws AccumuloException, AccumuloSecurityException, AlreadyInitializedException, RyaDetailsRepositoryException {
-        final String instanceName = "testInstance";
+        final String instanceName = getRyaInstanceName();
 
         // Create the metadata object the repository will be initialized with.
         final RyaDetails details = RyaDetails.builder()
@@ -273,7 +273,7 @@ public class AccumuloRyaDetailsRepositoryIT extends AccumuloITBase {
 
         // Setup the repository that will be tested using a mini instance of Accumulo.
         final Connector connector = getClusterInstance().getConnector();
-        final RyaDetailsRepository repo = new AccumuloRyaInstanceDetailsRepository(connector, "testInstance");
+        final RyaDetailsRepository repo = new AccumuloRyaInstanceDetailsRepository(connector, instanceName);
 
         // Initialize the repository
         repo.initialize(details);

--- a/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/MongoDBQueryEngineTest.java
+++ b/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/MongoDBQueryEngineTest.java
@@ -52,7 +52,7 @@ public class MongoDBQueryEngineTest extends MongoRyaTestBase {
     public void setUp() throws Exception {
         // Set up Mongo/Rya
         final Configuration conf = new Configuration();
-        conf.set(MongoDBRdfConfiguration.MONGO_DB_NAME, "test");
+        conf.set(MongoDBRdfConfiguration.MONGO_DB_NAME, getDbName());
         conf.set(MongoDBRdfConfiguration.MONGO_COLLECTION_PREFIX, "rya_");
         conf.set(RdfCloudTripleStoreConfiguration.CONF_TBL_PREFIX, "rya_");
         configuration = new MongoDBRdfConfiguration(conf);

--- a/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/MongoDBRyaDAOIT.java
+++ b/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/MongoDBRyaDAOIT.java
@@ -46,7 +46,7 @@ public class MongoDBRyaDAOIT extends MongoRyaTestBase {
     @Before
     public void setUp() throws IOException, RyaDAOException{
            final Configuration conf = new Configuration();
-            conf.set(MongoDBRdfConfiguration.MONGO_DB_NAME, "test");
+            conf.set(MongoDBRdfConfiguration.MONGO_DB_NAME, getDbName());
             conf.set(MongoDBRdfConfiguration.MONGO_COLLECTION_PREFIX, "rya_");
             conf.set(RdfCloudTripleStoreConfiguration.CONF_TBL_PREFIX, "rya_");
             configuration = new MongoDBRdfConfiguration(conf);

--- a/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/MongoDBRyaDAOTest.java
+++ b/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/MongoDBRyaDAOTest.java
@@ -21,6 +21,7 @@ package org.apache.rya.mongodb;
 import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.rya.api.RdfCloudTripleStoreConfiguration;
@@ -43,7 +44,7 @@ public class MongoDBRyaDAOTest extends MongoRyaTestBase {
 	@Before
 	public void setUp() throws IOException, RyaDAOException{
 		final Configuration conf = new Configuration();
-        conf.set(MongoDBRdfConfiguration.MONGO_DB_NAME, "test");
+        conf.set(MongoDBRdfConfiguration.MONGO_DB_NAME, getDbName());
         conf.set(MongoDBRdfConfiguration.MONGO_COLLECTION_PREFIX, "rya_");
         conf.set(RdfCloudTripleStoreConfiguration.CONF_TBL_PREFIX, "rya_");
         configuration = new MongoDBRdfConfiguration(conf);

--- a/extras/indexing/src/test/java/org/apache/rya/api/client/accumulo/AccumuloGetInstanceDetailsIT.java
+++ b/extras/indexing/src/test/java/org/apache/rya/api/client/accumulo/AccumuloGetInstanceDetailsIT.java
@@ -54,7 +54,7 @@ public class AccumuloGetInstanceDetailsIT extends AccumuloITBase {
     @Test
     public void getDetails() throws AccumuloException, AccumuloSecurityException, DuplicateInstanceNameException, RyaClientException {
         // Install an instance of Rya.
-        final String instanceName = "instance_name";
+        final String instanceName = getRyaInstanceName();
         final InstallConfiguration installConfig = InstallConfiguration.builder()
                 .setEnableTableHashPrefix(true)
                 .setEnableEntityCentricIndex(true)
@@ -106,19 +106,17 @@ public class AccumuloGetInstanceDetailsIT extends AccumuloITBase {
                 getZookeepers());
 
         final GetInstanceDetails getInstanceDetails = new AccumuloGetInstanceDetails(connectionDetails, getConnector());
-        getInstanceDetails.getDetails("instance_name");
+        getInstanceDetails.getDetails("instance_name_does_not_exist");
     }
 
     @Test
     public void getDetails_instanceDoesNotHaveDetails() throws AccumuloException, AccumuloSecurityException, InstanceDoesNotExistException, RyaClientException, TableExistsException {
         // Mimic a pre-details rya install.
-        final String instanceName = "instance_name";
-
         final TableOperations tableOps = getConnector().tableOperations();
 
-        final String spoTableName = instanceName + RdfCloudTripleStoreConstants.TBL_SPO_SUFFIX;
-        final String ospTableName = instanceName + RdfCloudTripleStoreConstants.TBL_OSP_SUFFIX;
-        final String poTableName = instanceName + RdfCloudTripleStoreConstants.TBL_PO_SUFFIX;
+        final String spoTableName = getRyaInstanceName() + RdfCloudTripleStoreConstants.TBL_SPO_SUFFIX;
+        final String ospTableName = getRyaInstanceName() + RdfCloudTripleStoreConstants.TBL_OSP_SUFFIX;
+        final String poTableName = getRyaInstanceName() + RdfCloudTripleStoreConstants.TBL_PO_SUFFIX;
         tableOps.create(spoTableName);
         tableOps.create(ospTableName);
         tableOps.create(poTableName);
@@ -131,7 +129,7 @@ public class AccumuloGetInstanceDetailsIT extends AccumuloITBase {
                 getZookeepers());
 
         final GetInstanceDetails getInstanceDetails = new AccumuloGetInstanceDetails(connectionDetails, getConnector());
-        final Optional<RyaDetails> details = getInstanceDetails.getDetails(instanceName);
+        final Optional<RyaDetails> details = getInstanceDetails.getDetails(getRyaInstanceName());
         assertFalse( details.isPresent() );
     }
 }

--- a/extras/indexing/src/test/java/org/apache/rya/api/client/accumulo/AccumuloInstallIT.java
+++ b/extras/indexing/src/test/java/org/apache/rya/api/client/accumulo/AccumuloInstallIT.java
@@ -40,7 +40,7 @@ public class AccumuloInstallIT extends AccumuloITBase {
     @Test
     public void install() throws AccumuloException, AccumuloSecurityException, DuplicateInstanceNameException, RyaClientException, NotInitializedException, RyaDetailsRepositoryException {
         // Install an instance of Rya.
-        final String instanceName = "testInstance_";
+        final String instanceName = getRyaInstanceName();
         final InstallConfiguration installConfig = InstallConfiguration.builder()
                 .setEnableTableHashPrefix(false)
                 .setEnableEntityCentricIndex(false)
@@ -68,7 +68,7 @@ public class AccumuloInstallIT extends AccumuloITBase {
     @Test(expected = DuplicateInstanceNameException.class)
     public void install_alreadyExists() throws DuplicateInstanceNameException, RyaClientException, AccumuloException, AccumuloSecurityException {
         // Install an instance of Rya.
-        final String instanceName = "testInstance_";
+        final String instanceName = getRyaInstanceName();
         final InstallConfiguration installConfig = InstallConfiguration.builder().build();
 
         final AccumuloConnectionDetails connectionDetails = new AccumuloConnectionDetails(

--- a/extras/indexing/src/test/java/org/apache/rya/api/client/accumulo/AccumuloListInstancesIT.java
+++ b/extras/indexing/src/test/java/org/apache/rya/api/client/accumulo/AccumuloListInstancesIT.java
@@ -25,6 +25,10 @@ import java.util.List;
 
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
+import org.apache.accumulo.core.client.admin.SecurityOperations;
+import org.apache.accumulo.core.client.admin.TableOperations;
+import org.apache.accumulo.core.security.SystemPermission;
+import org.junit.Before;
 import org.junit.Test;
 
 import com.beust.jcommander.internal.Lists;
@@ -39,6 +43,21 @@ import org.apache.rya.api.client.RyaClientException;
  * Integration tests the methods of {@link AccumuloListInstances}.
  */
 public class AccumuloListInstancesIT extends AccumuloITBase {
+
+    @Before
+    public void setup() throws Exception {
+        // this is a bit of a hack to clear any existing instances before
+        // adding the instances we want to exist for testing the list command
+        TableOperations tableOps = getConnector().tableOperations();
+        SecurityOperations secOps = getConnector().securityOperations();
+        secOps.grantSystemPermission("root", SystemPermission.DROP_TABLE);
+
+        for (String tableName : getConnector().tableOperations().list()) {
+            if (!tableName.startsWith("accumulo.")) {
+                tableOps.delete(tableName);
+            }
+        }
+    }
 
     @Test
     public void listInstances_hasRyaDetailsTable() throws AccumuloException, AccumuloSecurityException, RyaClientException {

--- a/extras/indexing/src/test/java/org/apache/rya/api/client/accumulo/AccumuloLoadStatementsFileIT.java
+++ b/extras/indexing/src/test/java/org/apache/rya/api/client/accumulo/AccumuloLoadStatementsFileIT.java
@@ -60,13 +60,12 @@ public class AccumuloLoadStatementsFileIT extends AccumuloITBase {
                 getZookeepers());
 
         final RyaClient ryaClient = AccumuloRyaClientFactory.build(connectionDetails, getConnector());
-        ryaClient.getLoadStatementsFile().loadStatements("testInstance_", Paths.get("src/test/resources/example.ttl"), RDFFormat.TURTLE);
+        ryaClient.getLoadStatementsFile().loadStatements(getRyaInstanceName(), Paths.get("src/test/resources/example.ttl"), RDFFormat.TURTLE);
     }
 
     @Test
     public void loadTurtleFile() throws Exception {
         // Install an instance of Rya.
-        final String instanceName = "testInstance_";
         final InstallConfiguration installConfig = InstallConfiguration.builder()
                 .setEnableTableHashPrefix(false)
                 .setEnableEntityCentricIndex(false)
@@ -85,10 +84,10 @@ public class AccumuloLoadStatementsFileIT extends AccumuloITBase {
 
         final RyaClient ryaClient = AccumuloRyaClientFactory.build(connectionDetails, getConnector());
         final Install install = ryaClient.getInstall();
-        install.install(instanceName, installConfig);
+        install.install(getRyaInstanceName(), installConfig);
 
         // Load the test statement file.
-        ryaClient.getLoadStatementsFile().loadStatements("testInstance_", Paths.get("src/test/resources/example.ttl"), RDFFormat.TURTLE);
+        ryaClient.getLoadStatementsFile().loadStatements(getRyaInstanceName(), Paths.get("src/test/resources/example.ttl"), RDFFormat.TURTLE);
 
         // Verify that the statements were loaded.
         final ValueFactory vf = new ValueFactoryImpl();
@@ -101,7 +100,7 @@ public class AccumuloLoadStatementsFileIT extends AccumuloITBase {
         final List<Statement> statements = new ArrayList<>();
 
         final WholeRowTripleResolver tripleResolver = new WholeRowTripleResolver();
-        final Scanner scanner = getConnector().createScanner("testInstance_spo", new Authorizations());
+        final Scanner scanner = getConnector().createScanner(getRyaInstanceName() + "spo", new Authorizations());
         final Iterator<Entry<Key, Value>> it = scanner.iterator();
         while(it.hasNext()) {
             final Entry<Key, Value> next = it.next();

--- a/extras/indexing/src/test/java/org/apache/rya/api/client/accumulo/AccumuloUninstallIT.java
+++ b/extras/indexing/src/test/java/org/apache/rya/api/client/accumulo/AccumuloUninstallIT.java
@@ -64,7 +64,7 @@ public class AccumuloUninstallIT extends AccumuloITBase {
                 getZookeepers());
 
         final Install install = new AccumuloInstall(connectionDetails, getConnector());
-        final String ryaInstanceName = "testInstance_";
+        final String ryaInstanceName = getRyaInstanceName();
         install.install(ryaInstanceName, installConfig);
 
         // Check that the instance exists.

--- a/extras/indexing/src/test/java/org/apache/rya/indexing/mongo/MongoFreeTextIndexerTest.java
+++ b/extras/indexing/src/test/java/org/apache/rya/indexing/mongo/MongoFreeTextIndexerTest.java
@@ -55,7 +55,7 @@ public class MongoFreeTextIndexerTest extends MongoRyaTestBase {
     public void before() throws Exception {
         conf = new MongoDBRdfConfiguration();
         conf.set(ConfigUtils.USE_MONGO, "true");
-        conf.setMongoDBName("test");
+        conf.setMongoDBName(getDbName());
         conf.setCollectionName("rya_");
         conf.setTablePrefix("another_");
     }

--- a/extras/indexing/src/test/java/org/apache/rya/indexing/mongo/MongoTemporalIndexerTest.java
+++ b/extras/indexing/src/test/java/org/apache/rya/indexing/mongo/MongoTemporalIndexerTest.java
@@ -176,8 +176,8 @@ public final class MongoTemporalIndexerTest extends MongoRyaTestBase {
     @Before
     public void before() throws Exception {
         conf = new MongoDBRdfConfiguration();
-        conf.set(ConfigUtils.USE_MONGO, "true");
-        conf.set(MongoDBRdfConfiguration.MONGO_DB_NAME, "test");
+        conf.set(ConfigUtils.USE_MONGO, getDbName());
+        conf.set(MongoDBRdfConfiguration.MONGO_DB_NAME, getDbName());
         conf.set(MongoDBRdfConfiguration.MONGO_COLLECTION_PREFIX, "rya_");
         conf.setTablePrefix("isthisused_");
         

--- a/extras/rya.console/src/test/java/org/apache/rya/shell/RyaShellITBase.java
+++ b/extras/rya.console/src/test/java/org/apache/rya/shell/RyaShellITBase.java
@@ -25,10 +25,13 @@ import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.minicluster.MiniAccumuloCluster;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
+import org.apache.rya.accumulo.MiniAccumuloSingleton;
+import org.apache.rya.accumulo.RyaTestInstanceRule;
 import org.apache.zookeeper.ClientCnxn;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.springframework.shell.Bootstrap;
 import org.springframework.shell.core.JLineShellComponent;
 
@@ -42,11 +45,6 @@ import org.apache.rya.accumulo.MiniAccumuloClusterInstance;
 public class RyaShellITBase {
 
     /**
-     * The cluster that will be used.
-     */
-    private MiniAccumuloClusterInstance cluster = null;
-
-    /**
      * The bootstrap that was used to initialize the Shell that will be tested.
      */
     private Bootstrap bootstrap;
@@ -56,6 +54,9 @@ public class RyaShellITBase {
      */
     private JLineShellComponent shell;
 
+    @Rule
+    public RyaTestInstanceRule testInstance = new RyaTestInstanceRule(false);
+
     @BeforeClass
     public static void killLoudLogs() {
         Logger.getLogger(ClientCnxn.class).setLevel(Level.ERROR);
@@ -63,10 +64,6 @@ public class RyaShellITBase {
 
     @Before
     public void startShell() throws IOException, InterruptedException, AccumuloException, AccumuloSecurityException {
-        // Start the cluster.
-        cluster = new MiniAccumuloClusterInstance();
-        cluster.startMiniAccumulo();
-
         // Bootstrap the shell with the test bean configuration.
         bootstrap = new Bootstrap(new String[]{}, new String[]{"file:src/test/resources/RyaShellTest-context.xml"});
         shell = bootstrap.getJLineShellComponent();
@@ -75,9 +72,6 @@ public class RyaShellITBase {
     @After
     public void stopShell() throws IOException, InterruptedException {
         shell.stop();
-
-        // Stop the cluster.
-        cluster.stopMiniAccumulo();
     }
 
     /**
@@ -98,6 +92,11 @@ public class RyaShellITBase {
      * @return The cluster that is hosting the test.
      */
     public MiniAccumuloCluster getCluster() {
-        return cluster.getCluster();
+        return MiniAccumuloSingleton.getInstance().getCluster();
     }
+
+    public String getInstanceName() {
+        return testInstance.getRyaInstanceName();
+    }
+
 }

--- a/extras/rya.geoindexing/pom.xml
+++ b/extras/rya.geoindexing/pom.xml
@@ -170,6 +170,9 @@
 				<artifactId>maven-shade-plugin</artifactId>
 				<executions>
 					<execution>
+						<goals>
+							<goal>shade</goal>
+						</goals>
 						<configuration>
 							<shadedArtifactAttached>true</shadedArtifactAttached>
 							<shadedClassifierName>map-reduce</shadedClassifierName>

--- a/extras/rya.geoindexing/src/test/java/org/apache/rya/indexing/mongo/MongoGeoIndexerSfTest.java
+++ b/extras/rya.geoindexing/src/test/java/org/apache/rya/indexing/mongo/MongoGeoIndexerSfTest.java
@@ -110,7 +110,7 @@ public class MongoGeoIndexerSfTest extends MongoRyaTestBase {
         System.out.println(UUID.randomUUID().toString());
         conf = new MongoDBRdfConfiguration();
         conf.set(ConfigUtils.USE_MONGO, "true");
-        conf.set(MongoDBRdfConfiguration.MONGO_DB_NAME, "test");
+        conf.set(MongoDBRdfConfiguration.MONGO_DB_NAME, getDbName());
         conf.set(MongoDBRdfConfiguration.MONGO_COLLECTION_PREFIX, "rya_");
         conf.set(ConfigUtils.GEO_PREDICATES_LIST, "http://www.opengis.net/ont/geosparql#asWKT");
         conf.set(OptionalConfigUtils.USE_GEO, "true");

--- a/extras/rya.geoindexing/src/test/java/org/apache/rya/indexing/mongo/MongoGeoIndexerTest.java
+++ b/extras/rya.geoindexing/src/test/java/org/apache/rya/indexing/mongo/MongoGeoIndexerTest.java
@@ -66,7 +66,7 @@ public class MongoGeoIndexerTest extends MongoRyaTestBase {
     public void before() throws Exception {
         conf = new MongoDBRdfConfiguration();
         conf.set(ConfigUtils.USE_MONGO, "true");
-        conf.set(MongoDBRdfConfiguration.MONGO_DB_NAME, "test");
+        conf.set(MongoDBRdfConfiguration.MONGO_DB_NAME, getDbName());
         conf.set(MongoDBRdfConfiguration.MONGO_COLLECTION_PREFIX, "rya_");
         conf.set(ConfigUtils.GEO_PREDICATES_LIST, "http://www.opengis.net/ont/geosparql#asWKT");
         conf.set(OptionalConfigUtils.USE_GEO, "true");

--- a/extras/rya.indexing.pcj/src/test/java/org/apache/rya/indexing/pcj/storage/accumulo/PcjTablesIntegrationTest.java
+++ b/extras/rya.indexing.pcj/src/test/java/org/apache/rya/indexing/pcj/storage/accumulo/PcjTablesIntegrationTest.java
@@ -41,6 +41,8 @@ import org.apache.log4j.Logger;
 import org.apache.rya.accumulo.AccumuloRdfConfiguration;
 import org.apache.rya.accumulo.AccumuloRyaDAO;
 import org.apache.rya.accumulo.MiniAccumuloClusterInstance;
+import org.apache.rya.accumulo.MiniAccumuloSingleton;
+import org.apache.rya.accumulo.RyaTestInstanceRule;
 import org.apache.rya.api.RdfCloudTripleStoreConfiguration;
 import org.apache.rya.indexing.pcj.storage.PcjException;
 import org.apache.rya.indexing.pcj.storage.PcjMetadata;
@@ -53,6 +55,7 @@ import org.apache.zookeeper.ClientCnxn;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 import org.openrdf.model.Statement;
 import org.openrdf.model.impl.LiteralImpl;
@@ -83,14 +86,15 @@ public class PcjTablesIntegrationTest {
 
     private static final AccumuloPcjSerializer converter = new AccumuloPcjSerializer();
 
-    protected static final String RYA_TABLE_PREFIX = "demo_";
-
     // The MiniAccumuloCluster is re-used between tests.
-    private MiniAccumuloClusterInstance cluster;
+    private MiniAccumuloClusterInstance cluster = MiniAccumuloSingleton.getInstance();
 
     // Rya data store and connections.
     protected RyaSailRepository ryaRepo = null;
     protected RepositoryConnection ryaConn = null;
+
+    @Rule
+    public RyaTestInstanceRule testInstance = new RyaTestInstanceRule(false);
 
     @BeforeClass
     public static void killLoudLogs() {
@@ -99,10 +103,6 @@ public class PcjTablesIntegrationTest {
 
     @Before
     public void resetTestEnvironmanet() throws AccumuloException, AccumuloSecurityException, TableNotFoundException, RepositoryException, IOException, InterruptedException {
-        // Start the cluster.
-        cluster = new MiniAccumuloClusterInstance();
-        cluster.startMiniAccumulo();
-
         // Setup the Rya library to use the Mini Accumulo.
         ryaRepo = setupRya();
         ryaConn = ryaRepo.getConnection();
@@ -111,12 +111,15 @@ public class PcjTablesIntegrationTest {
     @After
     public void shutdownMiniCluster() throws IOException, InterruptedException, RepositoryException {
         // Stop Rya.
-        ryaRepo.shutDown();
-
-        // Stop the cluster.
-        cluster.stopMiniAccumulo();
+        if (ryaRepo != null) {
+            ryaRepo.shutDown();
+        }
     }
 
+    private String getRyaInstanceName() {
+        return testInstance.getRyaInstanceName();
+    }
+    
     /**
      * Format a Mini Accumulo to be a Rya repository.
      *
@@ -130,11 +133,11 @@ public class PcjTablesIntegrationTest {
 
         // Setup Rya configuration values.
         final AccumuloRdfConfiguration conf = new AccumuloRdfConfiguration();
-        conf.setTablePrefix(RYA_TABLE_PREFIX);
+        conf.setTablePrefix(getRyaInstanceName());
         conf.setDisplayQueryPlan(true);
 
         conf.setBoolean(USE_MOCK_INSTANCE, false);
-        conf.set(RdfCloudTripleStoreConfiguration.CONF_TBL_PREFIX, RYA_TABLE_PREFIX);
+        conf.set(RdfCloudTripleStoreConfiguration.CONF_TBL_PREFIX, getRyaInstanceName());
         conf.set(CLOUDBASE_USER, cluster.getUsername());
         conf.set(CLOUDBASE_PASSWORD, cluster.getPassword());
         conf.set(CLOUDBASE_INSTANCE, cluster.getInstanceName());
@@ -167,7 +170,7 @@ public class PcjTablesIntegrationTest {
         final Connector accumuloConn = cluster.getConnector();
 
         // Create a PCJ table in the Mini Accumulo.
-        final String pcjTableName = new PcjTableNameFactory().makeTableName(RYA_TABLE_PREFIX, "testPcj");
+        final String pcjTableName = new PcjTableNameFactory().makeTableName(getRyaInstanceName(), "testPcj");
         final Set<VariableOrder> varOrders = new ShiftVarOrderFactory().makeVarOrders(new VariableOrder("name;age"));
         final PcjTables pcjs = new PcjTables();
         pcjs.createPcjTable(accumuloConn, pcjTableName, varOrders, sparql);
@@ -198,7 +201,7 @@ public class PcjTablesIntegrationTest {
         final Connector accumuloConn = cluster.getConnector();
 
         // Create a PCJ table in the Mini Accumulo.
-        final String pcjTableName = new PcjTableNameFactory().makeTableName(RYA_TABLE_PREFIX, "testPcj");
+        final String pcjTableName = new PcjTableNameFactory().makeTableName(getRyaInstanceName(), "testPcj");
         final Set<VariableOrder> varOrders = new ShiftVarOrderFactory().makeVarOrders(new VariableOrder("name;age"));
         final PcjTables pcjs = new PcjTables();
         pcjs.createPcjTable(accumuloConn, pcjTableName, varOrders, sparql);
@@ -249,7 +252,7 @@ public class PcjTablesIntegrationTest {
         final Connector accumuloConn = cluster.getConnector();
 
         // Create a PCJ table in the Mini Accumulo.
-        final String pcjTableName = new PcjTableNameFactory().makeTableName(RYA_TABLE_PREFIX, "testPcj");
+        final String pcjTableName = new PcjTableNameFactory().makeTableName(getRyaInstanceName(), "testPcj");
         final Set<VariableOrder> varOrders = new ShiftVarOrderFactory().makeVarOrders(new VariableOrder("name;age"));
         final PcjTables pcjs = new PcjTables();
         pcjs.createPcjTable(accumuloConn, pcjTableName, varOrders, sparql);
@@ -323,7 +326,7 @@ public class PcjTablesIntegrationTest {
 
         final Connector accumuloConn = cluster.getConnector();
 
-        final String pcjTableName = new PcjTableNameFactory().makeTableName(RYA_TABLE_PREFIX, "testPcj");
+        final String pcjTableName = new PcjTableNameFactory().makeTableName(getRyaInstanceName(), "testPcj");
         final Set<VariableOrder> varOrders = new ShiftVarOrderFactory().makeVarOrders(new VariableOrder("name;age"));
         final PcjTables pcjs = new PcjTables();
         pcjs.createPcjTable(accumuloConn, pcjTableName, varOrders, sparql);
@@ -393,7 +396,7 @@ public class PcjTablesIntegrationTest {
 
         final Connector accumuloConn = cluster.getConnector();
 
-        final String pcjTableName = new PcjTableNameFactory().makeTableName(RYA_TABLE_PREFIX, "testPcj");
+        final String pcjTableName = new PcjTableNameFactory().makeTableName(getRyaInstanceName(), "testPcj");
 
         // Create and populate the PCJ table.
         final PcjTables pcjs = new PcjTables();
@@ -476,7 +479,7 @@ public class PcjTablesIntegrationTest {
         final Connector accumuloConn = cluster.getConnector();
 
         // Create a PCJ table in the Mini Accumulo.
-        final String pcjTableName = new PcjTableNameFactory().makeTableName(RYA_TABLE_PREFIX, "testPcj");
+        final String pcjTableName = new PcjTableNameFactory().makeTableName(getRyaInstanceName(), "testPcj");
         final Set<VariableOrder> varOrders = new ShiftVarOrderFactory().makeVarOrders(new VariableOrder("name;age"));
         final PcjTables pcjs = new PcjTables();
         pcjs.createPcjTable(accumuloConn, pcjTableName, varOrders, sparql);
@@ -516,7 +519,7 @@ public class PcjTablesIntegrationTest {
         final Connector accumuloConn = cluster.getConnector();
 
         // Create a PCJ index.
-        final String tableName = new PcjTableNameFactory().makeTableName(RYA_TABLE_PREFIX, "thePcj");
+        final String tableName = new PcjTableNameFactory().makeTableName(getRyaInstanceName(), "thePcj");
         final Set<VariableOrder> varOrders = Sets.<VariableOrder>newHashSet( new VariableOrder("x") );
         final String sparql = "SELECT x WHERE ?x <http://isA> <http://Food>";
 

--- a/extras/rya.pcj.fluo/pcj.fluo.integration/src/test/java/org/apache/rya/indexing/pcj/fluo/FluoITBase.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.integration/src/test/java/org/apache/rya/indexing/pcj/fluo/FluoITBase.java
@@ -1,0 +1,282 @@
+package org.apache.rya.indexing.pcj.fluo;
+
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.net.UnknownHostException;
+
+import org.apache.accumulo.core.client.AccumuloException;
+import org.apache.accumulo.core.client.AccumuloSecurityException;
+import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.client.Instance;
+import org.apache.accumulo.core.client.ZooKeeperInstance;
+import org.apache.accumulo.core.client.security.tokens.PasswordToken;
+import org.apache.accumulo.minicluster.MiniAccumuloCluster;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.apache.rya.accumulo.MiniAccumuloClusterInstance;
+import org.apache.rya.accumulo.MiniAccumuloSingleton;
+import org.apache.rya.accumulo.RyaTestInstanceRule;
+import org.apache.rya.api.client.accumulo.AccumuloConnectionDetails;
+import org.apache.rya.api.client.accumulo.AccumuloInstall;
+import org.apache.zookeeper.ClientCnxn;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.openrdf.repository.RepositoryConnection;
+import org.openrdf.repository.RepositoryException;
+import org.openrdf.sail.Sail;
+import org.openrdf.sail.SailException;
+
+import org.apache.fluo.api.client.FluoAdmin;
+import org.apache.fluo.api.client.FluoAdmin.AlreadyInitializedException;
+import org.apache.fluo.api.client.FluoClient;
+import org.apache.fluo.api.client.FluoFactory;
+import org.apache.fluo.api.config.FluoConfiguration;
+import org.apache.fluo.api.mini.MiniFluo;
+import org.apache.rya.accumulo.AccumuloRdfConfiguration;
+import org.apache.rya.api.client.RyaClientException;
+import org.apache.rya.api.client.Install;
+import org.apache.rya.api.client.Install.DuplicateInstanceNameException;
+import org.apache.rya.api.client.Install.InstallConfiguration;
+import org.apache.rya.api.instance.RyaDetailsRepository.RyaDetailsRepositoryException;
+import org.apache.rya.api.persist.RyaDAOException;
+import org.apache.rya.indexing.accumulo.ConfigUtils;
+import org.apache.rya.indexing.external.PrecomputedJoinIndexerConfig;
+import org.apache.rya.rdftriplestore.RyaSailRepository;
+import org.apache.rya.rdftriplestore.inference.InferenceEngineException;
+import org.apache.rya.sail.config.RyaSailFactory;
+
+/**
+ * Integration tests that ensure the Fluo application processes PCJs results
+ * correctly.
+ * <p>
+ * This class is being ignored because it doesn't contain any unit tests.
+ */
+public abstract class FluoITBase {
+    private static final Logger log = Logger.getLogger(FluoITBase.class);
+
+    // Mini Accumulo Cluster
+    private static MiniAccumuloClusterInstance clusterInstance = MiniAccumuloSingleton.getInstance();
+    private static MiniAccumuloCluster cluster;
+
+    private static String instanceName = null;
+    private static String zookeepers = null;
+
+    protected static Connector accumuloConn = null;
+
+    // Fluo data store and connections.
+    protected MiniFluo fluo = null;
+    protected FluoConfiguration fluoConfig = null;
+    protected FluoClient fluoClient = null;
+
+    // Rya data store and connections.
+    protected RyaSailRepository ryaRepo = null;
+    protected RepositoryConnection ryaConn = null;
+
+    @Rule
+    public RyaTestInstanceRule testInstance = new RyaTestInstanceRule(false);
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        Logger.getLogger(ClientCnxn.class).setLevel(Level.ERROR);
+
+        // Setup and start the Mini Accumulo.
+        cluster = clusterInstance.getCluster();
+
+        // Store a connector to the Mini Accumulo.
+        instanceName = cluster.getInstanceName();
+        zookeepers = cluster.getZooKeepers();
+
+        final Instance instance = new ZooKeeperInstance(instanceName, zookeepers);
+        accumuloConn = instance.getConnector(clusterInstance.getUsername(), new PasswordToken(clusterInstance.getPassword()));
+    }
+
+    @Before
+    public void setupMiniResources() throws Exception {
+        // Initialize the Mini Fluo that will be used to store created queries.
+        fluoConfig = createFluoConfig();
+        preFluoInitHook();
+        FluoFactory.newAdmin(fluoConfig).initialize(new FluoAdmin.InitializationOptions()
+                .setClearTable(true)
+                .setClearZookeeper(true));
+        postFluoInitHook();
+        fluo = FluoFactory.newMiniFluo(fluoConfig);
+        fluoClient = FluoFactory.newClient(fluo.getClientConfiguration());
+
+        // Initialize the Rya that will be used by the tests.
+        ryaRepo = setupRya();
+        ryaConn = ryaRepo.getConnection();
+    }
+
+    @After
+    public void shutdownMiniResources() {
+        if (ryaConn != null) {
+            try {
+                log.info("Shutting down Rya Connection.");
+                ryaConn.close();
+                log.info("Rya Connection shut down.");
+            } catch (final Exception e) {
+                log.error("Could not shut down the Rya Connection.", e);
+            }
+        }
+
+        if (ryaRepo != null) {
+            try {
+                log.info("Shutting down Rya Repo.");
+                ryaRepo.shutDown();
+                log.info("Rya Repo shut down.");
+            } catch (final Exception e) {
+                log.error("Could not shut down the Rya Repo.", e);
+            }
+        }
+
+        if (fluoClient != null) {
+            try {
+                log.info("Shutting down Fluo Client.");
+                fluoClient.close();
+                log.info("Fluo Client shut down.");
+            } catch (final Exception e) {
+                log.error("Could not shut down the Fluo Client.", e);
+            }
+        }
+
+        if (fluo != null) {
+            try {
+                log.info("Shutting down Mini Fluo.");
+                fluo.close();
+                log.info("Mini Fluo shut down.");
+            } catch (final Exception e) {
+                log.error("Could not shut down the Mini Fluo.", e);
+            }
+        }
+    }
+
+    protected void preFluoInitHook() throws Exception {
+
+    }
+
+    protected void postFluoInitHook() throws Exception {
+
+    }
+
+    protected MiniAccumuloCluster getMiniAccumuloCluster() {
+        return cluster;
+    }
+
+    protected MiniFluo getMiniFluo() {
+        return fluo;
+    }
+
+    public RyaSailRepository getRyaSailRepository() {
+        return ryaRepo;
+    }
+
+    public Connector getAccumuloConnector() {
+        return accumuloConn;
+    }
+
+    public String getRyaInstanceName() {
+        return testInstance.getRyaInstanceName();
+    }
+
+    protected String getUsername() {
+        return clusterInstance.getUsername();
+    }
+
+    protected String getPassword() {
+        return clusterInstance.getPassword();
+    }
+
+    protected FluoConfiguration getFluoConfiguration() {
+        return fluoConfig;
+    }
+
+    public AccumuloConnectionDetails createConnectionDetails() {
+        return new AccumuloConnectionDetails(
+                clusterInstance.getUsername(),
+                clusterInstance.getPassword().toCharArray(),
+                clusterInstance.getInstanceName(),
+                clusterInstance.getZookeepers());
+    }
+
+    private FluoConfiguration createFluoConfig() {
+        // Configure how the mini fluo will run.
+        final FluoConfiguration config = new FluoConfiguration();
+        config.setMiniStartAccumulo(false);
+        config.setAccumuloInstance(instanceName);
+        config.setAccumuloUser(clusterInstance.getUsername());
+        config.setAccumuloPassword(clusterInstance.getPassword());
+        config.setInstanceZookeepers(zookeepers + "/fluo");
+        config.setAccumuloZookeepers(zookeepers);
+
+        config.setApplicationName(getRyaInstanceName());
+        config.setAccumuloTable("fluo" + getRyaInstanceName());
+        return config;
+    }
+
+    /**
+     * Sets up a Rya instance.
+     */
+    protected RyaSailRepository setupRya()
+            throws AccumuloException, AccumuloSecurityException, RepositoryException, RyaDAOException,
+            NumberFormatException, UnknownHostException, InferenceEngineException, AlreadyInitializedException,
+            RyaDetailsRepositoryException, DuplicateInstanceNameException, RyaClientException, SailException {
+        checkNotNull(instanceName);
+        checkNotNull(zookeepers);
+
+        // Setup Rya configuration values.
+        final AccumuloRdfConfiguration conf = new AccumuloRdfConfiguration();
+        conf.setTablePrefix(getRyaInstanceName());
+        conf.setDisplayQueryPlan(true);
+        conf.setBoolean(ConfigUtils.USE_MOCK_INSTANCE, false);
+        conf.set(ConfigUtils.CLOUDBASE_USER, clusterInstance.getUsername());
+        conf.set(ConfigUtils.CLOUDBASE_PASSWORD, clusterInstance.getPassword());
+        conf.set(ConfigUtils.CLOUDBASE_INSTANCE, clusterInstance.getInstanceName());
+        conf.set(ConfigUtils.CLOUDBASE_ZOOKEEPERS, clusterInstance.getZookeepers());
+        conf.set(ConfigUtils.USE_PCJ, "true");
+        conf.set(ConfigUtils.FLUO_APP_NAME, getRyaInstanceName());
+        conf.set(ConfigUtils.PCJ_STORAGE_TYPE, PrecomputedJoinIndexerConfig.PrecomputedJoinStorageType.ACCUMULO.toString());
+        conf.set(ConfigUtils.PCJ_UPDATER_TYPE, PrecomputedJoinIndexerConfig.PrecomputedJoinUpdaterType.FLUO.toString());
+        conf.set(ConfigUtils.CLOUDBASE_AUTHS, "");
+
+        // Install the test instance of Rya.
+        final Install install = new AccumuloInstall(createConnectionDetails(), accumuloConn);
+
+        final InstallConfiguration installConfig = InstallConfiguration.builder()
+                .setEnableTableHashPrefix(true)
+                .setEnableEntityCentricIndex(true)
+                .setEnableFreeTextIndex(true)
+                .setEnableTemporalIndex(true)
+                .setEnablePcjIndex(true)
+                .setEnableGeoIndex(true)
+                .setFluoPcjAppName(getRyaInstanceName())
+                .build();
+        install.install(getRyaInstanceName(), installConfig);
+
+        // Connect to the instance of Rya that was just installed.
+        final Sail sail = RyaSailFactory.getInstance(conf);
+        final RyaSailRepository ryaRepo = new RyaSailRepository(sail);
+
+        return ryaRepo;
+    }
+}

--- a/extras/rya.pcj.fluo/pcj.fluo.integration/src/test/java/org/apache/rya/indexing/pcj/fluo/KafkaExportITBase.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.integration/src/test/java/org/apache/rya/indexing/pcj/fluo/KafkaExportITBase.java
@@ -93,8 +93,6 @@ public class KafkaExportITBase extends AccumuloExportITBase {
 
     /**
      * Add info about the Kafka queue/topic to receive the export.
-     *
-     * @see org.apache.rya.indexing.pcj.fluo.ITBase#setExportParameters(java.util.HashMap)
      */
     @Override
     protected void preFluoInitHook() throws Exception {
@@ -128,8 +126,6 @@ public class KafkaExportITBase extends AccumuloExportITBase {
 
     /**
      * setup mini kafka and call the super to setup mini fluo
-     *
-     * @see org.apache.rya.indexing.pcj.fluo.ITBase#setupMiniResources()
      */
     @Before
     public void setupKafka() throws Exception {
@@ -239,8 +235,6 @@ public class KafkaExportITBase extends AccumuloExportITBase {
 
     /**
      * Close all the Kafka mini server and mini-zookeeper
-     *
-     * @see org.apache.rya.indexing.pcj.fluo.ITBase#shutdownMiniResources()
      */
     @After
     public void teardownKafka() {

--- a/extras/rya.pcj.fluo/pcj.fluo.integration/src/test/java/org/apache/rya/indexing/pcj/fluo/RyaExportITBase.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.integration/src/test/java/org/apache/rya/indexing/pcj/fluo/RyaExportITBase.java
@@ -22,19 +22,10 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-import org.apache.accumulo.minicluster.MiniAccumuloCluster;
 import org.apache.fluo.api.config.ObserverSpecification;
-import org.apache.fluo.recipes.test.AccumuloExportITBase;
 import org.apache.log4j.BasicConfigurator;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
-import org.apache.rya.accumulo.AccumuloRdfConfiguration;
-import org.apache.rya.api.client.Install.InstallConfiguration;
-import org.apache.rya.api.client.RyaClient;
-import org.apache.rya.api.client.accumulo.AccumuloConnectionDetails;
-import org.apache.rya.api.client.accumulo.AccumuloRyaClientFactory;
-import org.apache.rya.indexing.accumulo.ConfigUtils;
-import org.apache.rya.indexing.external.PrecomputedJoinIndexerConfig;
 import org.apache.rya.indexing.pcj.fluo.app.export.rya.RyaExportParameters;
 import org.apache.rya.indexing.pcj.fluo.app.observers.AggregationObserver;
 import org.apache.rya.indexing.pcj.fluo.app.observers.FilterObserver;
@@ -42,26 +33,12 @@ import org.apache.rya.indexing.pcj.fluo.app.observers.JoinObserver;
 import org.apache.rya.indexing.pcj.fluo.app.observers.QueryResultObserver;
 import org.apache.rya.indexing.pcj.fluo.app.observers.StatementPatternObserver;
 import org.apache.rya.indexing.pcj.fluo.app.observers.TripleObserver;
-import org.apache.rya.rdftriplestore.RyaSailRepository;
-import org.apache.rya.sail.config.RyaSailFactory;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.BeforeClass;
-import org.openrdf.sail.Sail;
 
 /**
  * The base Integration Test class used for Fluo applications that export to a Rya PCJ Index.
  */
-public class RyaExportITBase extends AccumuloExportITBase {
-
-    protected static final String RYA_INSTANCE_NAME = "test_";
-
-    private RyaSailRepository ryaSailRepo = null;
-
-    public RyaExportITBase() {
-        // Indicates that MiniFluo should be started before each test.
-        super(true);
-    }
+public class RyaExportITBase extends FluoITBase {
 
     @BeforeClass
     public static void setupLogging() {
@@ -83,11 +60,11 @@ public class RyaExportITBase extends AccumuloExportITBase {
         final HashMap<String, String> exportParams = new HashMap<>();
         final RyaExportParameters ryaParams = new RyaExportParameters(exportParams);
         ryaParams.setExportToRya(true);
-        ryaParams.setRyaInstanceName(RYA_INSTANCE_NAME);
+        ryaParams.setRyaInstanceName(getRyaInstanceName());
         ryaParams.setAccumuloInstanceName(super.getMiniAccumuloCluster().getInstanceName());
         ryaParams.setZookeeperServers(super.getMiniAccumuloCluster().getZooKeepers());
-        ryaParams.setExporterUsername(ACCUMULO_USER);
-        ryaParams.setExporterPassword(ACCUMULO_PASSWORD);
+        ryaParams.setExporterUsername(getUsername());
+        ryaParams.setExporterPassword(getPassword());
 
         final ObserverSpecification exportObserverConfig = new ObserverSpecification(QueryResultObserver.class.getName(), exportParams);
         observers.add(exportObserverConfig);
@@ -96,87 +73,4 @@ public class RyaExportITBase extends AccumuloExportITBase {
         super.getFluoConfiguration().addObservers(observers);
     }
 
-    @Before
-    public void setupRya() throws Exception {
-        final MiniAccumuloCluster cluster = super.getMiniAccumuloCluster();
-        final String instanceName = cluster.getInstanceName();
-        final String zookeepers = cluster.getZooKeepers();
-
-        // Install the Rya instance to the mini accumulo cluster.
-        final RyaClient ryaClient = AccumuloRyaClientFactory.build(
-                new AccumuloConnectionDetails(
-                    ACCUMULO_USER,
-                    ACCUMULO_PASSWORD.toCharArray(),
-                    instanceName,
-                    zookeepers),
-                super.getAccumuloConnector());
-
-        ryaClient.getInstall().install(RYA_INSTANCE_NAME, InstallConfiguration.builder()
-                .setEnableTableHashPrefix(false)
-                .setEnableFreeTextIndex(false)
-                .setEnableEntityCentricIndex(false)
-                .setEnableGeoIndex(false)
-                .setEnableTemporalIndex(false)
-                .setEnablePcjIndex(true)
-                .setFluoPcjAppName( super.getFluoConfiguration().getApplicationName() )
-                .build());
-
-        // Connect to the Rya instance that was just installed.
-        final AccumuloRdfConfiguration conf = makeConfig(instanceName, zookeepers);
-        final Sail sail = RyaSailFactory.getInstance(conf);
-        ryaSailRepo = new RyaSailRepository(sail);
-    }
-
-    @After
-    public void teardownRya() throws Exception {
-        final MiniAccumuloCluster cluster = super.getMiniAccumuloCluster();
-        final String instanceName = cluster.getInstanceName();
-        final String zookeepers = cluster.getZooKeepers();
-
-        // Uninstall the instance of Rya.
-        final RyaClient ryaClient = AccumuloRyaClientFactory.build(
-                new AccumuloConnectionDetails(
-                    ACCUMULO_USER,
-                    ACCUMULO_PASSWORD.toCharArray(),
-                    instanceName,
-                    zookeepers),
-                super.getAccumuloConnector());
-
-        ryaClient.getUninstall().uninstall(RYA_INSTANCE_NAME);
-
-        // Shutdown the repo.
-        ryaSailRepo.shutDown();
-    }
-
-    /**
-     * @return A {@link RyaSailRepository} that is connected to the Rya instance that statements are loaded into.
-     */
-    protected RyaSailRepository getRyaSailRepository() throws Exception {
-        return ryaSailRepo;
-    }
-
-    protected AccumuloRdfConfiguration makeConfig(final String instanceName, final String zookeepers) {
-        final AccumuloRdfConfiguration conf = new AccumuloRdfConfiguration();
-        conf.setTablePrefix(RYA_INSTANCE_NAME);
-
-        // Accumulo connection information.
-        conf.setAccumuloUser(AccumuloExportITBase.ACCUMULO_USER);
-        conf.setAccumuloPassword(AccumuloExportITBase.ACCUMULO_PASSWORD);
-        conf.setAccumuloInstance(super.getAccumuloConnector().getInstance().getInstanceName());
-        conf.setAccumuloZookeepers(super.getAccumuloConnector().getInstance().getZooKeepers());
-        conf.setAuths("");
-
-        // PCJ configuration information.
-        conf.set(ConfigUtils.USE_PCJ, "true");
-        conf.set(ConfigUtils.USE_PCJ_UPDATER_INDEX, "true");
-        conf.set(ConfigUtils.FLUO_APP_NAME, super.getFluoConfiguration().getApplicationName());
-        conf.set(ConfigUtils.PCJ_STORAGE_TYPE,
-                PrecomputedJoinIndexerConfig.PrecomputedJoinStorageType.ACCUMULO.toString());
-        conf.set(ConfigUtils.PCJ_UPDATER_TYPE,
-                PrecomputedJoinIndexerConfig.PrecomputedJoinUpdaterType.FLUO.toString());
-
-        conf.setDisplayQueryPlan(true);
-
-        return conf;
-    }
 }

--- a/extras/rya.pcj.fluo/pcj.fluo.integration/src/test/java/org/apache/rya/indexing/pcj/fluo/api/GetPcjMetadataIT.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.integration/src/test/java/org/apache/rya/indexing/pcj/fluo/api/GetPcjMetadataIT.java
@@ -63,12 +63,12 @@ public class GetPcjMetadataIT extends RyaExportITBase {
 
         // Create the PCJ table.
         final Connector accumuloConn = super.getAccumuloConnector();
-        final PrecomputedJoinStorage pcjStorage = new AccumuloPcjStorage(accumuloConn, RYA_INSTANCE_NAME);
+        final PrecomputedJoinStorage pcjStorage = new AccumuloPcjStorage(accumuloConn, getRyaInstanceName());
         final String pcjId = pcjStorage.createPcj(sparql);
 
         try(FluoClient fluoClient = FluoFactory.newClient(super.getFluoConfiguration())) {
             // Tell the Fluo app to maintain the PCJ.
-            new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, accumuloConn, RYA_INSTANCE_NAME);
+            new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, accumuloConn, getRyaInstanceName());
 
             // Fetch the PCJ's Metadata through the GetPcjMetadata interactor.
             final String queryId = new ListQueryIds().listQueryIds(fluoClient).get(0);
@@ -84,7 +84,7 @@ public class GetPcjMetadataIT extends RyaExportITBase {
     @Test
     public void getAllMetadata() throws MalformedQueryException, SailException, QueryEvaluationException, PcjException, NotInFluoException, NotInAccumuloException, AccumuloException, AccumuloSecurityException, RyaDAOException {
         final Connector accumuloConn = super.getAccumuloConnector();
-        final PrecomputedJoinStorage pcjStorage = new AccumuloPcjStorage(accumuloConn, RYA_INSTANCE_NAME);
+        final PrecomputedJoinStorage pcjStorage = new AccumuloPcjStorage(accumuloConn, getRyaInstanceName());
 
         try(FluoClient fluoClient = FluoFactory.newClient(super.getFluoConfiguration())) {
             // Add a couple of queries to Accumulo.
@@ -96,7 +96,7 @@ public class GetPcjMetadataIT extends RyaExportITBase {
                             "}";
             final String q1PcjId = pcjStorage.createPcj(q1Sparql);
             final CreatePcj createPcj = new CreatePcj();
-            createPcj.withRyaIntegration(q1PcjId, pcjStorage, fluoClient, accumuloConn, RYA_INSTANCE_NAME);
+            createPcj.withRyaIntegration(q1PcjId, pcjStorage, fluoClient, accumuloConn, getRyaInstanceName());
 
             final String q2Sparql =
                     "SELECT ?x ?y " +
@@ -105,7 +105,7 @@ public class GetPcjMetadataIT extends RyaExportITBase {
                             "?y <http://worksAt> <http://Chipotle>." +
                             "}";
             final String q2PcjId = pcjStorage.createPcj(q2Sparql);
-            createPcj.withRyaIntegration(q2PcjId, pcjStorage, fluoClient, accumuloConn, RYA_INSTANCE_NAME);
+            createPcj.withRyaIntegration(q2PcjId, pcjStorage, fluoClient, accumuloConn, getRyaInstanceName());
 
             // Ensure the command returns the correct metadata.
             final Set<PcjMetadata> expected = new HashSet<>();

--- a/extras/rya.pcj.fluo/pcj.fluo.integration/src/test/java/org/apache/rya/indexing/pcj/fluo/api/GetQueryReportIT.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.integration/src/test/java/org/apache/rya/indexing/pcj/fluo/api/GetQueryReportIT.java
@@ -78,13 +78,14 @@ public class GetQueryReportIT extends RyaExportITBase {
                 new RyaStatement(new RyaURI("http://Frank"), new RyaURI("http://livesIn"), new RyaURI("http://Lost County")));
 
         // Create the PCJ table.
+
         final Connector accumuloConn = super.getAccumuloConnector();
-        final PrecomputedJoinStorage pcjStorage = new AccumuloPcjStorage(accumuloConn, RYA_INSTANCE_NAME);
+        final PrecomputedJoinStorage pcjStorage = new AccumuloPcjStorage(accumuloConn, getRyaInstanceName());
         final String pcjId = pcjStorage.createPcj(sparql);
 
         try(FluoClient fluoClient = FluoFactory.newClient(super.getFluoConfiguration())) {
             // Tell the Fluo app to maintain the PCJ.
-            new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, accumuloConn, RYA_INSTANCE_NAME);
+            new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, accumuloConn, getRyaInstanceName());
 
             // Stream the data into Fluo.
             new InsertTriples().insert(fluoClient, streamedTriples, Optional.<String>absent());

--- a/extras/rya.pcj.fluo/pcj.fluo.integration/src/test/java/org/apache/rya/indexing/pcj/fluo/integration/CreateDeleteIT.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.integration/src/test/java/org/apache/rya/indexing/pcj/fluo/integration/CreateDeleteIT.java
@@ -26,8 +26,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.accumulo.core.client.Connector;
-import org.apache.accumulo.core.client.Instance;
 import org.apache.fluo.api.client.FluoClient;
 import org.apache.fluo.api.client.FluoFactory;
 import org.apache.fluo.api.client.Snapshot;
@@ -36,7 +34,6 @@ import org.apache.fluo.api.client.scanner.RowScanner;
 import org.apache.fluo.api.data.Bytes;
 import org.apache.fluo.api.data.Span;
 import org.apache.rya.api.client.RyaClient;
-import org.apache.rya.api.client.accumulo.AccumuloConnectionDetails;
 import org.apache.rya.api.client.accumulo.AccumuloRyaClientFactory;
 import org.apache.rya.indexing.pcj.fluo.RyaExportITBase;
 import org.apache.rya.indexing.pcj.fluo.api.DeletePcj;
@@ -130,16 +127,9 @@ public class CreateDeleteIT extends RyaExportITBase {
         requireNonNull(statements);
 
         // Register the PCJ with Rya.
-        final Instance accInstance = super.getAccumuloConnector().getInstance();
-        final Connector accumuloConn = super.getAccumuloConnector();
+        final RyaClient ryaClient = AccumuloRyaClientFactory.build(createConnectionDetails(), getAccumuloConnector());
 
-        final RyaClient ryaClient = AccumuloRyaClientFactory.build(new AccumuloConnectionDetails(
-                ACCUMULO_USER,
-                ACCUMULO_PASSWORD.toCharArray(),
-                accInstance.getInstanceName(),
-                accInstance.getZooKeepers()), accumuloConn);
-
-        final String pcjId = ryaClient.getCreatePCJ().createPCJ(RYA_INSTANCE_NAME, sparql);
+        final String pcjId = ryaClient.getCreatePCJ().createPCJ(getRyaInstanceName(), sparql);
 
         // Write the data to Rya.
         final SailRepositoryConnection ryaConn = super.getRyaSailRepository().getConnection();

--- a/extras/rya.pcj.fluo/pcj.fluo.integration/src/test/java/org/apache/rya/indexing/pcj/fluo/integration/InputIT.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.integration/src/test/java/org/apache/rya/indexing/pcj/fluo/integration/InputIT.java
@@ -97,12 +97,12 @@ public class InputIT extends RyaExportITBase {
 
         // Create the PCJ table.
         final Connector accumuloConn = super.getAccumuloConnector();
-        final PrecomputedJoinStorage pcjStorage = new AccumuloPcjStorage(accumuloConn, RYA_INSTANCE_NAME);
+        final PrecomputedJoinStorage pcjStorage = new AccumuloPcjStorage(accumuloConn, getRyaInstanceName());
         final String pcjId = pcjStorage.createPcj(sparql);
 
         try(FluoClient fluoClient = FluoFactory.newClient(super.getFluoConfiguration())) {
             // Tell the Fluo app to maintain the PCJ.
-            new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, accumuloConn, RYA_INSTANCE_NAME);
+            new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, accumuloConn, getRyaInstanceName());
 
             // Verify the end results of the query match the expected results.
             super.getMiniFluo().waitForObservers();
@@ -157,12 +157,12 @@ public class InputIT extends RyaExportITBase {
 
         // Create the PCJ table.
         final Connector accumuloConn = super.getAccumuloConnector();
-        final PrecomputedJoinStorage pcjStorage = new AccumuloPcjStorage(accumuloConn, RYA_INSTANCE_NAME);
+        final PrecomputedJoinStorage pcjStorage = new AccumuloPcjStorage(accumuloConn, getRyaInstanceName());
         final String pcjId = pcjStorage.createPcj(sparql);
 
         try(FluoClient fluoClient = FluoFactory.newClient(super.getFluoConfiguration())) {
             // Tell the Fluo app to maintain the PCJ.
-            new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, accumuloConn, RYA_INSTANCE_NAME);
+            new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, accumuloConn, getRyaInstanceName());
 
             // Ensure the query has no results yet.
             super.getMiniFluo().waitForObservers();
@@ -223,12 +223,12 @@ public class InputIT extends RyaExportITBase {
 
         // Create the PCJ table.
         final Connector accumuloConn = super.getAccumuloConnector();
-        final PrecomputedJoinStorage pcjStorage = new AccumuloPcjStorage(accumuloConn, RYA_INSTANCE_NAME);
+        final PrecomputedJoinStorage pcjStorage = new AccumuloPcjStorage(accumuloConn, getRyaInstanceName());
         final String pcjId = pcjStorage.createPcj(sparql);
 
         try(FluoClient fluoClient = FluoFactory.newClient(super.getFluoConfiguration())) {
             // Tell the Fluo app to maintain the PCJ.
-            new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, accumuloConn, RYA_INSTANCE_NAME);
+            new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, accumuloConn, getRyaInstanceName());
 
             // Ensure Alice is a match.
             super.getMiniFluo().waitForObservers();
@@ -312,12 +312,12 @@ public class InputIT extends RyaExportITBase {
 
         // Create the PCJ table.
         final Connector accumuloConn = super.getAccumuloConnector();
-        final PrecomputedJoinStorage pcjStorage = new AccumuloPcjStorage(accumuloConn, RYA_INSTANCE_NAME);
+        final PrecomputedJoinStorage pcjStorage = new AccumuloPcjStorage(accumuloConn, getRyaInstanceName());
         final String pcjId = pcjStorage.createPcj(sparql);
 
         try(FluoClient fluoClient = FluoFactory.newClient(super.getFluoConfiguration())) {
             // Tell the Fluo app to maintain the PCJ.
-            new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, accumuloConn, RYA_INSTANCE_NAME);
+            new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, accumuloConn, getRyaInstanceName());
 
             // Ensure Alice is a match.
             super.getMiniFluo().waitForObservers();

--- a/extras/rya.pcj.fluo/pcj.fluo.integration/src/test/java/org/apache/rya/indexing/pcj/fluo/integration/QueryIT.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.integration/src/test/java/org/apache/rya/indexing/pcj/fluo/integration/QueryIT.java
@@ -439,16 +439,11 @@ public class QueryIT extends RyaExportITBase {
         requireNonNull(expectedResults);
 
         // Register the PCJ with Rya.
-        final Instance accInstance = super.getAccumuloConnector().getInstance();
         final Connector accumuloConn = super.getAccumuloConnector();
 
-        final RyaClient ryaClient = AccumuloRyaClientFactory.build(new AccumuloConnectionDetails(
-                ACCUMULO_USER,
-                ACCUMULO_PASSWORD.toCharArray(),
-                accInstance.getInstanceName(),
-                accInstance.getZooKeepers()), accumuloConn);
+        final RyaClient ryaClient = AccumuloRyaClientFactory.build(createConnectionDetails(), accumuloConn);
 
-        ryaClient.getCreatePCJ().createPCJ(RYA_INSTANCE_NAME, sparql);
+        ryaClient.getCreatePCJ().createPCJ(getRyaInstanceName(), sparql);
 
         // Write the data to Rya.
         final SailRepositoryConnection ryaConn = super.getRyaSailRepository().getConnection();
@@ -461,7 +456,7 @@ public class QueryIT extends RyaExportITBase {
         super.getMiniFluo().waitForObservers();
 
         // Fetch the value that is stored within the PCJ table.
-        try(final PrecomputedJoinStorage pcjStorage = new AccumuloPcjStorage(accumuloConn, RYA_INSTANCE_NAME)) {
+        try(final PrecomputedJoinStorage pcjStorage = new AccumuloPcjStorage(accumuloConn, getRyaInstanceName())) {
             final String pcjId = pcjStorage.listPcjs().get(0);
             final Set<BindingSet> results = Sets.newHashSet( pcjStorage.listResults(pcjId) );
 

--- a/extras/rya.pcj.fluo/pcj.fluo.integration/src/test/java/org/apache/rya/indexing/pcj/fluo/integration/RyaExportIT.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.integration/src/test/java/org/apache/rya/indexing/pcj/fluo/integration/RyaExportIT.java
@@ -105,12 +105,12 @@ public class RyaExportIT extends RyaExportITBase {
 
         // Create the PCJ table.
         final Connector accumuloConn = super.getAccumuloConnector();
-        final PrecomputedJoinStorage pcjStorage = new AccumuloPcjStorage(accumuloConn, RYA_INSTANCE_NAME);
+        final PrecomputedJoinStorage pcjStorage = new AccumuloPcjStorage(accumuloConn, getRyaInstanceName());
         final String pcjId = pcjStorage.createPcj(sparql);
 
         try(FluoClient fluoClient = FluoFactory.newClient(super.getFluoConfiguration())) {
             // Tell the Fluo app to maintain the PCJ.
-            new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, accumuloConn, RYA_INSTANCE_NAME);
+            new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, accumuloConn, getRyaInstanceName());
 
             // Stream the data into Fluo.
             new InsertTriples().insert(fluoClient, streamedTriples, Optional.<String>absent());

--- a/extras/rya.pcj.fluo/pcj.fluo.integration/src/test/java/org/apache/rya/indexing/pcj/fluo/integration/RyaInputIncrementalUpdateIT.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.integration/src/test/java/org/apache/rya/indexing/pcj/fluo/integration/RyaInputIncrementalUpdateIT.java
@@ -94,12 +94,12 @@ public class RyaInputIncrementalUpdateIT extends RyaExportITBase {
 
         // Create the PCJ table.
         final Connector accumuloConn = super.getAccumuloConnector();
-        final PrecomputedJoinStorage pcjStorage = new AccumuloPcjStorage(accumuloConn, RYA_INSTANCE_NAME);
+        final PrecomputedJoinStorage pcjStorage = new AccumuloPcjStorage(accumuloConn, getRyaInstanceName());
         final String pcjId = pcjStorage.createPcj(sparql);
 
         try(FluoClient fluoClient = FluoFactory.newClient(super.getFluoConfiguration())) {
             // Tell the Fluo app to maintain the PCJ.
-            new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, accumuloConn, RYA_INSTANCE_NAME);
+            new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, accumuloConn, getRyaInstanceName());
 
             // Verify the end results of the query match the expected results.
             super.getMiniFluo().waitForObservers();
@@ -160,12 +160,12 @@ public class RyaInputIncrementalUpdateIT extends RyaExportITBase {
 
         // Create the PCJ table.
         final Connector accumuloConn = super.getAccumuloConnector();
-        final PrecomputedJoinStorage pcjStorage = new AccumuloPcjStorage(accumuloConn, RYA_INSTANCE_NAME);
+        final PrecomputedJoinStorage pcjStorage = new AccumuloPcjStorage(accumuloConn, getRyaInstanceName());
         final String pcjId = pcjStorage.createPcj(sparql);
 
         try(FluoClient fluoClient = FluoFactory.newClient(super.getFluoConfiguration())) {
             // Tell the Fluo app to maintain the PCJ.
-            new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, accumuloConn, RYA_INSTANCE_NAME);
+            new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, accumuloConn, getRyaInstanceName());
 
             super.getMiniFluo().waitForObservers();
 
@@ -231,12 +231,12 @@ public class RyaInputIncrementalUpdateIT extends RyaExportITBase {
 
         // Create the PCJ table.
         final Connector accumuloConn = super.getAccumuloConnector();
-        final PrecomputedJoinStorage pcjStorage = new AccumuloPcjStorage(accumuloConn, RYA_INSTANCE_NAME);
+        final PrecomputedJoinStorage pcjStorage = new AccumuloPcjStorage(accumuloConn, getRyaInstanceName());
         final String pcjId = pcjStorage.createPcj(sparql);
 
         try(FluoClient fluoClient = FluoFactory.newClient(super.getFluoConfiguration())) {
             // Tell the Fluo app to maintain the PCJ.
-            new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, accumuloConn, RYA_INSTANCE_NAME);
+            new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, accumuloConn, getRyaInstanceName());
 
             super.getMiniFluo().waitForObservers();
 

--- a/extras/rya.pcj.fluo/pcj.fluo.integration/src/test/java/org/apache/rya/indexing/pcj/fluo/integration/StreamingTestIT.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.integration/src/test/java/org/apache/rya/indexing/pcj/fluo/integration/StreamingTestIT.java
@@ -56,11 +56,11 @@ public class StreamingTestIT extends RyaExportITBase {
 	    try (FluoClient fluoClient = FluoFactory.newClient(super.getFluoConfiguration())) {
 	        // Create the PCJ table.
 	        final Connector accumuloConn = super.getAccumuloConnector();
-	        final PrecomputedJoinStorage pcjStorage = new AccumuloPcjStorage(accumuloConn, RYA_INSTANCE_NAME);
+	        final PrecomputedJoinStorage pcjStorage = new AccumuloPcjStorage(accumuloConn, getRyaInstanceName());
 	        final String pcjId = pcjStorage.createPcj(sparql);
 
 	        // Task the Fluo app with the PCJ.
-	        new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, accumuloConn, RYA_INSTANCE_NAME);
+	        new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, accumuloConn, getRyaInstanceName());
 
 	        // Add Statements to the Fluo app.
 	        log.info("Adding Join Pairs...");

--- a/extras/rya.pcj.fluo/pcj.fluo.integration/src/test/java/org/apache/rya/indexing/pcj/fluo/visibility/HistoricStreamingVisibilityIT.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.integration/src/test/java/org/apache/rya/indexing/pcj/fluo/visibility/HistoricStreamingVisibilityIT.java
@@ -67,7 +67,7 @@ public class HistoricStreamingVisibilityIT extends RyaExportITBase {
               "}";
 
         final Connector accumuloConn = super.getAccumuloConnector();
-        accumuloConn.securityOperations().changeUserAuthorizations(ACCUMULO_USER, new Authorizations("U","V","W"));
+        accumuloConn.securityOperations().changeUserAuthorizations(getUsername(), new Authorizations("U","V","W"));
         final AccumuloRyaDAO dao = new AccumuloRyaDAO();
         dao.setConnector(accumuloConn);
         dao.setConf(makeConfig());
@@ -103,11 +103,11 @@ public class HistoricStreamingVisibilityIT extends RyaExportITBase {
         expected.add(bs);
 
         // Create the PCJ table.
-        final PrecomputedJoinStorage pcjStorage = new AccumuloPcjStorage(accumuloConn, RYA_INSTANCE_NAME);
+        final PrecomputedJoinStorage pcjStorage = new AccumuloPcjStorage(accumuloConn, getRyaInstanceName());
         final String pcjId = pcjStorage.createPcj(sparql);
 
         try(FluoClient fluoClient = FluoFactory.newClient(super.getFluoConfiguration())) {
-            new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, accumuloConn, RYA_INSTANCE_NAME);
+            new CreatePcj().withRyaIntegration(pcjId, pcjStorage, fluoClient, accumuloConn, getRyaInstanceName());
         }
 
         // Verify the end results of the query match the expected results.
@@ -119,10 +119,10 @@ public class HistoricStreamingVisibilityIT extends RyaExportITBase {
 
     private AccumuloRdfConfiguration makeConfig() {
         final AccumuloRdfConfiguration conf = new AccumuloRdfConfiguration();
-        conf.setTablePrefix(RYA_INSTANCE_NAME);
+        conf.setTablePrefix(getRyaInstanceName());
         // Accumulo connection information.
-        conf.set(ConfigUtils.CLOUDBASE_USER, ACCUMULO_USER);
-        conf.set(ConfigUtils.CLOUDBASE_PASSWORD, ACCUMULO_PASSWORD);
+        conf.set(ConfigUtils.CLOUDBASE_USER, getUsername());
+        conf.set(ConfigUtils.CLOUDBASE_PASSWORD, getPassword());
         conf.set(ConfigUtils.CLOUDBASE_INSTANCE, super.getMiniAccumuloCluster().getInstanceName());
         conf.set(ConfigUtils.CLOUDBASE_ZOOKEEPERS, super.getMiniAccumuloCluster().getZooKeepers());
         conf.set(RdfCloudTripleStoreConfiguration.CONF_QUERY_AUTH, "U,V,W");


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

  http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
## Description
Adds a singleton container for the Accumulo MiniCluster to share the MiniCluster across tests (within a project).  Also adds a test rule that can be used to get unique rya instance names and user names within an execution of the tests.

A new fluo instance is still created per test and this is now the dominating contributor to test runtime.  There does not appear to be an obvious way to share the fluo instance since each test will have a separate rya instance and the export observer must be configured up front with the rya instance name.

### Tests
Tests were updated to avoid conflicting rya instance names, user names, etc.  No new tests were added because no functionality was added.

### Links
[Jira](https://issues.apache.org/jira/browse/RYA-67)

### Checklist
- [ ] Code Review
- [x] Squash Commits

#### People To Reivew
@meiercaleb @isper3at @pujav65 @amihalik 
