### PR TITLE
RYA-362 Improved UX for case where create-pcj is called without args.

### DIFF
--- a/extras/shell/src/test/java/org/apache/rya/shell/RyaAdminCommandsTest.java
+++ b/extras/shell/src/test/java/org/apache/rya/shell/RyaAdminCommandsTest.java
@@ -128,6 +128,25 @@ public class RyaAdminCommandsTest {
     }
 
     @Test
+    public void createPCJ_noExportStrategy() throws InstanceDoesNotExistException, RyaClientException, IOException {
+        // Mock the object that performs the create operation.
+        final String instanceName = "unitTest";
+
+        final RyaClient mockCommands = mock(RyaClient.class);
+
+        final SharedShellState state = new SharedShellState();
+        state.connectedToAccumulo(mock(AccumuloConnectionDetails.class), mockCommands);
+        state.connectedToInstance(instanceName);
+
+        // Execute the command.
+        final RyaAdminCommands commands = new RyaAdminCommands(state, mock(InstallPrompt.class), mock(SparqlPrompt.class), mock(UninstallPrompt.class));
+        final String message = commands.createPcj(false, false);
+
+        // Verify a message is returned that explains what was created.
+        assertEquals("The user must specify at least one export strategy: (--exportToRya, --exportToKafka)", message);
+    }
+
+    @Test
     public void deletePCJ() throws InstanceDoesNotExistException, RyaClientException {
         // Mock the object that performs the delete operation.
         final DeletePCJ mockDeletePCJ = mock(DeletePCJ.class);


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

  http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
## Description
Improved UX for case where create-pcj is called without args.
Also updated the order of operations so we fail for insufficient arguments before we prompt for the SPARQL query.

### Tests
Added a test case to `RyaAdminCommandsTest`

### Links
[Jira RYA-362](https://issues.apache.org/jira/browse/RYA-362)

### Checklist
- [ ] Code Review
- [X] Squash Commits

#### People To Review
@DLotts
@meiercaleb 
@amihalik 
@pujav65 
