### PR TITLE
RYA-301 owl:ReflexiveProperty inference

### DIFF
--- a/common/rya.api/src/main/java/org/apache/rya/api/RdfCloudTripleStoreConfiguration.java
+++ b/common/rya.api/src/main/java/org/apache/rya/api/RdfCloudTripleStoreConfiguration.java
@@ -72,15 +72,21 @@ public abstract class RdfCloudTripleStoreConfiguration extends Configuration {
     public static final String CONF_STATEMENT_METADATA_PROPERTIES = "statement.metadata.properites";
     public static final String CONF_USE_STATEMENT_METADATA = "use.statement.metadata";
     public static final String STATS_PUSH_EMPTY_RDFTYPE_DOWN = "conf.stats.rdftype.down";
+    public static final String INFER_INCLUDE_ALL_VALUES_FROM = "infer.include.allvaluesfrom";
+    public static final String INFER_INCLUDE_DOMAIN_RANGE = "infer.include.domainrange";
+    public static final String INFER_INCLUDE_HAS_SELF = "infer.include.hasself";
+    public static final String INFER_INCLUDE_HAS_VALUE = "infer.include.hasvalue";
     public static final String INFER_INCLUDE_INTERSECTION_OF = "infer.include.intersectionof";
     public static final String INFER_INCLUDE_INVERSEOF = "infer.include.inverseof";
     public static final String INFER_INCLUDE_ONE_OF = "infer.include.oneof";
+    public static final String INFER_INCLUDE_PROPERTY_CHAIN = "infer.include.propertychain";
+    public static final String INFER_INCLUDE_REFLEXIVE_PROP = "infer.include.reflexiveprop";
     public static final String INFER_INCLUDE_SOME_VALUES_FROM = "infer.include.somevaluesfrom";
+    public static final String INFER_INCLUDE_SAME_AS = "infer.include.sameas";
     public static final String INFER_INCLUDE_SUBCLASSOF = "infer.include.subclassof";
     public static final String INFER_INCLUDE_SUBPROPOF = "infer.include.subpropof";
     public static final String INFER_INCLUDE_SYMMPROP = "infer.include.symmprop";
     public static final String INFER_INCLUDE_TRANSITIVEPROP = "infer.include.transprop";
-    public static final String INFER_INCLUDE_HAS_SELF = "infer.include.hasself";
 
     public static final String RDF_DAO_CLASS = "class.rdf.dao";
     public static final String RDF_EVAL_STATS_DAO_CLASS = "class.rdf.evalstats";
@@ -334,6 +340,82 @@ public abstract class RdfCloudTripleStoreConfiguration extends Configuration {
     }
 
     /**
+     * @return {@code true} if owl:allValuesFrom inferencing is enabled.
+     * {@code false} otherwise. Defaults to {@code true} if nothing is
+     * specified.
+     */
+    public Boolean isInferAllValuesFrom() {
+        return getBoolean(INFER_INCLUDE_ALL_VALUES_FROM, true);
+    }
+
+    /**
+     * Sets whether owl:allValuesFrom inferencing is enabled or disabled.
+     * @param value {@code true} if owl:allValuesFrom inferencing is enabled.
+     * {@code false} otherwise.
+     */
+    public void setInferAllValuesFrom(final Boolean value) {
+        Preconditions.checkNotNull(value);
+        setBoolean(INFER_INCLUDE_ALL_VALUES_FROM, value);
+    }
+
+    /**
+     * @return {@code true} if rdfs:domain and rdfs:range inferencing is enabled.
+     * {@code false} otherwise. Defaults to {@code true} if nothing is
+     * specified.
+     */
+    public Boolean isInferDomainRange() {
+        return getBoolean(INFER_INCLUDE_DOMAIN_RANGE, true);
+    }
+
+    /**
+     * Sets whether rdfs:domain and rdfs:range inferencing is enabled or disabled.
+     * @param value {@code true} if rdfs:domain/range inferencing is enabled.
+     * {@code false} otherwise.
+     */
+    public void setInferDomainRange(final Boolean val) {
+        Preconditions.checkNotNull(val);
+        setBoolean(INFER_INCLUDE_DOMAIN_RANGE, val);
+    }
+
+    /**
+     * @return {@code true} if owl:hasSelf inferencing is enabled.
+     * {@code false} otherwise. Defaults to {@code true} if nothing is
+     * specified.
+     */
+    public Boolean isInferHasSelf() {
+        return getBoolean(INFER_INCLUDE_HAS_SELF, true);
+    }
+
+    /**
+     * Sets whether owl:hasSelf inferencing is enabled or disabled.
+     * @param value {@code true} if owl:hasSelf inferencing is enabled.
+     * {@code false} otherwise.
+     */
+    public void setInferHasSelf(final Boolean val) {
+        Preconditions.checkNotNull(val);
+        setBoolean(INFER_INCLUDE_HAS_SELF, val);
+    }
+
+    /**
+     * @return {@code true} if owl:hasValue inferencing is enabled.
+     * {@code false} otherwise. Defaults to {@code true} if nothing is
+     * specified.
+     */
+    public Boolean isInferHasValue() {
+        return getBoolean(INFER_INCLUDE_HAS_VALUE, true);
+    }
+
+    /**
+     * Sets whether owl:hasValue inferencing is enabled or disabled.
+     * @param value {@code true} if owl:hasValue inferencing is enabled.
+     * {@code false} otherwise.
+     */
+    public void setInferHasValue(final Boolean value) {
+        Preconditions.checkNotNull(value);
+        setBoolean(INFER_INCLUDE_HAS_VALUE, value);
+    }
+
+    /**
      * @return {@code true} if owl:intersectionOf inferencing is enabled.
      * {@code false} otherwise. Defaults to {@code true} if nothing is
      * specified.
@@ -352,10 +434,20 @@ public abstract class RdfCloudTripleStoreConfiguration extends Configuration {
         setBoolean(INFER_INCLUDE_INTERSECTION_OF, value);
     }
 
+    /**
+     * @return {@code true} if owl:inverseOf inferencing is enabled.
+     * {@code false} otherwise. Defaults to {@code true} if nothing is
+     * specified.
+     */
     public Boolean isInferInverseOf() {
         return getBoolean(INFER_INCLUDE_INVERSEOF, true);
     }
 
+    /**
+     * Sets whether owl:inverseOf inferencing is enabled or disabled.
+     * @param value {@code true} if owl:inverseOf inferencing is enabled.
+     * {@code false} otherwise.
+     */
     public void setInferInverseOf(final Boolean val) {
         Preconditions.checkNotNull(val);
         setBoolean(INFER_INCLUDE_INVERSEOF, val);
@@ -381,6 +473,63 @@ public abstract class RdfCloudTripleStoreConfiguration extends Configuration {
     }
 
     /**
+     * @return {@code true} if owl:propertyChainAxiom inferencing is enabled.
+     * {@code false} otherwise. Defaults to {@code true} if nothing is
+     * specified.
+     */
+    public Boolean isInferPropertyChain() {
+        return getBoolean(INFER_INCLUDE_PROPERTY_CHAIN, true);
+    }
+
+    /**
+     * Sets whether owl:propertyChainAxiom inferencing is enabled or disabled.
+     * @param value {@code true} if owl:propertyChainAxiom inferencing is
+     * enabled. {@code false} otherwise.
+     */
+    public void setInferPropertyChain(final Boolean value) {
+        Preconditions.checkNotNull(value);
+        setBoolean(INFER_INCLUDE_PROPERTY_CHAIN, value);
+    }
+
+    /**
+     * @return {@code true} if owl:ReflexiveProperty inferencing is enabled.
+     * {@code false} otherwise. Defaults to {@code true} if nothing is
+     * specified.
+     */
+    public Boolean isInferReflexiveProperty() {
+        return getBoolean(INFER_INCLUDE_REFLEXIVE_PROP, true);
+    }
+
+    /**
+     * Sets whether owl:ReflexiveProperty inferencing is enabled or disabled.
+     * @param value {@code true} if owl:ReflexiveProperty inferencing is
+     * enabled. {@code false} otherwise.
+     */
+    public void setInferReflexiveProperty(final Boolean value) {
+        Preconditions.checkNotNull(value);
+        setBoolean(INFER_INCLUDE_REFLEXIVE_PROP, value);
+    }
+
+    /**
+     * @return {@code true} if owl:sameAs inferencing is enabled.
+     * {@code false} otherwise. Defaults to {@code true} if nothing is
+     * specified.
+     */
+    public Boolean isInferSameAs() {
+        return getBoolean(INFER_INCLUDE_SAME_AS, true);
+    }
+
+    /**
+     * Sets whether owl:sameAs inferencing is enabled or disabled.
+     * @param value {@code true} if owl:sameAs inferencing is enabled.
+     * {@code false} otherwise.
+     */
+    public void setInferSameAs(final Boolean value) {
+        Preconditions.checkNotNull(value);
+        setBoolean(INFER_INCLUDE_SAME_AS, value);
+    }
+
+    /**
      * @return {@code true} if owl:someValuesFrom inferencing is enabled.
      * {@code false} otherwise. Defaults to {@code true} if nothing is
      * specified.
@@ -399,46 +548,77 @@ public abstract class RdfCloudTripleStoreConfiguration extends Configuration {
         setBoolean(INFER_INCLUDE_SOME_VALUES_FROM, value);
     }
 
+    /**
+     * @return {@code true} if rdfs:subClassOf inferencing is enabled.
+     * {@code false} otherwise. Defaults to {@code true} if nothing is
+     * specified.
+     */
     public Boolean isInferSubClassOf() {
         return getBoolean(INFER_INCLUDE_SUBCLASSOF, true);
     }
 
+    /**
+     * Sets whether rdfs:subClassOf inferencing is enabled or disabled.
+     * @param value {@code true} if rdfs:subClassOf inferencing is enabled.
+     * {@code false} otherwise.
+     */
     public void setInferSubClassOf(final Boolean val) {
         Preconditions.checkNotNull(val);
         setBoolean(INFER_INCLUDE_SUBCLASSOF, val);
     }
 
+    /**
+     * @return {@code true} if rdfs:subPropertyOf inferencing is enabled.
+     * {@code false} otherwise. Defaults to {@code true} if nothing is
+     * specified.
+     */
     public Boolean isInferSubPropertyOf() {
         return getBoolean(INFER_INCLUDE_SUBPROPOF, true);
     }
 
+    /**
+     * Sets whether rdfs:subPropertyOf inferencing is enabled or disabled.
+     * @param value {@code true} if rdfs:subPropertyOf inferencing is enabled.
+     * {@code false} otherwise.
+     */
     public void setInferSubPropertyOf(final Boolean val) {
         Preconditions.checkNotNull(val);
         setBoolean(INFER_INCLUDE_SUBPROPOF, val);
     }
 
-    public Boolean hasSelf() {
-        return getBoolean(INFER_INCLUDE_HAS_SELF, true);
-    }
-
-    public void setHasSelf(final Boolean val) {
-        Preconditions.checkNotNull(val);
-        setBoolean(INFER_INCLUDE_HAS_SELF, val);
-    }
-
+    /**
+     * @return {@code true} if owl:SymmetricProperty inferencing is enabled.
+     * {@code false} otherwise. Defaults to {@code true} if nothing is
+     * specified.
+     */
     public Boolean isInferSymmetricProperty() {
         return getBoolean(INFER_INCLUDE_SYMMPROP, true);
     }
 
+    /**
+     * Sets whether owl:SymmetricProperty inferencing is enabled or disabled.
+     * @param value {@code true} if owl:SymmetricProperty inferencing is enabled.
+     * {@code false} otherwise.
+     */
     public void setInferSymmetricProperty(final Boolean val) {
         Preconditions.checkNotNull(val);
         setBoolean(INFER_INCLUDE_SYMMPROP, val);
     }
 
+    /**
+     * @return {@code true} if owl:TransitiveProperty inferencing is enabled.
+     * {@code false} otherwise. Defaults to {@code true} if nothing is
+     * specified.
+     */
     public Boolean isInferTransitiveProperty() {
         return getBoolean(INFER_INCLUDE_TRANSITIVEPROP, true);
     }
 
+    /**
+     * Sets whether owl:TransitiveProperty inferencing is enabled or disabled.
+     * @param value {@code true} if owl:TransitiveProperty inferencing is enabled.
+     * {@code false} otherwise.
+     */
     public void setInferTransitiveProperty(final Boolean val) {
         Preconditions.checkNotNull(val);
         setBoolean(INFER_INCLUDE_TRANSITIVEPROP, val);

--- a/sail/src/main/java/org/apache/rya/rdftriplestore/RdfCloudTripleStoreConnection.java
+++ b/sail/src/main/java/org/apache/rya/rdftriplestore/RdfCloudTripleStoreConnection.java
@@ -60,6 +60,7 @@ import org.apache.rya.rdftriplestore.inference.IntersectionOfVisitor;
 import org.apache.rya.rdftriplestore.inference.InverseOfVisitor;
 import org.apache.rya.rdftriplestore.inference.OneOfVisitor;
 import org.apache.rya.rdftriplestore.inference.PropertyChainVisitor;
+import org.apache.rya.rdftriplestore.inference.ReflexivePropertyVisitor;
 import org.apache.rya.rdftriplestore.inference.SameAsVisitor;
 import org.apache.rya.rdftriplestore.inference.SomeValuesFromVisitor;
 import org.apache.rya.rdftriplestore.inference.SubClassOfVisitor;
@@ -359,6 +360,7 @@ public class RdfCloudTripleStoreConnection extends SailConnectionBase {
                     tupleExpr.visit(new AllValuesFromVisitor(queryConf, inferenceEngine));
                     tupleExpr.visit(new HasValueVisitor(queryConf, inferenceEngine));
                     tupleExpr.visit(new IntersectionOfVisitor(queryConf, inferenceEngine));
+                    tupleExpr.visit(new ReflexivePropertyVisitor(queryConf, inferenceEngine));
                     tupleExpr.visit(new PropertyChainVisitor(queryConf, inferenceEngine));
                     tupleExpr.visit(new TransitivePropertyVisitor(queryConf, inferenceEngine));
                     tupleExpr.visit(new SymmetricPropertyVisitor(queryConf, inferenceEngine));

--- a/sail/src/main/java/org/apache/rya/rdftriplestore/inference/AllValuesFromVisitor.java
+++ b/sail/src/main/java/org/apache/rya/rdftriplestore/inference/AllValuesFromVisitor.java
@@ -58,13 +58,13 @@ import org.openrdf.query.algebra.Var;
 public class AllValuesFromVisitor extends AbstractInferVisitor {
 
     /**
-     * Creates a new {@link AllValuesFromVisitor}, which is enabled by default.
+     * Creates a new {@link AllValuesFromVisitor}.
      * @param conf The {@link RdfCloudTripleStoreConfiguration}.
      * @param inferenceEngine The InferenceEngine containing the relevant ontology.
      */
     public AllValuesFromVisitor(RdfCloudTripleStoreConfiguration conf, InferenceEngine inferenceEngine) {
         super(conf, inferenceEngine);
-        include = true;
+        include = conf.isInferAllValuesFrom();
     }
 
     /**

--- a/sail/src/main/java/org/apache/rya/rdftriplestore/inference/DomainRangeVisitor.java
+++ b/sail/src/main/java/org/apache/rya/rdftriplestore/inference/DomainRangeVisitor.java
@@ -50,13 +50,13 @@ import org.openrdf.query.algebra.Var;
  */
 public class DomainRangeVisitor extends AbstractInferVisitor {
     /**
-     * Creates a new {@link DomainRangeVisitor}, which is enabled by default.
+     * Creates a new {@link DomainRangeVisitor}.
      * @param conf The {@link RdfCloudTripleStoreConfiguration}.
      * @param inferenceEngine The InferenceEngine containing the relevant ontology.
      */
     public DomainRangeVisitor(RdfCloudTripleStoreConfiguration conf, InferenceEngine inferenceEngine) {
         super(conf, inferenceEngine);
-        include = true;
+        include = conf.isInferDomainRange();
     }
 
     /**

--- a/sail/src/main/java/org/apache/rya/rdftriplestore/inference/HasSelfVisitor.java
+++ b/sail/src/main/java/org/apache/rya/rdftriplestore/inference/HasSelfVisitor.java
@@ -50,13 +50,13 @@ public class HasSelfVisitor extends AbstractInferVisitor {
     private static final Var TYPE_VAR = new Var(RDF.TYPE.stringValue(), RDF.TYPE);
 
     /**
-     * Creates a new {@link HasSelfVisitor}, which is enabled by default.
+     * Creates a new {@link HasSelfVisitor}.
      * @param conf The {@link RdfCloudTripleStoreConfiguration}.
      * @param inferenceEngine The InferenceEngine containing the relevant ontology.
      */
     public HasSelfVisitor(final RdfCloudTripleStoreConfiguration conf, final InferenceEngine inferenceEngine) {
         super(conf, inferenceEngine);
-        include = conf.hasSelf();
+        include = conf.isInferHasSelf();
     }
 
     @Override

--- a/sail/src/main/java/org/apache/rya/rdftriplestore/inference/HasValueVisitor.java
+++ b/sail/src/main/java/org/apache/rya/rdftriplestore/inference/HasValueVisitor.java
@@ -71,13 +71,13 @@ import org.openrdf.query.algebra.Var;
  */
 public class HasValueVisitor extends AbstractInferVisitor {
     /**
-     * Creates a new {@link HasValueVisitor}, which is enabled by default.
+     * Creates a new {@link HasValueVisitor}.
      * @param conf The {@link RdfCloudTripleStoreConfiguration}.
      * @param inferenceEngine The InferenceEngine containing the relevant ontology.
      */
     public HasValueVisitor(RdfCloudTripleStoreConfiguration conf, InferenceEngine inferenceEngine) {
         super(conf, inferenceEngine);
-        include = true;
+        include = conf.isInferHasValue();
     }
 
     /**

--- a/sail/src/main/java/org/apache/rya/rdftriplestore/inference/PropertyChainVisitor.java
+++ b/sail/src/main/java/org/apache/rya/rdftriplestore/inference/PropertyChainVisitor.java
@@ -42,7 +42,7 @@ public class PropertyChainVisitor extends AbstractInferVisitor {
 
     public PropertyChainVisitor(final RdfCloudTripleStoreConfiguration conf, final InferenceEngine inferenceEngine) {
         super(conf, inferenceEngine);
-        include = true;
+        include = conf.isInferPropertyChain();
     }
 
 

--- a/sail/src/main/java/org/apache/rya/rdftriplestore/inference/ReflexivePropertyVisitor.java
+++ b/sail/src/main/java/org/apache/rya/rdftriplestore/inference/ReflexivePropertyVisitor.java
@@ -1,0 +1,73 @@
+package org.apache.rya.rdftriplestore.inference;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.rya.api.RdfCloudTripleStoreConfiguration;
+import org.openrdf.model.URI;
+import org.openrdf.query.algebra.StatementPattern;
+import org.openrdf.query.algebra.Var;
+import org.openrdf.query.algebra.ZeroLengthPath;
+
+/**
+ * Expands the query tree to account for any relevant reflexive properties
+ * known to the {@link InferenceEngine}.
+ *
+ * A reflexive property is a property for which any node can be inferred to have
+ * reflexively: If :p is a reflexive property, then <?x :p ?x> is true for all ?x.
+ *
+ * Applies to any statement pattern whose predicate is defined (not a variable)
+ * and is a reflexive property according to the InferenceEngine. If the property
+ * is reflexive, then the statement pattern should match when the subject equals
+ * the object. Therefore, replace the statement pattern with a union of itself
+ * and a ZeroLengthPath between the subject and object. This union is similar to
+ * the ZeroOrOnePath property path expression in SPARQL: <?x :p? ?y> matches if
+ * ?x and ?y are connected via :p or if ?x and ?y are equal.
+ */
+public class ReflexivePropertyVisitor extends AbstractInferVisitor {
+    /**
+     * Creates a new {@link ReflexivePropertyVisitor}.
+     * @param conf The {@link RdfCloudTripleStoreConfiguration}.
+     * @param inferenceEngine The InferenceEngine containing the relevant ontology.
+     */
+    public ReflexivePropertyVisitor(RdfCloudTripleStoreConfiguration conf, InferenceEngine inferenceEngine) {
+        super(conf, inferenceEngine);
+        include = conf.isInferReflexiveProperty();
+    }
+
+    /**
+     * Check whether any solution for the {@link StatementPattern} could be derived from
+     * reflexive property inference, and if so, replace the pattern with a union of itself and the
+     * reflexive solution.
+     */
+    @Override
+    protected void meetSP(StatementPattern node) throws Exception {
+        // Only applies when the predicate is defined and reflexive
+        final Var predVar = node.getPredicateVar();
+        if (predVar.getValue() != null && inferenceEngine.isReflexiveProperty((URI) predVar.getValue())) {
+            final StatementPattern originalSP = node.clone();
+            // The reflexive solution is a ZeroLengthPath between subject and
+            // object: they can be matched to one another, whether constants or
+            // variables.
+            final Var subjVar = node.getSubjectVar();
+            final Var objVar = node.getObjectVar();
+            final ZeroLengthPath reflexiveSolution = new ZeroLengthPath(subjVar, objVar);
+            node.replaceWith(new InferUnion(originalSP, reflexiveSolution));
+        }
+    }
+}

--- a/sail/src/main/java/org/apache/rya/rdftriplestore/inference/SameAsVisitor.java
+++ b/sail/src/main/java/org/apache/rya/rdftriplestore/inference/SameAsVisitor.java
@@ -49,7 +49,7 @@ public class SameAsVisitor extends AbstractInferVisitor {
 
     public SameAsVisitor(RdfCloudTripleStoreConfiguration conf, InferenceEngine inferenceEngine) {
         super(conf, inferenceEngine);
-        include = conf.isInferSubPropertyOf(); // oops
+        include = conf.isInferSameAs();
     }
     
     public void meet(StatementPattern sp) throws Exception {

--- a/sail/src/test/java/org/apache/rya/rdftriplestore/inference/InferenceEngineTest.java
+++ b/sail/src/test/java/org/apache/rya/rdftriplestore/inference/InferenceEngineTest.java
@@ -579,4 +579,45 @@ public class InferenceEngineTest extends TestCase {
         expectedProperties.add(vf.createURI("urn:love"));
         Assert.assertEquals(expectedProperties, inferenceEngine.getHasSelfImplyingType(vf.createURI("urn:Narcissist")));
     }
+
+    @Test
+    public void testPropertyTypes() throws Exception {
+        final String ontology = "INSERT DATA { GRAPH <http://updated/test> {\n"
+                + "  <urn:comment> a owl:AnnotationProperty .\n"
+                + "  <urn:olderThan> a owl:TransitiveProperty, owl:IrreflexiveProperty, owl:AsymmetricProperty .\n"
+                + "  <urn:notYoungerThan> a owl:TransitiveProperty, owl:ReflexiveProperty .\n"
+                + "  <urn:related> a owl:Property, owl:SymmetricProperty, owl:TransitiveProperty .\n"
+                + "  <urn:knows> a owl:SymmetricProperty, owl:ObjectProperty, owl:ReflexiveProperty .\n"
+                + "  <urn:sameAgeAs> a owl:SymmetricProperty, owl:ReflexiveProperty, owl:TransitiveProperty .\n"
+                + "}}";
+        conn.prepareUpdate(QueryLanguage.SPARQL, ontology).execute();
+        inferenceEngine.refreshGraph();
+        final URI comment = vf.createURI("urn:comment"); // none of the three supported types
+        final URI older = vf.createURI("urn:olderThan"); // transitive only
+        final URI notYounger = vf.createURI("urn:notYoungerThan"); // transitive and reflexive
+        final URI related = vf.createURI("urn:related"); // transitive and symmetric
+        final URI knows = vf.createURI("urn:knows"); // reflexive and symmetric
+        final URI sameAge = vf.createURI("urn:sameAgeAs"); // all three
+        // symmetry
+        Assert.assertFalse(inferenceEngine.isSymmetricProperty(comment));
+        Assert.assertFalse(inferenceEngine.isSymmetricProperty(older));
+        Assert.assertFalse(inferenceEngine.isSymmetricProperty(notYounger));
+        Assert.assertTrue(inferenceEngine.isSymmetricProperty(related));
+        Assert.assertTrue(inferenceEngine.isSymmetricProperty(knows));
+        Assert.assertTrue(inferenceEngine.isSymmetricProperty(sameAge));
+        // transitivity
+        Assert.assertFalse(inferenceEngine.isTransitiveProperty(comment));
+        Assert.assertTrue(inferenceEngine.isTransitiveProperty(older));
+        Assert.assertTrue(inferenceEngine.isTransitiveProperty(notYounger));
+        Assert.assertTrue(inferenceEngine.isTransitiveProperty(related));
+        Assert.assertFalse(inferenceEngine.isTransitiveProperty(knows));
+        Assert.assertTrue(inferenceEngine.isTransitiveProperty(sameAge));
+        // reflexivity
+        Assert.assertFalse(inferenceEngine.isReflexiveProperty(comment));
+        Assert.assertFalse(inferenceEngine.isReflexiveProperty(older));
+        Assert.assertTrue(inferenceEngine.isReflexiveProperty(notYounger));
+        Assert.assertFalse(inferenceEngine.isReflexiveProperty(related));
+        Assert.assertTrue(inferenceEngine.isReflexiveProperty(knows));
+        Assert.assertTrue(inferenceEngine.isReflexiveProperty(sameAge));
+    }
 }

--- a/sail/src/test/java/org/apache/rya/rdftriplestore/inference/ReflexivePropertyVisitorTest.java
+++ b/sail/src/test/java/org/apache/rya/rdftriplestore/inference/ReflexivePropertyVisitorTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.rdftriplestore.inference;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.apache.rya.accumulo.AccumuloRdfConfiguration;
+import org.apache.rya.api.RdfCloudTripleStoreConfiguration;
+import org.junit.Assert;
+import org.junit.Test;
+import org.openrdf.model.URI;
+import org.openrdf.model.ValueFactory;
+import org.openrdf.model.impl.ValueFactoryImpl;
+import org.openrdf.query.algebra.Projection;
+import org.openrdf.query.algebra.ProjectionElem;
+import org.openrdf.query.algebra.ProjectionElemList;
+import org.openrdf.query.algebra.StatementPattern;
+import org.openrdf.query.algebra.TupleExpr;
+import org.openrdf.query.algebra.Union;
+import org.openrdf.query.algebra.Var;
+import org.openrdf.query.algebra.ZeroLengthPath;
+
+/**
+ * Tests the methods of {@link ReflexivePropertyVisitor}.
+ */
+public class ReflexivePropertyVisitorTest {
+    private final AccumuloRdfConfiguration conf = new AccumuloRdfConfiguration();
+    private static final ValueFactory VF = new ValueFactoryImpl();
+
+    private static final URI ALICE = VF.createURI("urn:Alice");
+    private static final URI HAS_FAMILY = VF.createURI("urn:hasFamilyMember");
+
+    @Test
+    public void testReflexiveProperty() throws Exception {
+        // Define a reflexive property
+        final InferenceEngine inferenceEngine = mock(InferenceEngine.class);
+        when(inferenceEngine.isReflexiveProperty(HAS_FAMILY)).thenReturn(true);
+        // Construct a query, then visit it
+        final StatementPattern sp = new StatementPattern(new Var("s", ALICE), new Var("p", HAS_FAMILY), new Var("o"));
+        final Projection query = new Projection(sp, new ProjectionElemList(new ProjectionElem("o", "member")));
+        query.visit(new ReflexivePropertyVisitor(conf, inferenceEngine));
+        // Expected structure after rewriting SP(:Alice :hasFamilyMember ?member):
+        //
+        // Union(
+        //     originalSP(:Alice :hasFamilyMember ?member),
+        //     ZeroLengthPath(:Alice, ?member)
+        // )
+        Assert.assertTrue(query.getArg() instanceof Union);
+        final TupleExpr left = ((Union) query.getArg()).getLeftArg();
+        final TupleExpr right = ((Union) query.getArg()).getRightArg();
+        Assert.assertEquals(sp, left);
+        Assert.assertTrue(right instanceof ZeroLengthPath);
+        Assert.assertEquals(sp.getSubjectVar(), ((ZeroLengthPath) right).getSubjectVar());
+        Assert.assertEquals(sp.getObjectVar(), ((ZeroLengthPath) right).getObjectVar());
+    }
+
+    @Test
+    public void testReflexivePropertyDisabled() throws Exception {
+        // Disable inference
+        final RdfCloudTripleStoreConfiguration disabledConf = conf.clone();
+        disabledConf.setInferReflexiveProperty(false);
+        // Define a reflexive property
+        final InferenceEngine inferenceEngine = mock(InferenceEngine.class);
+        when(inferenceEngine.isReflexiveProperty(HAS_FAMILY)).thenReturn(true);
+        // Construct a query, then make a copy and visit the copy
+        final Projection query = new Projection(
+                new StatementPattern(new Var("s", ALICE), new Var("p", HAS_FAMILY), new Var("o")),
+                new ProjectionElemList(new ProjectionElem("s", "subject")));
+        final Projection modifiedQuery = query.clone();
+        modifiedQuery.visit(new ReflexivePropertyVisitor(disabledConf, inferenceEngine));
+        // There should be no difference
+        Assert.assertEquals(query, modifiedQuery);
+    }
+}

--- a/sail/src/test/java/org/apache/rya/rdftriplestore/inference/SameAsTest.java
+++ b/sail/src/test/java/org/apache/rya/rdftriplestore/inference/SameAsTest.java
@@ -1,4 +1,5 @@
-package org.apache.rya.triplestore.inference;
+package org.apache.rya.rdftriplestore.inference;
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -17,7 +18,17 @@ package org.apache.rya.triplestore.inference;
  * specific language governing permissions and limitations
  * under the License.
  */
-import java.util.List;
+
+
+
+import info.aduna.iteration.Iterations;
+import junit.framework.TestCase;
+import org.apache.rya.accumulo.AccumuloRdfConfiguration;
+import org.apache.rya.accumulo.AccumuloRyaDAO;
+import org.apache.rya.api.RdfCloudTripleStoreConstants;
+import org.apache.rya.api.resolver.RdfToRyaConversions;
+import org.apache.rya.rdftriplestore.RdfCloudTripleStore;
+import org.apache.rya.rdftriplestore.inference.InferenceEngine;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.Connector;
@@ -25,42 +36,15 @@ import org.apache.accumulo.core.client.admin.SecurityOperations;
 import org.apache.accumulo.core.client.mock.MockInstance;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.TablePermission;
-import org.junit.Assert;
 import org.junit.Test;
+import org.openrdf.model.Resource;
+import org.openrdf.model.Statement;
 import org.openrdf.model.URI;
 import org.openrdf.model.ValueFactory;
+import org.openrdf.model.impl.StatementImpl;
 import org.openrdf.model.impl.ValueFactoryImpl;
-import org.openrdf.query.QueryLanguage;
-import org.openrdf.query.Update;
-import org.openrdf.repository.sail.SailRepository;
-import org.openrdf.repository.sail.SailRepositoryConnection;
 
-import junit.framework.TestCase;
-import org.apache.rya.accumulo.AccumuloRdfConfiguration;
-import org.apache.rya.accumulo.AccumuloRyaDAO;
-import org.apache.rya.api.RdfCloudTripleStoreConstants;
-import org.apache.rya.rdftriplestore.RdfCloudTripleStore;
-import org.apache.rya.rdftriplestore.inference.InferenceEngine;
-import org.apache.rya.rdftriplestore.inference.InverseURI;
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- * 
- *   http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-public class PropertyChainTest extends TestCase {
+public class SameAsTest extends TestCase {
     private String user = "user";
     private String pwd = "pwd";
     private String instance = "myinstance";
@@ -105,36 +89,27 @@ public class PropertyChainTest extends TestCase {
     }
 
     @Test
+    //This isn't a good test.  It's simply a cut-and-paste from a test that was failing in a different package in the SameAsVisitor.
     public void testGraphConfiguration() throws Exception {
+        URI a = vf.createURI(namespace, "a");
+        Statement statement = new StatementImpl(a, vf.createURI(namespace, "p"), vf.createLiteral("l"));
+        Statement statement2 = new StatementImpl(a, vf.createURI(namespace, "p2"), vf.createLiteral("l"));
+        ryaDAO.add(RdfToRyaConversions.convertStatement(statement));
+        ryaDAO.add(RdfToRyaConversions.convertStatement(statement2));
+        ryaDAO.add(RdfToRyaConversions.convertStatement(new StatementImpl(vf.createURI(namespace, "b"), vf.createURI(namespace, "p"), vf.createLiteral("l"))));
+        ryaDAO.add(RdfToRyaConversions.convertStatement(new StatementImpl(vf.createURI(namespace, "c"), vf.createURI(namespace, "n"), vf.createLiteral("l"))));
+
         // build a connection
         RdfCloudTripleStore store = new RdfCloudTripleStore();
         store.setConf(conf);
         store.setRyaDAO(ryaDAO);
+
         InferenceEngine inferenceEngine = new InferenceEngine();
         inferenceEngine.setRyaDAO(ryaDAO);
         store.setInferenceEngine(inferenceEngine);
-        inferenceEngine.refreshGraph();
+        
         store.initialize();
-        SailRepository repository = new SailRepository(store);
-        SailRepositoryConnection conn = repository.getConnection();
-        
 
-        
-    	String query = "INSERT DATA\n"//
-    			+ "{ GRAPH <http://updated/test> {\n"//
-    			+ "  <urn:greatMother> owl:propertyChainAxiom <urn:12342>  . " + 
-    			" <urn:12342> <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:node1atjakcvbx15023 . " + 
-    			" _:node1atjakcvbx15023 <http://www.w3.org/2002/07/owl#inverseOf> <urn:isChildOf> . " + 
-    			" <urn:12342> <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:node1atjakcvbx15123 . " + 
-       			" _:node1atjakcvbx15123 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> . " + 
-    			" _:node1atjakcvbx15123 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <urn:MotherOf> .  }}";
-    	Update update = conn.prepareUpdate(QueryLanguage.SPARQL, query);
-    	update.execute();
-        inferenceEngine.refreshGraph();
-       List<URI> chain = inferenceEngine.getPropertyChain(vf.createURI("urn:greatMother"));
-       Assert.assertEquals(chain.size(), 2);
-       Assert.assertEquals(chain.get(0), new InverseURI(vf.createURI("urn:isChildOf")));
-       Assert.assertEquals(chain.get(1), vf.createURI("urn:MotherOf"));
- 
+        System.out.println(Iterations.asList(store.getConnection().getStatements(a, vf.createURI(namespace, "p"), vf.createLiteral("l"), false, new Resource[0])).size());
     }
 }


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

  http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
## Description
1. Added owl:ReflexiveProperty inference: If :hasFamilyMember is reflexive, then `?x :hasFamilyMember ?y` is true for `?x==?y`. Inference engine now loads reflexive properties like it does transitive and symmetric properties, and a visitor expands triples involving reflexive properties to match both when the triple actually exists or when the subject and object are the same.

2. Minor cleanup to wrap up latest inference changes: added/fixed configuration constants to enable/disable those inference visitors that were missing them or using the wrong one; fixed packaging for two test classes.
### Tests
Test rewriting done by ReflexivePropertyVisitor; test that InferenceEngine correctly determines property types; test queries involving reflexive properties.

### Links
[Jira](https://issues.apache.org/jira/browse/RYA-301)

### Checklist
- [x] Code Review
- [x] Squash Commits

#### People To Reivew
@meiercaleb @pujav65 @ejwhite922 @isper3at 