### PR TITLE
RYA-288: corrected path to launch PcjAdminClient

### DIFF
--- a/extras/rya.pcj.fluo/pcj.fluo.client/pom.xml
+++ b/extras/rya.pcj.fluo/pcj.fluo.client/pom.xml
@@ -115,7 +115,7 @@ under the License.
                             <classpathLayoutType>custom</classpathLayoutType>
                             <customClasspathLayout>WEB-INF/lib/$${artifact.groupIdPath}/$${artifact.artifactId}-$${artifact.version}$${dashClassifier?}.$${artifact.extension}</customClasspathLayout>
                         
-                            <mainClass>org.apache.rya.indexing.pcj.fluo.PcjAdminClient</mainClass>
+                            <mainClass>org.apache.rya.indexing.pcj.fluo.client.PcjAdminClient</mainClass>
                         </manifest>
                     </archive>
                     <descriptorRefs>


### PR DESCRIPTION
## Description
Unable to launch PcjAdminClient from the bundle jar due to invalid path to PcjAdminClient defined in the pom file.

### Tests
No Test added

Successfully launched PcjAdminClient using "java -jar" command

### Links
[JIRA -> RYA-288](https://issues.apache.org/jira/browse/RYA-288)

#### People To Reivew
@amihalik 
