### PR TITLE
Null checks fix and predicates logging.

### DIFF
--- a/extras/indexing/src/main/java/org/apache/rya/indexing/mongodb/freetext/MongoFreeTextIndexer.java
+++ b/extras/indexing/src/main/java/org/apache/rya/indexing/mongodb/freetext/MongoFreeTextIndexer.java
@@ -21,16 +21,16 @@ package org.apache.rya.indexing.mongodb.freetext;
 import java.io.IOException;
 
 import org.apache.log4j.Logger;
+import org.apache.rya.indexing.FreeTextIndexer;
+import org.apache.rya.indexing.StatementConstraints;
+import org.apache.rya.indexing.accumulo.ConfigUtils;
+import org.apache.rya.indexing.mongodb.AbstractMongoIndexer;
 import org.openrdf.model.Statement;
 import org.openrdf.query.QueryEvaluationException;
 
 import com.mongodb.QueryBuilder;
 
 import info.aduna.iteration.CloseableIteration;
-import org.apache.rya.indexing.FreeTextIndexer;
-import org.apache.rya.indexing.StatementConstraints;
-import org.apache.rya.indexing.accumulo.ConfigUtils;
-import org.apache.rya.indexing.mongodb.AbstractMongoIndexer;
 
 public class MongoFreeTextIndexer extends AbstractMongoIndexer<TextMongoDBStorageStrategy> implements FreeTextIndexer {
     private static final String COLLECTION_SUFFIX = "freetext";
@@ -40,6 +40,9 @@ public class MongoFreeTextIndexer extends AbstractMongoIndexer<TextMongoDBStorag
     public void init() {
         initCore();
         predicates = ConfigUtils.getFreeTextPredicates(conf);
+        if(predicates.size() == 0) {
+            logger.debug("No predicates specified for freetext indexing.  During insertion, all statements will be attempted to be indexed into the freetext indexer.");
+        }
         storageStrategy = new TextMongoDBStorageStrategy();
         storageStrategy.createIndices(collection);
     }

--- a/extras/indexing/src/main/java/org/apache/rya/indexing/mongodb/temporal/MongoTemporalIndexer.java
+++ b/extras/indexing/src/main/java/org/apache/rya/indexing/mongodb/temporal/MongoTemporalIndexer.java
@@ -23,6 +23,12 @@ import static org.apache.rya.indexing.mongodb.temporal.TemporalMongoDBStorageStr
 import static org.apache.rya.indexing.mongodb.temporal.TemporalMongoDBStorageStrategy.INTERVAL_START;
 
 import org.apache.log4j.Logger;
+import org.apache.rya.indexing.StatementConstraints;
+import org.apache.rya.indexing.TemporalIndexer;
+import org.apache.rya.indexing.TemporalInstant;
+import org.apache.rya.indexing.TemporalInterval;
+import org.apache.rya.indexing.accumulo.ConfigUtils;
+import org.apache.rya.indexing.mongodb.AbstractMongoIndexer;
 import org.openrdf.model.Statement;
 import org.openrdf.query.QueryEvaluationException;
 
@@ -31,12 +37,6 @@ import com.mongodb.DBCollection;
 import com.mongodb.QueryBuilder;
 
 import info.aduna.iteration.CloseableIteration;
-import org.apache.rya.indexing.StatementConstraints;
-import org.apache.rya.indexing.TemporalIndexer;
-import org.apache.rya.indexing.TemporalInstant;
-import org.apache.rya.indexing.TemporalInterval;
-import org.apache.rya.indexing.accumulo.ConfigUtils;
-import org.apache.rya.indexing.mongodb.AbstractMongoIndexer;
 
 /**
  * Indexes MongoDB based on time instants or intervals.
@@ -49,6 +49,9 @@ public class MongoTemporalIndexer extends AbstractMongoIndexer<TemporalMongoDBSt
     public void init() {
         initCore();
         predicates = ConfigUtils.getTemporalPredicates(conf);
+        if(predicates.size() == 0) {
+            LOG.debug("No predicates specified for temporal indexing.  During insertion, all statements will be attempted to be indexed into the temporal indexer.");
+        }
         storageStrategy = new TemporalMongoDBStorageStrategy();
         storageStrategy.createIndices(collection);
     }

--- a/extras/rya.geoindexing/src/main/java/org/apache/rya/indexing/mongodb/geo/GeoMongoDBStorageStrategy.java
+++ b/extras/rya.geoindexing/src/main/java/org/apache/rya/indexing/mongodb/geo/GeoMongoDBStorageStrategy.java
@@ -127,6 +127,10 @@ public class GeoMongoDBStorageStrategy extends IndexingMongoDBStorageStrategy {
         try {
             final Statement statement = RyaToRdfConversions.convertStatement(ryaStatement);
             final Geometry geo = (new WKTReader()).read(GeoParseUtils.getWellKnownText(statement));
+            if(geo == null) {
+                LOG.error("Failed to parse geo statement: " + statement.toString());
+                return null;
+            }
             final BasicDBObject base = (BasicDBObject) super.serialize(ryaStatement);
             base.append(GEO, getCorrespondingPoints(geo));
             return base;

--- a/extras/rya.geoindexing/src/main/java/org/apache/rya/indexing/mongodb/geo/MongoGeoIndexer.java
+++ b/extras/rya.geoindexing/src/main/java/org/apache/rya/indexing/mongodb/geo/MongoGeoIndexer.java
@@ -46,6 +46,9 @@ public class MongoGeoIndexer extends AbstractMongoIndexer<GeoMongoDBStorageStrat
 	public void init() {
         initCore();
         predicates = ConfigUtils.getGeoPredicates(conf);
+        if(predicates.size() == 0) {
+            logger.debug("No predicates specified for geo indexing.  During insertion, all statements will be attempted to be indexed into the geo indexer.");
+        }
         storageStrategy = new GeoMongoDBStorageStrategy(Double.valueOf(conf.get(MongoDBRdfConfiguration.MONGO_GEO_MAXDISTANCE, "1e-10")));
         storageStrategy.createIndices(collection);
     }


### PR DESCRIPTION
Fixed a problem in the GeoMongoDBStorageStrategy when the
WKTReader would return null and an exception would be
thrown after.
Added logging for predicates check, advising to use them when
possible.

## Description
>What Changed?
Added logging for predicates list checks in the secondary indexers for mongo.
Added null check after WKTReader returned, if it returns null, the serialization failed.

### Tests
>Coverage?
no additional tests added

### Links

### Checklist
- [ ] Code Review
- [x] Squash Commits

#### People To Reivew
@meiercaleb 
@amihalik 
