### PR TITLE
RYA-298, RYA-299 Domain/range inference.

### DIFF
--- a/sail/src/main/java/org/apache/rya/rdftriplestore/RdfCloudTripleStoreConnection.java
+++ b/sail/src/main/java/org/apache/rya/rdftriplestore/RdfCloudTripleStoreConnection.java
@@ -50,6 +50,7 @@ import org.apache.rya.rdftriplestore.evaluation.QueryJoinSelectOptimizer;
 import org.apache.rya.rdftriplestore.evaluation.RdfCloudTripleStoreEvaluationStatistics;
 import org.apache.rya.rdftriplestore.evaluation.RdfCloudTripleStoreSelectivityEvaluationStatistics;
 import org.apache.rya.rdftriplestore.evaluation.SeparateFilterJoinsVisitor;
+import org.apache.rya.rdftriplestore.inference.DomainRangeVisitor;
 import org.apache.rya.rdftriplestore.inference.HasValueVisitor;
 import org.apache.rya.rdftriplestore.inference.InferenceEngine;
 import org.apache.rya.rdftriplestore.inference.InverseOfVisitor;
@@ -349,6 +350,7 @@ public class RdfCloudTripleStoreConnection extends SailConnectionBase {
                     && this.inferenceEngine != null
                     ) {
                 try {
+                    tupleExpr.visit(new DomainRangeVisitor(queryConf, inferenceEngine));
                     tupleExpr.visit(new HasValueVisitor(queryConf, inferenceEngine));
                     tupleExpr.visit(new PropertyChainVisitor(queryConf, inferenceEngine));
                     tupleExpr.visit(new TransitivePropertyVisitor(queryConf, inferenceEngine));

--- a/sail/src/main/java/org/apache/rya/rdftriplestore/inference/DomainRangeVisitor.java
+++ b/sail/src/main/java/org/apache/rya/rdftriplestore/inference/DomainRangeVisitor.java
@@ -1,0 +1,114 @@
+package org.apache.rya.rdftriplestore.inference;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Set;
+import java.util.UUID;
+
+import org.apache.rya.api.RdfCloudTripleStoreConfiguration;
+import org.apache.rya.api.utils.NullableStatementImpl;
+import org.apache.rya.rdftriplestore.utils.FixedStatementPattern;
+import org.openrdf.model.URI;
+import org.openrdf.model.vocabulary.RDF;
+import org.openrdf.model.vocabulary.RDFS;
+import org.openrdf.query.algebra.StatementPattern;
+import org.openrdf.query.algebra.TupleExpr;
+import org.openrdf.query.algebra.Var;
+
+/**
+ * Expands the query tree to account for any relevant domain and range information known to the
+ * {@link InferenceEngine}.
+ *
+ * Given a triple <:s :p :o>, if :p has an rdfs:domain of :D and rdfs:range of :R, the semantics of
+ * domain and range imply that :s has type :D and that :o has type :R.
+ *
+ * Only operates on {@link StatementPattern} nodes whose form is <?subject rdfs:type :DefinedClass>.
+ * If the class is the domain of any predicate, as reported by the {@link InferenceEngine}, a
+ * subtree is constructed to infer the type based on the domain. If the class is the range of any
+ * predicate, a subtree is similarly constructed to infer the type based on the range. If one or
+ * both apply, then the original node is replaced with the union of the new subtree(s) and the
+ * original statement pattern.
+ *
+ * If there are multiple ways to infer the type for one resource, the resulting query tree will
+ * match all of them and produce multiple solutions for that resource.
+ */
+public class DomainRangeVisitor extends AbstractInferVisitor {
+    /**
+     * Creates a new {@link DomainRangeVisitor}, which is enabled by default.
+     * @param conf The {@link RdfCloudTripleStoreConfiguration}.
+     * @param inferenceEngine The InferenceEngine containing the relevant ontology.
+     */
+    public DomainRangeVisitor(RdfCloudTripleStoreConfiguration conf, InferenceEngine inferenceEngine) {
+        super(conf, inferenceEngine);
+        include = true;
+    }
+
+    /**
+     * Checks whether this statement pattern might be inferred using domain and/or range knowledge,
+     * and, if so, replaces the statement pattern with a union of itself and any possible
+     * derivations.
+     */
+    @Override
+    protected void meetSP(StatementPattern node) throws Exception {
+        final Var subjVar = node.getSubjectVar();
+        final Var predVar = node.getPredicateVar();
+        final Var objVar = node.getObjectVar();
+        final Var contextVar = node.getContextVar();
+        // Only applies to statement patterns that query for members of a defined type.
+        if (predVar != null && RDF.TYPE.equals(predVar.getValue())
+                && objVar != null && objVar.getValue() instanceof URI) {
+            final URI inferredType = (URI) objVar.getValue();
+            // Preserve the original node so explicit type assertions are still matched:
+            TupleExpr currentNode = node.clone();
+            // If there are any properties with this type as domain, check for appropriate triples:
+            final Set<URI> domainProperties = inferenceEngine.getPropertiesWithDomain(inferredType);
+            if (!domainProperties.isEmpty()) {
+                Var domainPredVar = new Var("p-" + UUID.randomUUID());
+                Var domainObjVar = new Var("o-" + UUID.randomUUID());
+                domainObjVar.setAnonymous(true);
+                Var domainVar = new Var(RDFS.DOMAIN.stringValue(), RDFS.DOMAIN);
+                StatementPattern domainSP = new DoNotExpandSP(subjVar, domainPredVar, domainObjVar, contextVar);
+                // Enumerate predicates having this type as domain
+                FixedStatementPattern domainFSP = new FixedStatementPattern(domainPredVar, domainVar, objVar);
+                for (URI property : domainProperties) {
+                    domainFSP.statements.add(new NullableStatementImpl(property, RDFS.DOMAIN, inferredType));
+                }
+                // For each such predicate, any triple <subjVar predicate _:any> implies the type
+                currentNode = new InferUnion(currentNode, new InferJoin(domainFSP, domainSP));
+            }
+            // If there are any properties with this type as range, check for appropriate triples:
+            final Set<URI> rangeProperties = inferenceEngine.getPropertiesWithRange(inferredType);
+            if (!rangeProperties.isEmpty()) {
+                Var rangePredVar = new Var("p-" + UUID.randomUUID());
+                Var rangeSubjVar = new Var("s-" + UUID.randomUUID());
+                rangeSubjVar.setAnonymous(true);
+                Var rangeVar = new Var(RDFS.RANGE.stringValue(), RDFS.RANGE);
+                StatementPattern rangeSP = new DoNotExpandSP(rangeSubjVar, rangePredVar, subjVar, contextVar);
+                // Enumerate predicates having this type as range
+                FixedStatementPattern rangeFSP = new FixedStatementPattern(rangePredVar, rangeVar, objVar);
+                for (URI property : rangeProperties) {
+                    rangeFSP.statements.add(new NullableStatementImpl(property, RDFS.RANGE, inferredType));
+                }
+                // For each such predicate, any triple <_:any predicate subjVar> implies the type
+                currentNode = new InferUnion(currentNode, new InferJoin(rangeFSP, rangeSP));
+            }
+            node.replaceWith(currentNode);
+        }
+    }
+}

--- a/sail/src/test/java/org/apache/rya/rdftriplestore/inference/DomainRangeVisitorTest.java
+++ b/sail/src/test/java/org/apache/rya/rdftriplestore/inference/DomainRangeVisitorTest.java
@@ -1,0 +1,140 @@
+package org.apache.rya.rdftriplestore.inference;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.Stack;
+
+import org.apache.rya.accumulo.AccumuloRdfConfiguration;
+import org.apache.rya.rdftriplestore.utils.FixedStatementPattern;
+import org.junit.Assert;
+import org.junit.Test;
+import org.openrdf.model.Resource;
+import org.openrdf.model.Statement;
+import org.openrdf.model.URI;
+import org.openrdf.model.ValueFactory;
+import org.openrdf.model.impl.ValueFactoryImpl;
+import org.openrdf.model.vocabulary.RDF;
+import org.openrdf.model.vocabulary.RDFS;
+import org.openrdf.query.algebra.Join;
+import org.openrdf.query.algebra.Projection;
+import org.openrdf.query.algebra.ProjectionElem;
+import org.openrdf.query.algebra.ProjectionElemList;
+import org.openrdf.query.algebra.StatementPattern;
+import org.openrdf.query.algebra.TupleExpr;
+import org.openrdf.query.algebra.Union;
+import org.openrdf.query.algebra.Var;
+
+public class DomainRangeVisitorTest {
+    private static final AccumuloRdfConfiguration conf = new AccumuloRdfConfiguration();
+    private static final ValueFactory vf = new ValueFactoryImpl();
+    private static final URI person = vf.createURI("lubm:Person");
+    private static final URI advisor = vf.createURI("lubm:advisor");
+    private static final URI takesCourse = vf.createURI("lubm:takesCourse");
+
+    @Test
+    public void testRewriteTypePattern() throws Exception {
+        final InferenceEngine inferenceEngine = mock(InferenceEngine.class);
+        final Set<URI> domainPredicates = new HashSet<>();
+        final Set<URI> rangePredicates = new HashSet<>();
+        domainPredicates.add(advisor);
+        domainPredicates.add(takesCourse);
+        rangePredicates.add(advisor);
+        when(inferenceEngine.getPropertiesWithDomain(person)).thenReturn(domainPredicates);
+        when(inferenceEngine.getPropertiesWithRange(person)).thenReturn(rangePredicates);
+        final Var subjVar = new Var("s");
+        final StatementPattern originalSP = new StatementPattern(subjVar, new Var("p", RDF.TYPE), new Var("o", person));
+        final Projection query = new Projection(originalSP, new ProjectionElemList(new ProjectionElem("s", "subject")));
+        query.visit(new DomainRangeVisitor(conf, inferenceEngine));
+        // Resulting tree should consist of Unions of:
+        // 1. The original StatementPattern
+        // 2. A join checking for domain inference
+        // 3. A join checking for range inference
+        boolean containsOriginal = false;
+        boolean containsDomain = false;
+        boolean containsRange = false;
+        final Stack<TupleExpr> nodes = new Stack<>();
+        nodes.push(query.getArg());
+        while (!nodes.isEmpty()) {
+            final TupleExpr currentNode = nodes.pop();
+            if (currentNode instanceof Union) {
+                nodes.push(((Union) currentNode).getLeftArg());
+                nodes.push(((Union) currentNode).getRightArg());
+            }
+            else if (currentNode instanceof StatementPattern) {
+                Assert.assertFalse(containsOriginal);
+                Assert.assertEquals(originalSP, currentNode);
+                containsOriginal = true;
+            }
+            else if (currentNode instanceof Join) {
+                final TupleExpr left = ((Join) currentNode).getLeftArg();
+                final TupleExpr right = ((Join) currentNode).getRightArg();
+                Assert.assertTrue("Left-hand side should enumerate domain/range predicates",
+                        left instanceof FixedStatementPattern);
+                Assert.assertTrue("Right-hand side should be a non-expandable SP matching triples satisfying domain/range",
+                        right instanceof DoNotExpandSP);
+                final FixedStatementPattern fsp = (FixedStatementPattern) left;
+                final StatementPattern sp = (StatementPattern) right;
+                // fsp should be <predicate var, domain/range, original type var>
+                boolean isDomain = RDFS.DOMAIN.equals(fsp.getPredicateVar().getValue());
+                boolean isRange = RDFS.RANGE.equals(fsp.getPredicateVar().getValue());
+                Assert.assertTrue(isDomain || isRange);
+                Assert.assertEquals(originalSP.getObjectVar(), fsp.getObjectVar());
+                // sp should have same predicate var
+                Assert.assertEquals(fsp.getSubjectVar(), sp.getPredicateVar());
+                // collect predicates that are enumerated in the FixedStatementPattern
+                final Set<Resource> queryPredicates = new HashSet<>();
+                for (Statement statement : fsp.statements) {
+                    queryPredicates.add(statement.getSubject());
+                }
+                if (isDomain) {
+                    Assert.assertFalse(containsDomain);
+                    // sp should be <original subject var, predicate var, unbound object var> for domain
+                    Assert.assertEquals(originalSP.getSubjectVar(), sp.getSubjectVar());
+                    Assert.assertFalse(sp.getObjectVar().hasValue());
+                    // verify predicates
+                    Assert.assertEquals(2, fsp.statements.size());
+                    Assert.assertEquals(domainPredicates, queryPredicates);
+                    Assert.assertTrue(queryPredicates.contains(advisor));
+                    Assert.assertTrue(queryPredicates.contains(takesCourse));
+                    containsDomain = true;
+                }
+                else {
+                    Assert.assertFalse(containsRange);
+                    // sp should be <unbound subject var, predicate var, original subject var> for range
+                    Assert.assertFalse(sp.getSubjectVar().hasValue());
+                    Assert.assertEquals(originalSP.getSubjectVar(), sp.getObjectVar());
+                    // verify predicates
+                    Assert.assertEquals(1, fsp.statements.size());
+                    Assert.assertEquals(rangePredicates, queryPredicates);
+                    Assert.assertTrue(queryPredicates.contains(advisor));
+                    containsRange = true;
+                }
+            }
+            else {
+                Assert.fail("Expected nested Unions of Joins and StatementPatterns, found: " + currentNode.toString());
+            }
+        }
+        Assert.assertTrue(containsOriginal && containsDomain && containsRange);
+    }
+}

--- a/sail/src/test/java/org/apache/rya/rdftriplestore/inference/InferenceEngineTest.java
+++ b/sail/src/test/java/org/apache/rya/rdftriplestore/inference/InferenceEngineTest.java
@@ -165,6 +165,66 @@ public class InferenceEngineTest extends TestCase {
     }
 
     @Test
+    public void testDomainRange() throws Exception {
+        String insert = "INSERT DATA { GRAPH <http://updated/test> {\n"
+                + "  <urn:p1> rdfs:subPropertyOf <urn:p2> . \n"
+                + "  <urn:p2> rdfs:subPropertyOf <urn:p3> . \n"
+                + "  <urn:q1> rdfs:subPropertyOf <urn:q2> . \n"
+                + "  <urn:q2> rdfs:subPropertyOf <urn:q3> . \n"
+                + "  <urn:i1> rdfs:subPropertyOf <urn:i2> . \n"
+                + "  <urn:i2> rdfs:subPropertyOf <urn:i3> . \n"
+                + "  <urn:j1> rdfs:subPropertyOf <urn:j2> . \n"
+                + "  <urn:j2> rdfs:subPropertyOf <urn:j3> . \n"
+                + "  <urn:p2> owl:inverseOf <urn:i2> . \n"
+                + "  <urn:i1> owl:inverseOf <urn:q2> . \n"
+                + "  <urn:q1> owl:inverseOf <urn:j2> . \n"
+                + "  <urn:D1> rdfs:subClassOf <urn:D2> . \n"
+                + "  <urn:D2> rdfs:subClassOf <urn:D3> . \n"
+                + "  <urn:R1> rdfs:subClassOf <urn:R2> . \n"
+                + "  <urn:R2> rdfs:subClassOf <urn:R3> . \n"
+                + "  <urn:p2> rdfs:domain <urn:D2> . \n"
+                + "  <urn:p2> rdfs:range <urn:R2> . \n"
+                + "}}";
+        conn.prepareUpdate(QueryLanguage.SPARQL, insert).execute();
+        inferenceEngine.refreshGraph();
+        Set<URI> hasDomainD1 = inferenceEngine.getPropertiesWithDomain(vf.createURI("urn:D1"));
+        Set<URI> hasDomainD2 = inferenceEngine.getPropertiesWithDomain(vf.createURI("urn:D2"));
+        Set<URI> hasDomainD3 = inferenceEngine.getPropertiesWithDomain(vf.createURI("urn:D3"));
+        Set<URI> hasRangeD1 = inferenceEngine.getPropertiesWithRange(vf.createURI("urn:D1"));
+        Set<URI> hasRangeD2 = inferenceEngine.getPropertiesWithRange(vf.createURI("urn:D2"));
+        Set<URI> hasRangeD3 = inferenceEngine.getPropertiesWithRange(vf.createURI("urn:D3"));
+        Set<URI> hasDomainR1 = inferenceEngine.getPropertiesWithDomain(vf.createURI("urn:R1"));
+        Set<URI> hasDomainR2 = inferenceEngine.getPropertiesWithDomain(vf.createURI("urn:R2"));
+        Set<URI> hasDomainR3 = inferenceEngine.getPropertiesWithDomain(vf.createURI("urn:R3"));
+        Set<URI> hasRangeR1 = inferenceEngine.getPropertiesWithRange(vf.createURI("urn:R1"));
+        Set<URI> hasRangeR2 = inferenceEngine.getPropertiesWithRange(vf.createURI("urn:R2"));
+        Set<URI> hasRangeR3 = inferenceEngine.getPropertiesWithRange(vf.createURI("urn:R3"));
+        Set<URI> empty = new HashSet<>();
+        Set<URI> expectedForward = new HashSet<>();
+        expectedForward.add(vf.createURI("urn:p2"));
+        expectedForward.add(vf.createURI("urn:p1"));
+        expectedForward.add(vf.createURI("urn:q2"));
+        expectedForward.add(vf.createURI("urn:q1"));
+        Set<URI> expectedInverse = new HashSet<>();
+        expectedInverse.add(vf.createURI("urn:i1"));
+        expectedInverse.add(vf.createURI("urn:i2"));
+        expectedInverse.add(vf.createURI("urn:j1"));
+        expectedInverse.add(vf.createURI("urn:j2"));
+        Assert.assertEquals(empty, hasDomainD1);
+        Assert.assertEquals(empty, hasRangeD1);
+        Assert.assertEquals(empty, hasDomainR1);
+        Assert.assertEquals(empty, hasRangeR1);
+        Assert.assertEquals(expectedForward, hasDomainD2);
+        Assert.assertEquals(expectedInverse, hasRangeD2);
+        Assert.assertEquals(expectedInverse, hasDomainR2);
+        Assert.assertEquals(expectedForward, hasRangeR2);
+        Assert.assertEquals(expectedForward, hasDomainD3);
+        Assert.assertEquals(expectedInverse, hasRangeD3);
+        Assert.assertEquals(expectedInverse, hasDomainR3);
+        Assert.assertEquals(expectedForward, hasRangeR3);
+    }
+
+    @Test
     public void testHasValueGivenProperty() throws Exception {
         String insert = "INSERT DATA { GRAPH <http://updated/test> {\n"
                 + "  <urn:Biped> owl:onProperty <urn:walksUsingLegs>  . \n"


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

  http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
## Description
InferenceEngine: Added a method to query for and infer domain/range schema, incorporating subclass, subproperty, and inverse property information to compute the closure. Extended graph traversal methods to allow traversal in each direction (findParents has the same behavior as before, but is joined by findChildren, both of which call findConnections with a direction parameter).

DomainRangeVisitor: New class rewrites queries for members of a specific defined type to check for domain and range implications as well. Applies to StatementPatterns of the form <?s a Class>, where Class is not a variable, and produces (if domain and/or range exist for that type) a union which includes the original pattern as well.

RdfCloudTripleStoreConnection: Call the DomainRangeVisitor if inference is enabled. Called at the beginning of the sequence of visitors because the original statement is preserved as one branch of the union, so this won't stop other inference rules from being applied in that branch. However, as with the other visitors, the inferred branches of the unions won't be expanded. This means we won't infer the type by applying multiple rules at once (regardless of order of visitor calls), but we will have a union of alternative ways of inferring the type.

### Tests
Added tests to: Verify that InferenceEngine loads and infers expected schema (taking into account class hierarchy, property graph, and inverse properties); verify that the visitor produces the expected query tree; and verify that a type query returns the expected results given an ontology.

### Links
[RYA-298](https://issues.apache.org/jira/browse/RYA-298)
[RYA-299](https://issues.apache.org/jira/browse/RYA-299)

### Checklist
- [ ] Code Review
- [ ] Squash Commits

#### People To Reivew
@meiercaleb 
@ejwhite922 
@pujav65
@amihalik 