### PR TITLE
RYA-297 Added owl:equivalentClass inference

### DIFF
--- a/sail/src/main/java/org/apache/rya/rdftriplestore/inference/SubClassOfVisitor.java
+++ b/sail/src/main/java/org/apache/rya/rdftriplestore/inference/SubClassOfVisitor.java
@@ -68,7 +68,7 @@ public class SubClassOfVisitor extends AbstractInferVisitor {
                 String s = UUID.randomUUID().toString();
                 Var typeVar = new Var(s);
                 FixedStatementPattern fsp = new FixedStatementPattern(typeVar, new Var("c-" + s, RDFS.SUBCLASSOF), objVar, conVar);
-                fsp.statements.add(new NullableStatementImpl(subclassof_uri, RDFS.SUBCLASSOF, subclassof_uri));
+                parents.add(subclassof_uri);
                 for (URI u : parents) {
                     fsp.statements.add(new NullableStatementImpl(u, RDFS.SUBCLASSOF, subclassof_uri));
                 }


### PR DESCRIPTION
If A and B are equivalent classes, then A is a subclass of B and B is a subclass of A. Handled the same way as owl:equivalentProperty.

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

  http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
## Description
Modified InferenceEngine to add equivalentClass information to the subclass graph. (Semantics: for two classes to be equivalent means that they represent the same set, while for one class to be a subclass of another means that it represents a subset. Therefore to say that two classes are equivalent is identical to saying that each is a subclass of the other.) Pulled the query logic into a helper function because the same basic pattern is used for subclass, subproperty, equivalent property, and now equivalent class relations.

Because subClassOf inference is already supported, this means no new visitor is required.

Slightly edited one line in SubClassOfVisitor to avoid adding the same subclass relation to the FixedStatementPattern twice, which would otherwise be possible: equivalent classes are mutual subclasses of each other, creating a cycle in the subclass graph. and allowing findParents to return a set containing the original node. Therefore, instead of always adding a statement corresponding to the original type, just add the original type to the set returned by findParents, which will do nothing if it was already included. This is identical to the logic in SubPropertyOfVisitor.

### Tests
Added two tests to InferenceEngineTest, one for classes and one for properties, to verify that the inference engine builds the expected subclass/subproperty graph given an ontology involving sub- and equivalent- relations. Added a test to InferenceIT that inserts schema and instance data, then runs a query that depends on the application of subclass and equivalent class inference.

### Links
[Jira](https://issues.apache.org/jira/browse/RYA-297)

### Checklist
- [ ] Code Review
- [ ] Squash Commits

#### People To Reivew
@meiercaleb 