### PR TITLE
RYA-370 Improvements from review of 3.2.11-RC2

### DIFF
--- a/extras/pom.xml
+++ b/extras/pom.xml
@@ -45,15 +45,14 @@ under the License.
         <module>rya.merger</module>
         <module>rya.giraph</module>
        <module>rya.benchmark</module>
-       <module>rya.geoindexing</module>
     </modules>
-	
-	<profiles>
+
+    <profiles>
         <profile>
             <id>geoindexing</id>
             <modules>
                 <module>rya.geoindexing</module>
            </modules>
         </profile>
-	</profiles>
+    </profiles>
 </project>

--- a/extras/rya.geoindexing/geo.common/pom.xml
+++ b/extras/rya.geoindexing/geo.common/pom.xml
@@ -1,25 +1,32 @@
-<?xml version='1.0'?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
 
-<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor 
-	license agreements. See the NOTICE file distributed with this work for additional 
-	information regarding copyright ownership. The ASF licenses this file to 
-	you under the Apache License, Version 2.0 (the "License"); you may not use 
-	this file except in compliance with the License. You may obtain a copy of 
-	the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
-	by applicable law or agreed to in writing, software distributed under the 
-	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
-	OF ANY KIND, either express or implied. See the License for the specific 
-	language governing permissions and limitations under the License. -->
+    http://www.apache.org/licenses/LICENSE-2.0
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.apache.rya</groupId>
-		<artifactId>rya.geoindexing</artifactId>
-		<version>3.2.11-incubating-SNAPSHOT</version>
-	</parent>
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.rya</groupId>
+        <artifactId>rya.geoindexing</artifactId>
+        <version>3.2.11-incubating-SNAPSHOT</version>
+    </parent>
 
-	<artifactId>geo.common</artifactId>
-	<name>Apache Rya Geo Indexing Common Code</name>
+    <artifactId>rya.geo.common</artifactId>
+    <name>Apache Rya Geo Indexing Common Code</name>
 
 </project>

--- a/extras/rya.geoindexing/geo.geomesa/pom.xml
+++ b/extras/rya.geoindexing/geo.geomesa/pom.xml
@@ -1,51 +1,56 @@
-<?xml version='1.0'?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
 
-<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor 
-	license agreements. See the NOTICE file distributed with this work for additional 
-	information regarding copyright ownership. The ASF licenses this file to 
-	you under the Apache License, Version 2.0 (the "License"); you may not use 
-	this file except in compliance with the License. You may obtain a copy of 
-	the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
-	by applicable law or agreed to in writing, software distributed under the 
-	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
-	OF ANY KIND, either express or implied. See the License for the specific 
-	language governing permissions and limitations under the License. -->
+    http://www.apache.org/licenses/LICENSE-2.0
 
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.apache.rya</groupId>
-		<artifactId>rya.geoindexing</artifactId>
-		<version>3.2.11-incubating-SNAPSHOT</version>
-	</parent>
-	<artifactId>geo.geomesa</artifactId>
-	<name>Apache Rya Geo Indexing using GeoMesa</name>
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<geotools.version>14.3</geotools.version>
-	</properties>
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.rya</groupId>
+        <artifactId>rya.geoindexing</artifactId>
+        <version>3.2.11-incubating-SNAPSHOT</version>
+    </parent>
+    <artifactId>rya.geo.geomesa</artifactId>
+    <name>Apache Rya Geo Indexing using GeoMesa</name>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.apache.rya</groupId>
-			<artifactId>geo.common</artifactId>
-			<version>3.2.11-incubating-SNAPSHOT</version>
-		</dependency>
+    <properties>
+        <geotools.version>14.3</geotools.version>
+    </properties>
 
-		<dependency>
-			<groupId>org.locationtech.geomesa</groupId>
-			<artifactId>geomesa-accumulo-datastore_2.11</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.geotools.xsd</groupId>
-			<artifactId>gt-xsd-gml3</artifactId>
-			<version>${geotools.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.geotools</groupId>
-			<artifactId>gt-api</artifactId>
-			<version>${geotools.version}</version>
-		</dependency>
-	</dependencies>
-	</project>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.rya</groupId>
+            <artifactId>rya.geo.common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-accumulo-datastore_2.11</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools.xsd</groupId>
+            <artifactId>gt-xsd-gml3</artifactId>
+            <version>${geotools.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-api</artifactId>
+            <version>${geotools.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/extras/rya.geoindexing/geo.geowave/pom.xml
+++ b/extras/rya.geoindexing/geo.geowave/pom.xml
@@ -1,61 +1,63 @@
-<?xml version='1.0'?>
-<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor
-    license agreements. See the NOTICE file distributed with this work for additional
-    information regarding copyright ownership. The ASF licenses this file to
-    you under the Apache License, Version 2.0 (the "License"); you may not use
-    this file except in compliance with the License. You may obtain a copy of
-    the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required
-    by applicable law or agreed to in writing, software distributed under the
-    License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
-    OF ANY KIND, either express or implied. See the License for the specific
-    language governing permissions and limitations under the License.  -->
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.apache.rya</groupId>
-		<artifactId>rya.geoindexing</artifactId>
-		<version>3.2.11-incubating-SNAPSHOT</version>
-	</parent>
-	<artifactId>geo.geowave</artifactId>
-	<name>Apache Rya Geo indexing using GeoWave</name>
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.rya</groupId>
+        <artifactId>rya.geoindexing</artifactId>
+        <version>3.2.11-incubating-SNAPSHOT</version>
+    </parent>
+    <artifactId>rya.geo.geowave</artifactId>
+    <name>Apache Rya Geo indexing using GeoWave</name>
 
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<geotools.version>16.0</geotools.version>
-	</properties>
+    <properties>
+        <geotools.version>16.0</geotools.version>
+    </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.rya</groupId>
+            <artifactId>rya.geo.common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
-	<dependencies>
-
-		<dependency>
-			<groupId>org.apache.rya</groupId>
-			<artifactId>geo.common</artifactId>
-			<version>3.2.11-incubating-SNAPSHOT</version>
-		</dependency>
-
-		<dependency>
-			<groupId>mil.nga.giat</groupId>
-			<artifactId>geowave-datastore-accumulo</artifactId>
-			<version>${geowave.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>mil.nga.giat</groupId>
-			<artifactId>geowave-adapter-vector</artifactId>
-			<version>${geowave.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.geotools.xsd</groupId>
-			<artifactId>gt-xsd-gml3</artifactId>
-			<version>${geotools.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.geotools</groupId>
-			<artifactId>gt-api</artifactId>
-			<version>${geotools.version}</version>
-		</dependency>
-	</dependencies>
-
-	</project>
+        <dependency>
+            <groupId>mil.nga.giat</groupId>
+            <artifactId>geowave-datastore-accumulo</artifactId>
+            <version>${geowave.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>mil.nga.giat</groupId>
+            <artifactId>geowave-adapter-vector</artifactId>
+            <version>${geowave.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools.xsd</groupId>
+            <artifactId>gt-xsd-gml3</artifactId>
+            <version>${geotools.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-api</artifactId>
+            <version>${geotools.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/extras/rya.geoindexing/geo.mongo/pom.xml
+++ b/extras/rya.geoindexing/geo.mongo/pom.xml
@@ -1,41 +1,48 @@
-<?xml version='1.0'?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
 
-<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor
-    license agreements. See the NOTICE file distributed with this work for additional
-    information regarding copyright ownership. The ASF licenses this file to
-    you under the Apache License, Version 2.0 (the "License"); you may not use
-    this file except in compliance with the License. You may obtain a copy of
-    the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required
-    by applicable law or agreed to in writing, software distributed under the
-    License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
-    OF ANY KIND, either express or implied. See the License for the specific
-    language governing permissions and limitations under the License.  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <groupId>org.apache.rya</groupId>
-    <artifactId>rya.geoindexing</artifactId>
-    <version>3.2.11-incubating-SNAPSHOT</version>
-  </parent>
-  <artifactId>geo.mongo</artifactId>
-  <name>Apache Rya Geo Indexing using MongoDB</name>
-  <description>Implementation of a geospatial indexing for mongo DB backed Rya</description>
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <geotools.version>16.0</geotools.version>
-  </properties>
-  <dependencies>
-  	<dependency>
-  		<groupId>org.apache.rya</groupId>
-  		<artifactId>geo.common</artifactId>
-  		<version>${project.version}</version>
-  	</dependency>
-  		
-	<dependency>
-		<groupId>org.geotools.xsd</groupId>
-		<artifactId>gt-xsd-gml3</artifactId>
-		<version>${geotools.version}</version>
-	</dependency>
-  		
-  </dependencies>
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.rya</groupId>
+        <artifactId>rya.geoindexing</artifactId>
+        <version>3.2.11-incubating-SNAPSHOT</version>
+    </parent>
+    <artifactId>rya.geo.mongo</artifactId>
+    <name>Apache Rya Geo Indexing using MongoDB</name>
+    <description>Implementation of a geospatial indexing for mongo DB backed Rya</description>
+
+    <properties>
+        <geotools.version>16.0</geotools.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.rya</groupId>
+            <artifactId>rya.geo.common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools.xsd</groupId>
+            <artifactId>gt-xsd-gml3</artifactId>
+            <version>${geotools.version}</version>
+        </dependency>
+    </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -935,6 +935,13 @@ under the License.
                     </configuration>
                 </plugin>
                 <plugin>
+                    <!-- Used for auditing dependency licenses for releases. -->
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>license-maven-plugin</artifactId>
+                    <version>1.14</version>
+                </plugin>
+                <plugin>
+                    <!-- Used to add ASF license headers (without a copyright clause) to generated source. -->
                     <groupId>com.mycila</groupId>
                     <artifactId>license-maven-plugin</artifactId>
                     <version>3.0</version>
@@ -998,6 +1005,7 @@ under the License.
                             <skipITs>${skip.rya.it}</skipITs>
                             <reuseForks>false</reuseForks>  <!-- Temporary fix until RYA-331 is resolved. -->
                             <forkedProcessTimeoutInSeconds>600</forkedProcessTimeoutInSeconds> <!-- kill fork after 10 minutes -->
+                            <argLine>-Xmx2G</argLine>  <!-- Specify Xmx to get a consistent memory limit on hosts with reduced RAM. -->
                         </configuration>
                     </execution>
                 </executions>

--- a/web/web.rya/pom.xml
+++ b/web/web.rya/pom.xml
@@ -202,7 +202,7 @@ under the License.
             <dependencies>
                 <dependency>
                     <groupId>org.apache.rya</groupId>
-                    <artifactId>geo.geowave</artifactId>
+                    <artifactId>rya.geo.geowave</artifactId>
                     <version>${project.version}</version>
                     <!-- GeoWave brings in org.springframework jars that are not compatible with web.rya versions -->
                     <exclusions>


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

  http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
## Description
- Fixed a regression on the geoindexing profile in extras/pom.xml
- Added a 'rya.' prefix to the new geo.* artifactIds to disambiguate
generated artifacts.
- Added pluginManagement definition for
org.codehaus.mojo:license-maven-plugin for release auditing.
- Specified an Xmx value for maven-failsafe-plugin for improved
execution environment consistency on hosts with reduced memory.

### Tests
N/A, but ITs should run more reliably on reduced memory systems.

### Links
[JIRA RYA-370](https://issues.apache.org/jira/browse/RYA-370)

### Checklist
- [ ] Code Review
- [X] Squash Commits

#### People To Reivew
@meiercaleb
@amihalik
@pujav65
@isper3at
@DLotts
