### PR TITLE
RYA-316 Long OBJ string

### DIFF
--- a/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/dao/SimpleMongoDBStorageStrategy.java
+++ b/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/dao/SimpleMongoDBStorageStrategy.java
@@ -26,6 +26,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Map;
 
 import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.log4j.Logger;
 import org.apache.rya.api.domain.RyaStatement;
 import org.apache.rya.api.domain.RyaType;
@@ -53,7 +54,8 @@ public class SimpleMongoDBStorageStrategy implements MongoDBStorageStrategy<RyaS
     public static final String OBJECT_TYPE_VALUE = XMLSchema.ANYURI.stringValue();
     public static final String CONTEXT = "context";
     public static final String PREDICATE = "predicate";
-    public static final String OBJECT = "object";
+    public static final String OBJECT = "object_original";
+    public static final String OBJECT_HASH = "object_hash";
     public static final String SUBJECT = "subject";
     public static final String TIMESTAMP = "insertTimestamp";
     public static final String STATEMENT_METADATA = "statementMetadata";
@@ -68,10 +70,10 @@ public class SimpleMongoDBStorageStrategy implements MongoDBStorageStrategy<RyaS
         doc.put(PREDICATE, 1);
         coll.createIndex(doc);
         doc = new BasicDBObject(PREDICATE, 1);
-        doc.put(OBJECT, 1);
+        doc.put(OBJECT_HASH, 1);
         doc.put(OBJECT_TYPE, 1);
         coll.createIndex(doc);
-        doc = new BasicDBObject(OBJECT, 1);
+        doc = new BasicDBObject(OBJECT_HASH, 1);
         doc.put(OBJECT_TYPE, 1);
         doc.put(SUBJECT, 1);
         coll.createIndex(doc);
@@ -88,7 +90,7 @@ public class SimpleMongoDBStorageStrategy implements MongoDBStorageStrategy<RyaS
             query.append(SUBJECT, subject.getData());
         }
         if (object != null){
-            query.append(OBJECT, object.getData());
+            query.append(OBJECT_HASH, DigestUtils.sha256Hex(object.getData()));
             query.append(OBJECT_TYPE, object.getDataType().toString());
         }
         if (predicate != null){
@@ -175,6 +177,7 @@ public class SimpleMongoDBStorageStrategy implements MongoDBStorageStrategy<RyaS
         .append(SUBJECT, statement.getSubject().getData())
         .append(PREDICATE, statement.getPredicate().getData())
         .append(OBJECT, statement.getObject().getData())
+        .append(OBJECT_HASH, DigestUtils.sha256Hex(statement.getObject().getData()))
         .append(OBJECT_TYPE, statement.getObject().getDataType().toString())
         .append(CONTEXT, context)
         .append(STATEMENT_METADATA, statement.getMetadata().toString())

--- a/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/dao/SimpleMongoDBStorageStrategy.java
+++ b/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/dao/SimpleMongoDBStorageStrategy.java
@@ -55,7 +55,7 @@ public class SimpleMongoDBStorageStrategy implements MongoDBStorageStrategy<RyaS
     public static final String CONTEXT = "context";
     public static final String PREDICATE = "predicate";
     public static final String PREDICATE_HASH = "predicate_hash";
-    public static final String OBJECT = "object_original";
+    public static final String OBJECT = "object";
     public static final String OBJECT_HASH = "object_hash";
     public static final String SUBJECT = "subject";
     public static final String SUBJECT_HASH = "subject_hash";
@@ -70,6 +70,8 @@ public class SimpleMongoDBStorageStrategy implements MongoDBStorageStrategy<RyaS
         BasicDBObject doc = new BasicDBObject();
         doc.put(SUBJECT_HASH, 1);
         doc.put(PREDICATE_HASH, 1);
+        doc.put(OBJECT_HASH, 1);
+        doc.put(OBJECT_TYPE, 1);
         coll.createIndex(doc);
         doc = new BasicDBObject(PREDICATE_HASH, 1);
         doc.put(OBJECT_HASH, 1);
@@ -77,7 +79,7 @@ public class SimpleMongoDBStorageStrategy implements MongoDBStorageStrategy<RyaS
         coll.createIndex(doc);
         doc = new BasicDBObject(OBJECT_HASH, 1);
         doc.put(OBJECT_TYPE, 1);
-        doc.put(SUBJECT, 1);
+        doc.put(SUBJECT_HASH, 1);
         coll.createIndex(doc);
     }
 

--- a/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/dao/SimpleMongoDBStorageStrategy.java
+++ b/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/dao/SimpleMongoDBStorageStrategy.java
@@ -54,9 +54,11 @@ public class SimpleMongoDBStorageStrategy implements MongoDBStorageStrategy<RyaS
     public static final String OBJECT_TYPE_VALUE = XMLSchema.ANYURI.stringValue();
     public static final String CONTEXT = "context";
     public static final String PREDICATE = "predicate";
+    public static final String PREDICATE_HASH = "predicate_hash";
     public static final String OBJECT = "object_original";
     public static final String OBJECT_HASH = "object_hash";
     public static final String SUBJECT = "subject";
+    public static final String SUBJECT_HASH = "subject_hash";
     public static final String TIMESTAMP = "insertTimestamp";
     public static final String STATEMENT_METADATA = "statementMetadata";
     public static final String DOCUMENT_VISIBILITY = "documentVisibility";
@@ -66,10 +68,10 @@ public class SimpleMongoDBStorageStrategy implements MongoDBStorageStrategy<RyaS
     @Override
     public void createIndices(final DBCollection coll){
         BasicDBObject doc = new BasicDBObject();
-        doc.put(SUBJECT, 1);
-        doc.put(PREDICATE, 1);
+        doc.put(SUBJECT_HASH, 1);
+        doc.put(PREDICATE_HASH, 1);
         coll.createIndex(doc);
-        doc = new BasicDBObject(PREDICATE, 1);
+        doc = new BasicDBObject(PREDICATE_HASH, 1);
         doc.put(OBJECT_HASH, 1);
         doc.put(OBJECT_TYPE, 1);
         coll.createIndex(doc);
@@ -87,14 +89,14 @@ public class SimpleMongoDBStorageStrategy implements MongoDBStorageStrategy<RyaS
         final RyaURI context = stmt.getContext();
         final BasicDBObject query = new BasicDBObject();
         if (subject != null){
-            query.append(SUBJECT, subject.getData());
+            query.append(SUBJECT_HASH, DigestUtils.sha256Hex(subject.getData()));
         }
         if (object != null){
             query.append(OBJECT_HASH, DigestUtils.sha256Hex(object.getData()));
             query.append(OBJECT_TYPE, object.getDataType().toString());
         }
         if (predicate != null){
-            query.append(PREDICATE, predicate.getData());
+            query.append(PREDICATE_HASH, DigestUtils.sha256Hex(predicate.getData()));
         }
         if (context != null){
             query.append(CONTEXT, context.getData());
@@ -175,7 +177,9 @@ public class SimpleMongoDBStorageStrategy implements MongoDBStorageStrategy<RyaS
         final BasicDBObject dvObject = DocumentVisibilityAdapter.toDBObject(statement.getColumnVisibility());
         final BasicDBObject doc = new BasicDBObject(ID, new String(Hex.encodeHex(bytes)))
         .append(SUBJECT, statement.getSubject().getData())
+        .append(SUBJECT_HASH, DigestUtils.sha256Hex(statement.getSubject().getData()))
         .append(PREDICATE, statement.getPredicate().getData())
+        .append(PREDICATE_HASH, DigestUtils.sha256Hex(statement.getPredicate().getData()))
         .append(OBJECT, statement.getObject().getData())
         .append(OBJECT_HASH, DigestUtils.sha256Hex(statement.getObject().getData()))
         .append(OBJECT_TYPE, statement.getObject().getDataType().toString())

--- a/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/SimpleMongoDBStorageStrategyTest.java
+++ b/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/SimpleMongoDBStorageStrategyTest.java
@@ -23,6 +23,7 @@ import static org.openrdf.model.vocabulary.XMLSchema.ANYURI;
 
 import java.io.IOException;
 
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.rya.api.domain.RyaStatement;
 import org.apache.rya.api.domain.RyaStatement.RyaStatementBuilder;
 import org.apache.rya.api.domain.RyaURI;
@@ -64,6 +65,7 @@ public class SimpleMongoDBStorageStrategyTest {
         testDBO.put(SimpleMongoDBStorageStrategy.SUBJECT, SUBJECT);
         testDBO.put(SimpleMongoDBStorageStrategy.PREDICATE, PREDICATE);
         testDBO.put(SimpleMongoDBStorageStrategy.OBJECT, OBJECT);
+        testDBO.put(SimpleMongoDBStorageStrategy.OBJECT_HASH, DigestUtils.sha256Hex(OBJECT));
         testDBO.put(SimpleMongoDBStorageStrategy.OBJECT_TYPE, ANYURI.stringValue());
         testDBO.put(SimpleMongoDBStorageStrategy.CONTEXT, CONTEXT);
         testDBO.put(SimpleMongoDBStorageStrategy.STATEMENT_METADATA, STATEMENT_METADATA);

--- a/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/SimpleMongoDBStorageStrategyTest.java
+++ b/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/SimpleMongoDBStorageStrategyTest.java
@@ -63,7 +63,9 @@ public class SimpleMongoDBStorageStrategyTest {
         testDBO = new BasicDBObject();
         testDBO.put(SimpleMongoDBStorageStrategy.ID, "d5f8fea0e85300478da2c9b4e132c69502e21221");
         testDBO.put(SimpleMongoDBStorageStrategy.SUBJECT, SUBJECT);
+        testDBO.put(SimpleMongoDBStorageStrategy.SUBJECT_HASH, DigestUtils.sha256Hex(SUBJECT));
         testDBO.put(SimpleMongoDBStorageStrategy.PREDICATE, PREDICATE);
+        testDBO.put(SimpleMongoDBStorageStrategy.PREDICATE_HASH, DigestUtils.sha256Hex(PREDICATE));
         testDBO.put(SimpleMongoDBStorageStrategy.OBJECT, OBJECT);
         testDBO.put(SimpleMongoDBStorageStrategy.OBJECT_HASH, DigestUtils.sha256Hex(OBJECT));
         testDBO.put(SimpleMongoDBStorageStrategy.OBJECT_TYPE, ANYURI.stringValue());


### PR DESCRIPTION
## Description
>What Changed?

Hash the indexed object field with SHA256.
This will allow the indexer not to break
if the object is longer than 1024 bytes.

### Tests
>Coverage?

Updated the tests with the new fields

### Links
[Jira](https://issues.apache.org/jira/browse/RYA-316)

### Checklist
- [ ] Code Review
- [ ] Squash Commits

#### People To Reivew
@meiercaleb 
@amihalik 
@pujav65 
