### PR TITLE
RYA-216 Cleaned up maven build warnings and other issues in some poms.

### DIFF
--- a/extras/rya.benchmark/pom.xml
+++ b/extras/rya.benchmark/pom.xml
@@ -136,7 +136,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.2</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -172,7 +171,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.19.1</version>
                 <executions>
                   <execution>
                     <goals>
@@ -183,45 +181,5 @@
                 </executions>
               </plugin>
         </plugins>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <artifactId>maven-clean-plugin</artifactId>
-                    <version>2.5</version>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-deploy-plugin</artifactId>
-                    <version>2.8.1</version>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-install-plugin</artifactId>
-                    <version>2.5.1</version>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-jar-plugin</artifactId>
-                    <version>2.4</version>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.9.1</version>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-resources-plugin</artifactId>
-                    <version>2.6</version>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-site-plugin</artifactId>
-                    <version>3.3</version>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-source-plugin</artifactId>
-                    <version>2.2.1</version>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.17</version>
-                </plugin>
-            </plugins>
-        </pluginManagement>
     </build>
 </project>

--- a/extras/rya.export/export.accumulo/pom.xml
+++ b/extras/rya.export/export.accumulo/pom.xml
@@ -39,12 +39,10 @@ under the License.
         <dependency>
             <groupId>org.apache.rya</groupId>
             <artifactId>rya.export.api</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.rya</groupId>
             <artifactId>rya.indexing</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.rya</groupId>
@@ -67,23 +65,20 @@ under the License.
         <dependency>
             <groupId>org.apache.accumulo</groupId>
             <artifactId>accumulo-core</artifactId>
-            <version>1.6.4</version>
         </dependency>
         <dependency>
             <groupId>org.apache.accumulo</groupId>
             <artifactId>accumulo-start</artifactId>
-            <version>1.6.4</version>
         </dependency>
         <dependency>
             <groupId>org.apache.accumulo</groupId>
             <artifactId>accumulo</artifactId>
-            <version>1.6.4</version>
+            <version>${accumulo.version}</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>org.apache.thrift</groupId>
             <artifactId>libthrift</artifactId>
-            <version>0.9.1</version>
         </dependency>
     </dependencies>
     <build>
@@ -91,7 +86,6 @@ under the License.
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>jaxb2-maven-plugin</artifactId>
-                <version>2.2</version>
                 <executions>
                     <execution>
                         <id>xjc</id>

--- a/extras/rya.export/export.api/pom.xml
+++ b/extras/rya.export/export.api/pom.xml
@@ -57,24 +57,20 @@ under the License.
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.8.2</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.rya</groupId>
             <artifactId>mongodb.rya</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>
@@ -84,37 +80,10 @@ under the License.
     </dependencies>
 
     <build>
-        <pluginManagement>
-            <plugins>
-                <!--
-                    If we e.g. execute on JDK 1.7, we should compile for Java 7 to get
-                    the same (or higher) JAXB API version as used during the xjc execution.
-                -->
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <configuration>
-                        <source>1.8</source>
-                        <target>1.8</target>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-    
         <plugins>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.0.2</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-           </plugin>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.19.1</version>
                 <executions>
                     <execution>
                         <goals>
@@ -146,7 +115,6 @@ under the License.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.4.3</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -229,7 +197,6 @@ under the License.
             -->
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>2.7</version>
                 <executions>
                     <execution>
                         <id>copy-resource-bin</id>
@@ -238,7 +205,7 @@ under the License.
                             <goal>copy-resources</goal>
                         </goals>
                         <configuration>
-                            <outputDirectory>${project.build.directory}/distribution/${artifactId}-${version}/bin</outputDirectory>
+                            <outputDirectory>${project.build.directory}/distribution/${project.artifactId}-${project.version}/bin</outputDirectory>
                             <resources>
                                 <resource>
                                     <directory>${basedir}/startup_scripts</directory>
@@ -253,7 +220,7 @@ under the License.
                             <goal>copy-resources</goal>
                         </goals>
                         <configuration>
-                            <outputDirectory>${project.build.directory}/distribution/${artifactId}-${version}/config</outputDirectory>
+                            <outputDirectory>${project.build.directory}/distribution/${project.artifactId}-${project.version}/config</outputDirectory>
                             <resources>
                                 <resource>
                                     <directory>${basedir}/config</directory>
@@ -268,7 +235,7 @@ under the License.
                             <goal>copy-resources</goal>
                         </goals>
                         <configuration>
-                            <outputDirectory>${project.build.directory}/distribution/${artifactId}-${version}/lib</outputDirectory>
+                            <outputDirectory>${project.build.directory}/distribution/${project.artifactId}-${project.version}/lib</outputDirectory>
                             <resources>
                                 <resource>
                                     <directory>${project.build.directory}/lib</directory>
@@ -286,7 +253,7 @@ under the License.
                             <goal>copy-resources</goal>
                         </goals>
                         <configuration>
-                            <outputDirectory>${project.build.directory}/distribution/${artifactId}-${version}/</outputDirectory>
+                            <outputDirectory>${project.build.directory}/distribution/${project.artifactId}-${project.version}/</outputDirectory>
                             <resources>
                                 <resource>
                                     <directory>${project.build.directory}</directory>
@@ -309,7 +276,7 @@ under the License.
                             <goal>copy-resources</goal>
                         </goals>
                         <configuration>
-                            <outputDirectory>${project.build.directory}/distribution/${artifactId}-${version}/</outputDirectory>
+                            <outputDirectory>${project.build.directory}/distribution/${project.artifactId}-${project.version}/</outputDirectory>
                             <resources>
                                 <resource>
                                     <directory>${basedir}</directory>

--- a/extras/rya.giraph/pom.xml
+++ b/extras/rya.giraph/pom.xml
@@ -27,6 +27,7 @@ under the License.
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <name>Apache Rya Giraph</name>
     <artifactId>rya.giraph</artifactId>
 
     <dependencies>
@@ -40,46 +41,45 @@ under the License.
             <artifactId>giraph-accumulo</artifactId>
             <version>1.2.0</version>
         </dependency>
-<dependency>
-           <groupId>org.apache.hadoop</groupId>
-           <artifactId>hadoop-mapreduce-client-common</artifactId>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-mapreduce-client-common</artifactId>
             <version>2.5.1</version>
-          <scope>provided</scope>
-         </dependency>
-         <dependency>
-           <groupId>org.apache.hadoop</groupId>
-           <artifactId>hadoop-mapreduce-client-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-mapreduce-client-core</artifactId>
             <version>2.5.1</version>
-          <scope>provided</scope>
-</dependency>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>org.apache.rya</groupId>
             <artifactId>accumulo.rya</artifactId>
             <exclusions>
-             	<exclusion>
-            		<artifactId>
-            			hadoop-mapreduce-client-jobclient
-            		</artifactId>
-            		<groupId>org.apache.hadoop</groupId>
-            	</exclusion>
-             	<exclusion>
-             		<artifactId>
-             			hadoop-mapreduce-client-core
-             		</artifactId>
-             		<groupId>org.apache.hadoop</groupId>
-             	</exclusion>
+                <exclusion>
+                    <artifactId>
+                        hadoop-mapreduce-client-jobclient
+                    </artifactId>
+                    <groupId>org.apache.hadoop</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>
+                        hadoop-mapreduce-client-core
+                    </artifactId>
+                    <groupId>org.apache.hadoop</groupId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.rya</groupId>
             <artifactId>rya.mapreduce</artifactId>
             <exclusions>
-            	<exclusion>
-            		<artifactId>spark-graphx_2.11</artifactId>
-            		<groupId>org.apache.spark</groupId>
-            	</exclusion>
-            	
+                <exclusion>
+                    <artifactId>spark-graphx_2.11</artifactId>
+                    <groupId>org.apache.spark</groupId>
+                </exclusion>
             </exclusions>
         </dependency>
-   </dependencies>
+    </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,11 @@ under the License.
             </dependency>
             <dependency>
                 <groupId>org.apache.rya</groupId>
+                <artifactId>rya.export.api</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.rya</groupId>
                 <artifactId>rya.sail</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -783,6 +788,7 @@ under the License.
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
+                    <version>2.4.3</version>
                     <configuration>
                         <shadedArtifactAttached>true</shadedArtifactAttached>
                     </configuration>
@@ -794,6 +800,11 @@ under the License.
                             </goals>
                         </execution>
                     </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>jaxb2-maven-plugin</artifactId>
+                    <version>2.2</version>
                 </plugin>
                 <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
                 <plugin>


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

  http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
## Description
>What Changed?

Removed these warnings:
[WARNING] Some problems were encountered while building the effective model for ...
[WARNING] The expression ${artifactId} is deprecated.
[WARNING] The expression ${version} is deprecated.
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
Removed some unnecessary dependency versioning and plugin management.

### Tests
>Coverage?
N/A

### Links
[Jira](https://issues.apache.org/jira/browse/RYA-216)

### Checklist
- [ ] Code Review
- [ ] Squash Commits

#### People To Reivew
Aaron Mihalik, Caleb Meier