### PR TITLE
RYA-295 owl:allValuesFrom inference

### DIFF
--- a/sail/src/main/java/org/apache/rya/rdftriplestore/RdfCloudTripleStoreConnection.java
+++ b/sail/src/main/java/org/apache/rya/rdftriplestore/RdfCloudTripleStoreConnection.java
@@ -50,6 +50,7 @@ import org.apache.rya.rdftriplestore.evaluation.QueryJoinSelectOptimizer;
 import org.apache.rya.rdftriplestore.evaluation.RdfCloudTripleStoreEvaluationStatistics;
 import org.apache.rya.rdftriplestore.evaluation.RdfCloudTripleStoreSelectivityEvaluationStatistics;
 import org.apache.rya.rdftriplestore.evaluation.SeparateFilterJoinsVisitor;
+import org.apache.rya.rdftriplestore.inference.AllValuesFromVisitor;
 import org.apache.rya.rdftriplestore.inference.DomainRangeVisitor;
 import org.apache.rya.rdftriplestore.inference.HasValueVisitor;
 import org.apache.rya.rdftriplestore.inference.InferenceEngine;
@@ -351,6 +352,7 @@ public class RdfCloudTripleStoreConnection extends SailConnectionBase {
                     ) {
                 try {
                     tupleExpr.visit(new DomainRangeVisitor(queryConf, inferenceEngine));
+                    tupleExpr.visit(new AllValuesFromVisitor(queryConf, inferenceEngine));
                     tupleExpr.visit(new HasValueVisitor(queryConf, inferenceEngine));
                     tupleExpr.visit(new PropertyChainVisitor(queryConf, inferenceEngine));
                     tupleExpr.visit(new TransitivePropertyVisitor(queryConf, inferenceEngine));

--- a/sail/src/main/java/org/apache/rya/rdftriplestore/inference/AllValuesFromVisitor.java
+++ b/sail/src/main/java/org/apache/rya/rdftriplestore/inference/AllValuesFromVisitor.java
@@ -1,0 +1,112 @@
+package org.apache.rya.rdftriplestore.inference;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import org.apache.rya.api.RdfCloudTripleStoreConfiguration;
+import org.apache.rya.api.utils.NullableStatementImpl;
+import org.apache.rya.rdftriplestore.utils.FixedStatementPattern;
+import org.openrdf.model.Resource;
+import org.openrdf.model.URI;
+import org.openrdf.model.vocabulary.OWL;
+import org.openrdf.model.vocabulary.RDF;
+import org.openrdf.query.algebra.StatementPattern;
+import org.openrdf.query.algebra.Var;
+
+/**
+ * Expands the query tree to account for any universal class expressions (property restrictions
+ * using owl:allValuesFrom) in the ontology known to the {@link InferenceEngine}.
+ *
+ * Operates on {@link StatementPattern} nodes whose predicate is rdf:type and whose object is a
+ * defined type (not a variable) which is related to an allValuesFrom expression in the ontology.
+ * When applicable, replaces the node with a union of itself and a subtree that matches any
+ * instance that can be inferred to have the type in question via the semantics of
+ * owl:allValuesFrom.
+ *
+ * A universal class expression references a predicate and a value class, and represents the set of
+ * individuals who, for any instance of the predicate, have a value belonging to the value class.
+ * Therefore, the value class should be inferred for any individual which is the object of a triple
+ * with that predicate and with a subject belonging to the class expression. This implication is
+ * similar to rdfs:range except that it only applies when the subject of the triple belongs to a
+ * specific type.
+ *
+ * (Note: Because of OWL's open world assumption, the inference in the other direction can't be
+ * made. That is, when an individual is explicitly declared to have the universally quantified
+ * restriction, then the types of its values can be inferred. But when the universal restriction
+ * isn't explicitly stated, it can't be inferred from the values themselves, because there's no
+ * guarantee that all values are known.)
+ */
+public class AllValuesFromVisitor extends AbstractInferVisitor {
+
+    /**
+     * Creates a new {@link AllValuesFromVisitor}, which is enabled by default.
+     * @param conf The {@link RdfCloudTripleStoreConfiguration}.
+     * @param inferenceEngine The InferenceEngine containing the relevant ontology.
+     */
+    public AllValuesFromVisitor(RdfCloudTripleStoreConfiguration conf, InferenceEngine inferenceEngine) {
+        super(conf, inferenceEngine);
+        include = true;
+    }
+
+    /**
+     * Checks whether the StatementPattern is a type query whose solutions could be inferred
+     * by allValuesFrom inference, and if so, replaces the node with a union of itself and any
+     * possible inference.
+     */
+    @Override
+    protected void meetSP(StatementPattern node) throws Exception {
+        final Var subjVar = node.getSubjectVar();
+        final Var predVar = node.getPredicateVar();
+        final Var objVar = node.getObjectVar();
+        // Only applies to type queries where the type is defined
+        if (predVar != null && RDF.TYPE.equals(predVar.getValue()) && objVar != null && objVar.getValue() instanceof Resource) {
+            final Resource typeToInfer = (Resource) objVar.getValue();
+            Map<Resource, Set<URI>> relevantAvfRestrictions = inferenceEngine.getAllValuesFromByValueType(typeToInfer);
+            if (!relevantAvfRestrictions.isEmpty()) {
+                // We can infer the queried type if, for an allValuesFrom restriction type
+                // associated  with the queried type, some anonymous neighboring node belongs to the
+                // restriction type and has the node in question (subjVar) as a value for the
+                // restriction's property.
+                final Var avfTypeVar = new Var("t-" + UUID.randomUUID());
+                final Var avfPredVar = new Var("p-" + UUID.randomUUID());
+                final Var neighborVar = new Var("n-" + UUID.randomUUID());
+                neighborVar.setAnonymous(true);
+                final StatementPattern membershipPattern = new DoNotExpandSP(neighborVar,
+                        new Var(RDF.TYPE.stringValue(), RDF.TYPE), avfTypeVar);
+                final StatementPattern valuePattern = new StatementPattern(neighborVar, avfPredVar, subjVar);
+                final InferJoin avfPattern = new InferJoin(membershipPattern, valuePattern);
+                // Use a FixedStatementPattern to contain the appropriate (restriction, predicate)
+                // pairs, and check each one against the general pattern.
+                final FixedStatementPattern avfPropertyTypes = new FixedStatementPattern(avfTypeVar,
+                        new Var(OWL.ONPROPERTY.stringValue(), OWL.ONPROPERTY), avfPredVar);
+                for (Resource avfRestrictionType : relevantAvfRestrictions.keySet()) {
+                    for (URI avfProperty : relevantAvfRestrictions.get(avfRestrictionType)) {
+                        avfPropertyTypes.statements.add(new NullableStatementImpl(avfRestrictionType,
+                                OWL.ONPROPERTY, avfProperty));
+                    }
+                }
+                final InferJoin avfInferenceQuery = new InferJoin(avfPropertyTypes, avfPattern);
+                node.replaceWith(new InferUnion(node.clone(), avfInferenceQuery));
+            }
+        }
+    }
+}

--- a/sail/src/test/java/org/apache/rya/rdftriplestore/inference/AllValuesFromVisitorTest.java
+++ b/sail/src/test/java/org/apache/rya/rdftriplestore/inference/AllValuesFromVisitorTest.java
@@ -1,0 +1,128 @@
+package org.apache.rya.rdftriplestore.inference;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.rya.accumulo.AccumuloRdfConfiguration;
+import org.apache.rya.api.utils.NullableStatementImpl;
+import org.apache.rya.rdftriplestore.utils.FixedStatementPattern;
+import org.junit.Assert;
+import org.junit.Test;
+import org.openrdf.model.Resource;
+import org.openrdf.model.URI;
+import org.openrdf.model.ValueFactory;
+import org.openrdf.model.impl.ValueFactoryImpl;
+import org.openrdf.model.vocabulary.OWL;
+import org.openrdf.model.vocabulary.RDF;
+import org.openrdf.query.algebra.Join;
+import org.openrdf.query.algebra.Projection;
+import org.openrdf.query.algebra.ProjectionElem;
+import org.openrdf.query.algebra.ProjectionElemList;
+import org.openrdf.query.algebra.StatementPattern;
+import org.openrdf.query.algebra.TupleExpr;
+import org.openrdf.query.algebra.Union;
+import org.openrdf.query.algebra.Var;
+
+public class AllValuesFromVisitorTest {
+    private final AccumuloRdfConfiguration conf = new AccumuloRdfConfiguration();
+    private final ValueFactory vf = new ValueFactoryImpl();
+
+    // Value types
+    private final URI person = vf.createURI("urn:Person");
+    private final URI dog = vf.createURI("urn:Dog");
+    // Predicates
+    private final URI parent = vf.createURI("urn:parent");
+    private final URI relative = vf.createURI("urn:relative");
+    // Restriction types
+    private final URI parentsAreTallPeople = vf.createURI("urn:parentsAreTallPeople");
+    private final URI parentsArePeople = vf.createURI("urn:parentsArePeople");
+    private final URI relativesArePeople = vf.createURI("urn:relativesArePeople");
+    private final URI parentsAreDogs = vf.createURI("urn:parentsAreDogs");
+
+    @Test
+    public void testRewriteTypePattern() throws Exception {
+        // Configure a mock instance engine with an ontology:
+        final InferenceEngine inferenceEngine = mock(InferenceEngine.class);
+        Map<Resource, Set<URI>> personAVF = new HashMap<>();
+        personAVF.put(parentsAreTallPeople, new HashSet<>());
+        personAVF.put(parentsArePeople, new HashSet<>());
+        personAVF.put(relativesArePeople, new HashSet<>());
+        personAVF.get(parentsAreTallPeople).add(parent);
+        personAVF.get(parentsArePeople).add(parent);
+        personAVF.get(relativesArePeople).add(relative);
+        personAVF.get(relativesArePeople).add(parent);
+        Map<Resource, Set<URI>> dogAVF = new HashMap<>();
+        dogAVF.put(parentsAreDogs, new HashSet<>());
+        dogAVF.get(parentsAreDogs).add(parent);
+        when(inferenceEngine.getAllValuesFromByValueType(person)).thenReturn(personAVF);
+        when(inferenceEngine.getAllValuesFromByValueType(dog)).thenReturn(dogAVF);
+        // Query for a specific type and rewrite using the visitor:
+        StatementPattern originalSP = new StatementPattern(new Var("s"), new Var("p", RDF.TYPE), new Var("o", person));
+        final Projection query = new Projection(originalSP, new ProjectionElemList(new ProjectionElem("s", "subject")));
+        query.visit(new AllValuesFromVisitor(conf, inferenceEngine));
+        // Expected structure: a union of two elements: one is equal to the original statement
+        // pattern, and the other one joins a list of predicate/restriction type combinations
+        // with another join querying for values of that predicate for members of that type.
+        Assert.assertTrue(query.getArg() instanceof Union);
+        TupleExpr left = ((Union) query.getArg()).getLeftArg();
+        TupleExpr right = ((Union) query.getArg()).getRightArg();
+        final Join join;
+        if (left instanceof StatementPattern) {
+            Assert.assertEquals(originalSP, left);
+            Assert.assertTrue(right instanceof Join);
+            join = (Join) right;
+        }
+        else {
+            Assert.assertEquals(originalSP, right);
+            Assert.assertTrue(left instanceof Join);
+            join = (Join) left;
+        }
+        Assert.assertTrue(join.getLeftArg() instanceof FixedStatementPattern);
+        Assert.assertTrue(join.getRightArg() instanceof Join);
+        FixedStatementPattern fsp = (FixedStatementPattern) join.getLeftArg();
+        left = ((Join) join.getRightArg()).getLeftArg();
+        right = ((Join) join.getRightArg()).getRightArg();
+        Assert.assertTrue(left instanceof StatementPattern);
+        Assert.assertTrue(right instanceof StatementPattern);
+        // Verify expected predicate/restriction pairs
+        Assert.assertEquals(4, fsp.statements.size());
+        fsp.statements.contains(new NullableStatementImpl(parentsArePeople, OWL.ONPROPERTY, parent));
+        fsp.statements.contains(new NullableStatementImpl(relativesArePeople, OWL.ONPROPERTY, relative));
+        fsp.statements.contains(new NullableStatementImpl(relativesArePeople, OWL.ONPROPERTY, parent));
+        fsp.statements.contains(new NullableStatementImpl(parentsAreTallPeople, OWL.ONPROPERTY, parent));
+        // Verify general pattern for matching instances of each pair: Join on unknown subject; left
+        // triple states it belongs to the restriction while right triple relates it to the original
+        // subject variable by the relevant property. Restriction and property variables are given
+        // by the FixedStatementPattern.
+        StatementPattern leftSP = (StatementPattern) left;
+        StatementPattern rightSP = (StatementPattern) right;
+        Assert.assertEquals(rightSP.getSubjectVar(), leftSP.getSubjectVar());
+        Assert.assertEquals(RDF.TYPE, leftSP.getPredicateVar().getValue());
+        Assert.assertEquals(fsp.getSubjectVar(), leftSP.getObjectVar());
+        Assert.assertEquals(fsp.getObjectVar(), rightSP.getPredicateVar());
+        Assert.assertEquals(originalSP.getSubjectVar(), rightSP.getObjectVar());
+    }
+}

--- a/sail/src/test/java/org/apache/rya/rdftriplestore/inference/InferenceEngineTest.java
+++ b/sail/src/test/java/org/apache/rya/rdftriplestore/inference/InferenceEngineTest.java
@@ -225,6 +225,37 @@ public class InferenceEngineTest extends TestCase {
     }
 
     @Test
+    public void testAllValuesFrom() throws Exception {
+        String insert = "INSERT DATA { GRAPH <http://updated/test> {\n"
+                + "  <urn:Dog> owl:onProperty <urn:relative> ; owl:allValuesFrom <urn:Dog> .\n"
+                + "  <urn:Retriever> rdfs:subClassOf <urn:Dog> .\n"
+                + "  <urn:Terrier> rdfs:subClassOf <urn:Dog> .\n"
+                + "  <urn:Terrier> owl:onProperty <urn:relative> ; owl:allValuesFrom <urn:Terrier> .\n"
+                + "  <urn:Cairn_Terrier> rdfs:subClassOf <urn:Terrier> .\n"
+                + "  <urn:parent> rdfs:subPropertyOf <urn:relative> .\n"
+                + "  <urn:Dog> rdfs:subClassOf <urn:Mammal> .\n"
+                + "  <urn:Person> rdfs:subClassOf <urn:Mammal> .\n"
+                + "  <urn:Person> owl:onProperty <urn:relative> ; owl:allValuesFrom <urn:Person> .\n"
+                + "}}";
+        conn.prepareUpdate(QueryLanguage.SPARQL, insert).execute();
+        inferenceEngine.refreshGraph();
+        final Map<Resource, Set<URI>> restrictionsImplyingTerrier = new HashMap<>();
+        final Set<URI> properties = new HashSet<>();
+        properties.add(vf.createURI("urn:parent"));
+        properties.add(vf.createURI("urn:relative"));
+        restrictionsImplyingTerrier.put(vf.createURI("urn:Terrier"), properties);
+        restrictionsImplyingTerrier.put(vf.createURI("urn:Cairn_Terrier"), properties);
+        Assert.assertEquals(restrictionsImplyingTerrier, inferenceEngine.getAllValuesFromByValueType(vf.createURI("urn:Terrier")));
+        final Map<Resource, Set<URI>> restrictionsImplyingDog = new HashMap<>(restrictionsImplyingTerrier);
+        restrictionsImplyingDog.put(vf.createURI("urn:Dog"), properties);
+        restrictionsImplyingDog.put(vf.createURI("urn:Retriever"), properties);
+        Assert.assertEquals(restrictionsImplyingDog, inferenceEngine.getAllValuesFromByValueType(vf.createURI("urn:Dog")));
+        final Map<Resource, Set<URI>> restrictionsImplyingMammal = new HashMap<>(restrictionsImplyingDog);
+        restrictionsImplyingMammal.put(vf.createURI("urn:Person"), properties);
+        Assert.assertEquals(restrictionsImplyingMammal, inferenceEngine.getAllValuesFromByValueType(vf.createURI("urn:Mammal")));
+    }
+
+    @Test
     public void testHasValueGivenProperty() throws Exception {
         String insert = "INSERT DATA { GRAPH <http://updated/test> {\n"
                 + "  <urn:Biped> owl:onProperty <urn:walksUsingLegs>  . \n"


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

  http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
## Description
Inference applies owl:allValuesFrom semantics for queries including statement patterns of the form "?x rdf:type :DefinedClass".

An owl:allValuesFrom property restriction is a universal class expression: it defines type T1 to be the set of individuals such that, for a given property p and type T2, all values of that property (i.e. all objects of triples where the predicate is p and the subject belongs to T1) have type T2. Therefore, if an individual is known to belong to the universal class expression (T1), then it can be inferred that all of its values for the property belong to the value type (T2). This is similar to rdfs:range except that it only applies when the subject of the triple belongs to the appropriate class expression.

InferenceEngine, at refresh time, stores information about owl:allValuesFrom restrictions (universal class expressions). These definitions can then be accessed by the value type: getAllValuesFromByValueType(<value type>) returns every (restriction type, property) pair.

AllValuesFromVisitor processes statement patterns of the form "?x rdf:type :T2", and if :T2 is the value type for any owl:allValuesFrom restriction according to the inference engine, it replaces the statement pattern with a union: of 1) that same statement pattern (in case the type is explicitly asserted or can be inferred by some other rule); and 2) a subquery of the form "?y \:p ?x . ?y rdf:type :T1" for the appropriate (restriction type, property) pair.

RdfCloudTripleStoreConnection calls the visitor along with the other inference logic. Because the original statement pattern is preserved as one branch of the union, other visitors can still apply if there are other ways to derive the type.

Added a simple example of a query that relies on this inference to MongoRyaDirectExample.

### Tests
Unit test to verify that InferenceEngine stores and returns the schema; unit test to verify that AllValuesFromVisitor rewrites queries of the proper form; integration test to verify correct results for sample ontology+instances+query relying on allValuesFrom inference.

### Links
[Jira](https://issues.apache.org/jira/browse/RYA-295)

### Checklist
- [ ] Code Review
- [ ] Squash Commits

#### People To Reivew
@ejwhite922 
@isper3at 
@meiercaleb 
@pujav65 