### PR TITLE
RYA-294 owl:someValuesFrom inference

### DIFF
--- a/common/rya.api/src/main/java/org/apache/rya/api/RdfCloudTripleStoreConfiguration.java
+++ b/common/rya.api/src/main/java/org/apache/rya/api/RdfCloudTripleStoreConfiguration.java
@@ -75,6 +75,7 @@ public abstract class RdfCloudTripleStoreConfiguration extends Configuration {
     public static final String INFER_INCLUDE_INTERSECTION_OF = "infer.include.intersectionof";
     public static final String INFER_INCLUDE_INVERSEOF = "infer.include.inverseof";
     public static final String INFER_INCLUDE_ONE_OF = "infer.include.oneof";
+    public static final String INFER_INCLUDE_SOME_VALUES_FROM = "infer.include.somevaluesfrom";
     public static final String INFER_INCLUDE_SUBCLASSOF = "infer.include.subclassof";
     public static final String INFER_INCLUDE_SUBPROPOF = "infer.include.subpropof";
     public static final String INFER_INCLUDE_SYMMPROP = "infer.include.symmprop";
@@ -376,6 +377,25 @@ public abstract class RdfCloudTripleStoreConfiguration extends Configuration {
     public void setInferOneOf(final Boolean value) {
         Preconditions.checkNotNull(value);
         setBoolean(INFER_INCLUDE_ONE_OF, value);
+    }
+
+    /**
+     * @return {@code true} if owl:someValuesFrom inferencing is enabled.
+     * {@code false} otherwise. Defaults to {@code true} if nothing is
+     * specified.
+     */
+    public Boolean isInferSomeValuesFrom() {
+        return getBoolean(INFER_INCLUDE_SOME_VALUES_FROM, true);
+    }
+
+    /**
+     * Sets whether owl:someValuesFrom inferencing is enabled or disabled.
+     * @param value {@code true} if owl:someValuesFrom inferencing is enabled.
+     * {@code false} otherwise.
+     */
+    public void setInferSomeValuesFrom(final Boolean value) {
+        Preconditions.checkNotNull(value);
+        setBoolean(INFER_INCLUDE_SOME_VALUES_FROM, value);
     }
 
     public Boolean isInferSubClassOf() {

--- a/extras/indexingExample/src/main/java/MongoRyaDirectExample.java
+++ b/extras/indexingExample/src/main/java/MongoRyaDirectExample.java
@@ -118,6 +118,7 @@ public class MongoRyaDirectExample {
                 testInfer(conn, sail);
                 testPropertyChainInference(conn, sail);
                 testPropertyChainInferenceAltRepresentation(conn, sail);
+                testSomeValuesFromInference(conn, sail);
                 testAllValuesFromInference(conn, sail);
                 testIntersectionOfInference(conn, sail);
                 testOneOfInference(conn, sail);
@@ -521,6 +522,59 @@ public class MongoRyaDirectExample {
         tupleQuery.evaluate(resultHandler);
         log.info("Result count : " + resultHandler.getCount());
         Validate.isTrue(resultHandler.getCount() == 2);
+    }
+
+    public static void testSomeValuesFromInference(final SailRepositoryConnection conn, final Sail sail) throws MalformedQueryException, RepositoryException,
+    UpdateExecutionException, QueryEvaluationException, TupleQueryResultHandlerException, InferenceEngineException {
+        final String lubm = "http://swat.cse.lehigh.edu/onto/univ-bench.owl#";
+        log.info("Adding Data");
+        String insert = "PREFIX lubm: <" + lubm + ">\n"
+                + "INSERT DATA { GRAPH <http://updated/test> {\n"
+                + "  <urn:Department0> a lubm:Department; lubm:subOrganizationOf <urn:University0> .\n"
+                + "  <urn:ResearchGroup0> a lubm:ResearchGroup; lubm:subOrganizationOf <urn:Department0> .\n"
+                + "  <urn:Alice> lubm:headOf <urn:Department0> .\n"
+                + "  <urn:Bob> lubm:headOf <urn:ResearchGroup0> .\n"
+                + "  <urn:Carol> lubm:worksFor <urn:Department0> .\n"
+                + "}}";
+        Update update = conn.prepareUpdate(QueryLanguage.SPARQL, insert);
+        update.execute();
+        final String inferQuery = "select distinct ?x { GRAPH <http://updated/test> { ?x a <" + lubm + "Chair> }}";
+        final String explicitQuery = "prefix lubm: <" + lubm + ">\n"
+                + "select distinct ?x { GRAPH <http://updated/test> {\n"
+                + "  { ?x a lubm:Chair }\n"
+                + "  UNION\n"
+                + "  { ?x lubm:headOf [ a lubm:Department ] }\n"
+                + "}}";
+        log.info("Running Explicit Query");
+        final CountingResultHandler resultHandler = new CountingResultHandler();
+        TupleQuery tupleQuery = conn.prepareTupleQuery(QueryLanguage.SPARQL, explicitQuery);
+        tupleQuery.evaluate(resultHandler);
+        log.info("Result count : " + resultHandler.getCount());
+        Validate.isTrue(resultHandler.getCount() == 1);
+        log.info("Running Inference-dependent Query");
+        resultHandler.resetCount();
+        tupleQuery = conn.prepareTupleQuery(QueryLanguage.SPARQL, inferQuery);
+        tupleQuery.evaluate(resultHandler);
+        log.info("Result count : " + resultHandler.getCount());
+        Validate.isTrue(resultHandler.getCount() == 0);
+        log.info("Adding owl:someValuesFrom Schema");
+        insert = "PREFIX rdfs: <" + RDFS.NAMESPACE + ">\n"
+                + "PREFIX owl: <" + OWL.NAMESPACE + ">\n"
+                + "PREFIX lubm: <" + lubm + ">\n"
+                + "INSERT DATA\n"
+                + "{ GRAPH <http://updated/test> {\n"
+                + "  lubm:Chair owl:equivalentClass [ owl:onProperty lubm:headOf ; owl:someValuesFrom lubm:Department ] ."
+                + "}}";
+        update = conn.prepareUpdate(QueryLanguage.SPARQL, insert);
+        update.execute();
+        log.info("Refreshing InferenceEngine");
+        ((RdfCloudTripleStore) sail).getInferenceEngine().refreshGraph();
+        log.info("Re-running Inference-dependent Query");
+        resultHandler.resetCount();
+        tupleQuery = conn.prepareTupleQuery(QueryLanguage.SPARQL, inferQuery);
+        tupleQuery.evaluate(resultHandler);
+        log.info("Result count : " + resultHandler.getCount());
+        Validate.isTrue(resultHandler.getCount() == 1);
     }
 
     public static void testAllValuesFromInference(final SailRepositoryConnection conn, final Sail sail) throws MalformedQueryException, RepositoryException,

--- a/sail/src/main/java/org/apache/rya/rdftriplestore/RdfCloudTripleStoreConnection.java
+++ b/sail/src/main/java/org/apache/rya/rdftriplestore/RdfCloudTripleStoreConnection.java
@@ -60,6 +60,7 @@ import org.apache.rya.rdftriplestore.inference.InverseOfVisitor;
 import org.apache.rya.rdftriplestore.inference.OneOfVisitor;
 import org.apache.rya.rdftriplestore.inference.PropertyChainVisitor;
 import org.apache.rya.rdftriplestore.inference.SameAsVisitor;
+import org.apache.rya.rdftriplestore.inference.SomeValuesFromVisitor;
 import org.apache.rya.rdftriplestore.inference.SubClassOfVisitor;
 import org.apache.rya.rdftriplestore.inference.SubPropertyOfVisitor;
 import org.apache.rya.rdftriplestore.inference.SymmetricPropertyVisitor;
@@ -353,6 +354,7 @@ public class RdfCloudTripleStoreConnection extends SailConnectionBase {
                     ) {
                 try {
                     tupleExpr.visit(new DomainRangeVisitor(queryConf, inferenceEngine));
+                    tupleExpr.visit(new SomeValuesFromVisitor(queryConf, inferenceEngine));
                     tupleExpr.visit(new AllValuesFromVisitor(queryConf, inferenceEngine));
                     tupleExpr.visit(new HasValueVisitor(queryConf, inferenceEngine));
                     tupleExpr.visit(new IntersectionOfVisitor(queryConf, inferenceEngine));

--- a/sail/src/main/java/org/apache/rya/rdftriplestore/inference/SomeValuesFromVisitor.java
+++ b/sail/src/main/java/org/apache/rya/rdftriplestore/inference/SomeValuesFromVisitor.java
@@ -1,0 +1,110 @@
+package org.apache.rya.rdftriplestore.inference;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import org.apache.rya.api.RdfCloudTripleStoreConfiguration;
+import org.apache.rya.api.utils.NullableStatementImpl;
+import org.apache.rya.rdftriplestore.utils.FixedStatementPattern;
+import org.openrdf.model.Resource;
+import org.openrdf.model.URI;
+import org.openrdf.model.vocabulary.OWL;
+import org.openrdf.model.vocabulary.RDF;
+import org.openrdf.query.algebra.StatementPattern;
+import org.openrdf.query.algebra.Var;
+
+/**
+ * Expands the query tree to account for any existential class expressions (property restrictions
+ * using owl:someValuesFrom) in the ontology known to the {@link InferenceEngine}.
+ *
+ * Operates on {@link StatementPattern} nodes whose predicate is rdf:type and whose object is a
+ * defined type (not a variable) which corresponds to a someValuesFrom expression in the ontology.
+ * When applicable, replaces the node with a union of itself and a subtree that matches any instance
+ * that can be inferred to have the type in question via the semantics of owl:someValuesFrom.
+ *
+ * An existential class expression references a predicate and a value class, and represents the set
+ * of individuals with at least one value of that class for that predicate. Therefore, membership
+ * in the class expression should be inferred for any individual which is the subject of a triple
+ * with that predicate and with an object belonging to the value type. This implication is similar
+ * to rdfs:domain except that it only applies when the object of the triple belongs to a specific
+ * type.
+ *
+ * (Note: The inference in the other direction would be that, if an individual is declared to belong
+ * to the class expression, then there exists some other individual which satisfies the requirement
+ * that there is at least one value of the appropriate type. However, this other individual may be
+ * any arbitrary resource, explicitly represented in the data or otherwise, so this implication is
+ * not used.)
+ */
+public class SomeValuesFromVisitor extends AbstractInferVisitor {
+    /**
+     * Creates a new {@link SomeValuesFromVisitor}.
+     * @param conf The {@link RdfCloudTripleStoreConfiguration}.
+     * @param inferenceEngine The InferenceEngine containing the relevant ontology.
+     */
+    public SomeValuesFromVisitor(RdfCloudTripleStoreConfiguration conf, InferenceEngine inferenceEngine) {
+        super(conf, inferenceEngine);
+        include = conf.isInferSomeValuesFrom();
+    }
+
+    /**
+     * Checks whether the StatementPattern is a type query whose solutions could be inferred by
+     * someValuesFrom inference, and if so, replaces the node with a union of itself and any
+     * possible inference.
+     */
+    @Override
+    protected void meetSP(StatementPattern node) throws Exception {
+        final Var subjVar = node.getSubjectVar();
+        final Var predVar = node.getPredicateVar();
+        final Var objVar = node.getObjectVar();
+        // Only applies to type queries where the type is defined
+        if (predVar != null && RDF.TYPE.equals(predVar.getValue()) && objVar != null && objVar.getValue() instanceof Resource) {
+            final Resource typeToInfer = (Resource) objVar.getValue();
+            Map<Resource, Set<URI>> relevantSvfRestrictions = inferenceEngine.getSomeValuesFromByRestrictionType(typeToInfer);
+            if (!relevantSvfRestrictions.isEmpty()) {
+                // We can infer the queried type if it is to a someValuesFrom restriction (or a
+                // supertype of one), and the node in question (subjVar) is the subject of a triple
+                // whose predicate is the restriction's property and whose object is an arbitrary
+                // node of the restriction's value type.
+                final Var valueTypeVar = new Var("t-" + UUID.randomUUID());
+                final Var svfPredVar = new Var("p-" + UUID.randomUUID());
+                final Var neighborVar = new Var("n-" + UUID.randomUUID());
+                neighborVar.setAnonymous(true);
+                final StatementPattern membershipPattern = new DoNotExpandSP(neighborVar,
+                        new Var(RDF.TYPE.stringValue(), RDF.TYPE), valueTypeVar);
+                final StatementPattern valuePattern = new StatementPattern(subjVar, svfPredVar, neighborVar);
+                final InferJoin svfPattern = new InferJoin(membershipPattern, valuePattern);
+                // Use a FixedStatementPattern to contain the appropriate (predicate, value type)
+                // pairs, and check each one against the general pattern.
+                final FixedStatementPattern svfPropertyTypes = new FixedStatementPattern(svfPredVar,
+                        new Var(OWL.SOMEVALUESFROM.stringValue(), OWL.SOMEVALUESFROM), valueTypeVar);
+                for (Resource svfValueType : relevantSvfRestrictions.keySet()) {
+                    for (URI svfProperty : relevantSvfRestrictions.get(svfValueType)) {
+                        svfPropertyTypes.statements.add(new NullableStatementImpl(svfProperty,
+                                OWL.SOMEVALUESFROM, svfValueType));
+                    }
+                }
+                final InferJoin svfInferenceQuery = new InferJoin(svfPropertyTypes, svfPattern);
+                node.replaceWith(new InferUnion(node.clone(), svfInferenceQuery));
+            }
+        }
+    }
+}

--- a/sail/src/test/java/org/apache/rya/rdftriplestore/inference/AllValuesFromVisitorTest.java
+++ b/sail/src/test/java/org/apache/rya/rdftriplestore/inference/AllValuesFromVisitorTest.java
@@ -108,11 +108,11 @@ public class AllValuesFromVisitorTest {
         Assert.assertTrue(left instanceof StatementPattern);
         Assert.assertTrue(right instanceof StatementPattern);
         // Verify expected predicate/restriction pairs
+        Assert.assertTrue(fsp.statements.contains(new NullableStatementImpl(parentsArePeople, OWL.ONPROPERTY, parent)));
+        Assert.assertTrue(fsp.statements.contains(new NullableStatementImpl(relativesArePeople, OWL.ONPROPERTY, relative)));
+        Assert.assertTrue(fsp.statements.contains(new NullableStatementImpl(relativesArePeople, OWL.ONPROPERTY, parent)));
+        Assert.assertTrue(fsp.statements.contains(new NullableStatementImpl(parentsAreTallPeople, OWL.ONPROPERTY, parent)));
         Assert.assertEquals(4, fsp.statements.size());
-        fsp.statements.contains(new NullableStatementImpl(parentsArePeople, OWL.ONPROPERTY, parent));
-        fsp.statements.contains(new NullableStatementImpl(relativesArePeople, OWL.ONPROPERTY, relative));
-        fsp.statements.contains(new NullableStatementImpl(relativesArePeople, OWL.ONPROPERTY, parent));
-        fsp.statements.contains(new NullableStatementImpl(parentsAreTallPeople, OWL.ONPROPERTY, parent));
         // Verify general pattern for matching instances of each pair: Join on unknown subject; left
         // triple states it belongs to the restriction while right triple relates it to the original
         // subject variable by the relevant property. Restriction and property variables are given

--- a/sail/src/test/java/org/apache/rya/rdftriplestore/inference/SomeValuesFromVisitorTest.java
+++ b/sail/src/test/java/org/apache/rya/rdftriplestore/inference/SomeValuesFromVisitorTest.java
@@ -1,0 +1,152 @@
+package org.apache.rya.rdftriplestore.inference;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.rya.accumulo.AccumuloRdfConfiguration;
+import org.apache.rya.api.utils.NullableStatementImpl;
+import org.apache.rya.rdftriplestore.utils.FixedStatementPattern;
+import org.junit.Assert;
+import org.junit.Test;
+import org.openrdf.model.Resource;
+import org.openrdf.model.URI;
+import org.openrdf.model.ValueFactory;
+import org.openrdf.model.impl.ValueFactoryImpl;
+import org.openrdf.model.vocabulary.OWL;
+import org.openrdf.model.vocabulary.RDF;
+import org.openrdf.query.algebra.Join;
+import org.openrdf.query.algebra.Projection;
+import org.openrdf.query.algebra.ProjectionElem;
+import org.openrdf.query.algebra.ProjectionElemList;
+import org.openrdf.query.algebra.StatementPattern;
+import org.openrdf.query.algebra.TupleExpr;
+import org.openrdf.query.algebra.Union;
+import org.openrdf.query.algebra.Var;
+
+import com.google.common.collect.Sets;
+
+public class SomeValuesFromVisitorTest {
+    private static final AccumuloRdfConfiguration conf = new AccumuloRdfConfiguration();
+    private static final ValueFactory vf = new ValueFactoryImpl();
+
+    // Value types
+    private final URI course = vf.createURI("lubm:Course");
+    private final URI gradCourse = vf.createURI("lubm:GraduateCourse");
+    private final URI department = vf.createURI("lubm:Department");
+    private final URI organization = vf.createURI("lubm:Organization");
+    // Predicates
+    private final URI takesCourse = vf.createURI("lubm:takesCourse");
+    private final URI headOf = vf.createURI("lubm:headOf");
+    private final URI worksFor = vf.createURI("lubm:worksFor");
+    // Supertype of restriction types
+    private final URI person = vf.createURI("lubm:Person");
+
+    @Test
+    public void testSomeValuesFrom() throws Exception {
+        // Configure a mock instance engine with an ontology:
+        final InferenceEngine inferenceEngine = mock(InferenceEngine.class);
+        Map<Resource, Set<URI>> personSVF = new HashMap<>();
+        personSVF.put(gradCourse, Sets.newHashSet(takesCourse));
+        personSVF.put(course, Sets.newHashSet(takesCourse));
+        personSVF.put(department, Sets.newHashSet(headOf));
+        personSVF.put(organization, Sets.newHashSet(worksFor, headOf));
+        when(inferenceEngine.getSomeValuesFromByRestrictionType(person)).thenReturn(personSVF);
+        // Query for a specific type and rewrite using the visitor:
+        StatementPattern originalSP = new StatementPattern(new Var("s"), new Var("p", RDF.TYPE), new Var("o", person));
+        final Projection query = new Projection(originalSP, new ProjectionElemList(new ProjectionElem("s", "subject")));
+        query.visit(new SomeValuesFromVisitor(conf, inferenceEngine));
+        // Expected structure: a union of two elements: one is equal to the original statement
+        // pattern, and the other one joins a list of predicate/value type combinations
+        // with another join querying for any nodes who are the subject of a triple with that
+        // predicate and with an object of that type.
+        //
+        // Union(
+        //     SP(?node a :impliedType),
+        //     Join(
+        //         FSP(<?property someValuesFrom ?valueType> {
+        //             takesCourse/Course;
+        //             takesCourse/GraduateCourse;
+        //             headOf/Department;
+        //             headOf/Organization;
+        //             worksFor/Organization;
+        //         }),
+        //         Join(
+        //             SP(_:object a ?valueType),
+        //             SP(?node ?property _:object)
+        //         )
+        //     )
+        Assert.assertTrue(query.getArg() instanceof Union);
+        TupleExpr left = ((Union) query.getArg()).getLeftArg();
+        TupleExpr right = ((Union) query.getArg()).getRightArg();
+        Assert.assertEquals(originalSP, left);
+        Assert.assertTrue(right instanceof Join);
+        final Join join = (Join) right;
+        Assert.assertTrue(join.getLeftArg() instanceof FixedStatementPattern);
+        Assert.assertTrue(join.getRightArg() instanceof Join);
+        FixedStatementPattern fsp = (FixedStatementPattern) join.getLeftArg();
+        left = ((Join) join.getRightArg()).getLeftArg();
+        right = ((Join) join.getRightArg()).getRightArg();
+        Assert.assertTrue(left instanceof StatementPattern);
+        Assert.assertTrue(right instanceof StatementPattern);
+        // Verify expected predicate/type pairs
+        Assert.assertTrue(fsp.statements.contains(new NullableStatementImpl(takesCourse, OWL.SOMEVALUESFROM, course)));
+        Assert.assertTrue(fsp.statements.contains(new NullableStatementImpl(takesCourse, OWL.SOMEVALUESFROM, gradCourse)));
+        Assert.assertTrue(fsp.statements.contains(new NullableStatementImpl(headOf, OWL.SOMEVALUESFROM, department)));
+        Assert.assertTrue(fsp.statements.contains(new NullableStatementImpl(headOf, OWL.SOMEVALUESFROM, organization)));
+        Assert.assertTrue(fsp.statements.contains(new NullableStatementImpl(worksFor, OWL.SOMEVALUESFROM, organization)));
+        Assert.assertEquals(5, fsp.statements.size());
+        // Verify pattern for matching instances of each pair: a Join of <_:x rdf:type ?t> and
+        // <?s ?p _:x> where p and t are the predicate/type pair and s is the original subject
+        // variable.
+        StatementPattern leftSP = (StatementPattern) left;
+        StatementPattern rightSP = (StatementPattern) right;
+        Assert.assertEquals(rightSP.getObjectVar(), leftSP.getSubjectVar());
+        Assert.assertEquals(RDF.TYPE, leftSP.getPredicateVar().getValue());
+        Assert.assertEquals(fsp.getObjectVar(), leftSP.getObjectVar());
+        Assert.assertEquals(originalSP.getSubjectVar(), rightSP.getSubjectVar());
+        Assert.assertEquals(fsp.getSubjectVar(), rightSP.getPredicateVar());
+    }
+
+    @Test
+    public void testSomeValuesFromDisabled() throws Exception {
+        // Disable someValuesOf inference
+        final AccumuloRdfConfiguration disabledConf = conf.clone();
+        disabledConf.setInferSomeValuesFrom(false);
+        // Configure a mock instance engine with an ontology:
+        final InferenceEngine inferenceEngine = mock(InferenceEngine.class);
+        Map<Resource, Set<URI>> personSVF = new HashMap<>();
+        personSVF.put(gradCourse, Sets.newHashSet(takesCourse));
+        personSVF.put(course, Sets.newHashSet(takesCourse));
+        personSVF.put(department, Sets.newHashSet(headOf));
+        personSVF.put(organization, Sets.newHashSet(worksFor, headOf));
+        when(inferenceEngine.getSomeValuesFromByRestrictionType(person)).thenReturn(personSVF);
+        // Query for a specific type visit -- should not change
+        StatementPattern originalSP = new StatementPattern(new Var("s"), new Var("p", RDF.TYPE), new Var("o", person));
+        final Projection originalQuery = new Projection(originalSP, new ProjectionElemList(new ProjectionElem("s", "subject")));
+        final Projection modifiedQuery = originalQuery.clone();
+        modifiedQuery.visit(new SomeValuesFromVisitor(disabledConf, inferenceEngine));
+        Assert.assertEquals(originalQuery, modifiedQuery);
+    }
+}


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

  http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
## Description
Inference applies owl:someValuesFrom semantics for queries including statement patterns of the form "?x rdf:type :DefinedClass".

An owl:someValuesFrom property restriction is an existential class expression: it defines type T1 to be the set of individuals, such that, for a given property p and type T2, there is at least one value of type T2 for that property, i.e. for any subject belonging to T1 there exists a triple whose predicate is p and whose object belongs to T2. Therefore, if an individual is known to belong to the value type (T2), then any individual having it as a value for property p by definition belongs to T1. This is similar to rdfs:domain except that it only applies when the object of the triple belongs to the appropriate class expression. It is the converse of owl:allValuesFrom, in which the subject's type and the predicate are used to infer the object's type.

(It's also theoretically true that if something belongs to the set defined by owl:someValuesFrom, then there must exist some individual which is the value and belongs to that type. But we don't have a direct way to use that implication to answer queries, so it is ignored for now.)

InferenceEngine stores someValuesFrom information nearly identically to allValuesFrom information, except that it can be accessed by the type of the restriction rather than the type of the value. Some edits to allValuesFrom logic for consistency/simplicity/reuse.

SomeValuesFromVisitor processes statement patterns of the form "?x rdf:type :T1", and if :T2 is the type of an owl:someValuesFrom restriction according to the inference engine, it replaces the statement pattern with a union: of 1) the same statement pattern; and 2) a subquery of the form "?y rdf:type :T2. ?x :p ?y." for the appropriate (restriction type, property) pairs.

RdfCloudTripleStoreConnection adds this to its list of visitors to call on a query.

Added an example to MongoRyaDirectExample, using a slightly modified piece of the LUBM example schema (can't use the exact formulation from LUBM because it relies on composing intersection and property restriction logic, where Rya will not presently apply both).

### Tests
Unit test to verify that InferenceEngine stores and returns the schema; unit test to verify that type queries are rewritten appropriately; integration test to verify correct results for sample ontology+instances+query.

### Links
[Jira](https://issues.apache.org/jira/browse/RYA-294)

### Checklist
- [x] Code Review
- [x] Squash Commits

#### People To Reivew
@meiercaleb @ejwhite922 @isper3at @pujav65 
