### PR TITLE
RYA-372 Excluded org.json:json for incompatible license

### DIFF
--- a/extras/rya.giraph/pom.xml
+++ b/extras/rya.giraph/pom.xml
@@ -31,12 +31,24 @@ under the License.
     <artifactId>rya.giraph</artifactId>
 
     <dependencies>
+<!--         
+        Uncomment the following drop-in replacement if the exclusion
+        of the dependency org.json:json causes issues at runtime.
+        <dependency>
+            <groupId>com.tdunning</groupId>
+            <artifactId>json</artifactId>
+            <version>1.8</version>
+            <scope>runtime</scope>
+        </dependency>
+ -->
         <dependency>
             <groupId>org.apache.giraph</groupId>
             <artifactId>giraph-core</artifactId>
             <version>1.2.0</version>
             <exclusions>
-            	<!-- exclude for incompatible license -->
+                <!-- Exclude for incompatible license -->
+                <!-- If this exclusion causes a ClassNotFoundException at runtime, -->
+                <!-- then, replace using this alternate library: https://github.com/tdunning/open-json  . -->
                 <exclusion>
                     <artifactId>json</artifactId>
                     <groupId>org.json</groupId>
@@ -47,6 +59,13 @@ under the License.
             <groupId>org.apache.giraph</groupId>
             <artifactId>giraph-accumulo</artifactId>
             <version>1.2.0</version>
+            <exclusions>
+            	<!-- exclude for incompatible license, see above if this causes issues. -->
+                <exclusion>
+                    <artifactId>json</artifactId>
+                    <groupId>org.json</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>

--- a/extras/rya.giraph/pom.xml
+++ b/extras/rya.giraph/pom.xml
@@ -35,6 +35,13 @@ under the License.
             <groupId>org.apache.giraph</groupId>
             <artifactId>giraph-core</artifactId>
             <version>1.2.0</version>
+            <exclusions>
+            	<!-- exclude for incompatible license -->
+                <exclusion>
+                    <artifactId>json</artifactId>
+                    <groupId>org.json</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.giraph</groupId>


### PR DESCRIPTION
## Description
Excluded org.json:json for incompatible license.  Apparently, the Giraph library depends on it, but does not need it.  

### Tests
no new tests, old ones serve

### Links
[Jira](https://issues.apache.org/jira/browse/RYA-372)

### Checklist
- [ ] Code Review
- [X] Squash Commits

#### People To Reivew
anyone
