### PR TITLE
RYA-393 MongoDB Batch Writer Duplicate Key Exception

### DIFF
--- a/dao/accumulo.rya/src/main/java/org/apache/rya/accumulo/AccumuloRyaDAO.java
+++ b/dao/accumulo.rya/src/main/java/org/apache/rya/accumulo/AccumuloRyaDAO.java
@@ -472,8 +472,19 @@ public class AccumuloRyaDAO implements RyaDAO<AccumuloRdfConfiguration>, RyaName
     public void flush() throws RyaDAOException {
         try {
             mt_bw.flush();
+            flushIndexers();
         } catch (final MutationsRejectedException e) {
             throw new RyaDAOException(e);
+        }
+    }
+
+    private void flushIndexers() throws RyaDAOException {
+        for (final AccumuloIndexer indexer : secondaryIndexers) {
+            try {
+                indexer.flush();
+            } catch (final IOException e) {
+                logger.error("Error flushing data in indexer: " + indexer.getClass().getSimpleName(), e);
+            }
         }
     }
 

--- a/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/batch/MongoDbBatchWriter.java
+++ b/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/batch/MongoDbBatchWriter.java
@@ -36,6 +36,7 @@ import org.apache.rya.mongodb.batch.collection.CollectionType;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.mongodb.DuplicateKeyException;
+import com.mongodb.MongoBulkWriteException;
 
 /**
  * Handles batch writing MongoDB statement objects to the repository. It takes
@@ -221,6 +222,12 @@ public class MongoDbBatchWriter<T> {
             }
         } catch (final DuplicateKeyException e) {
             log.warn(e); // Suppress the stack trace so log doesn't get flooded.
+        } catch (final MongoBulkWriteException e) {
+            if (e.getMessage().contains("duplicate key error")) {
+                log.warn(e); // Suppress the stack trace so log doesn't get flooded.
+            } else {
+                throw new MongoDbBatchWriterException("Error flushing statements", e);
+            }
         } catch (final Exception e) {
             throw new MongoDbBatchWriterException("Error flushing statements", e);
         }

--- a/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/batch/MongoDbBatchWriter.java
+++ b/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/batch/MongoDbBatchWriter.java
@@ -35,6 +35,7 @@ import org.apache.log4j.Logger;
 import org.apache.rya.mongodb.batch.collection.CollectionType;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.mongodb.DuplicateKeyException;
 
 /**
  * Handles batch writing MongoDB statement objects to the repository. It takes
@@ -218,6 +219,8 @@ public class MongoDbBatchWriter<T> {
             if (!batch.isEmpty()) {
                 collectionType.insertMany(batch);
             }
+        } catch (final DuplicateKeyException e) {
+            log.warn(e); // Suppress the stack trace so log doesn't get flooded.
         } catch (final Exception e) {
             throw new MongoDbBatchWriterException("Error flushing statements", e);
         }

--- a/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/batch/MongoDbBatchWriter.java
+++ b/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/batch/MongoDbBatchWriter.java
@@ -97,7 +97,6 @@ public class MongoDbBatchWriter<T> {
 
     private static final ThreadFactory QUEUE_THREAD_FACTORY = new ThreadFactoryBuilder()
         .setNameFormat("Queue Full Checker Thread - %d")
-        .setDaemon(true)
         .build();
 
     /**

--- a/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/batch/collection/MongoCollectionType.java
+++ b/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/batch/collection/MongoCollectionType.java
@@ -25,6 +25,7 @@ import java.util.List;
 import org.bson.Document;
 
 import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.InsertManyOptions;
 
 /**
  * Provides access to the {@link MongoCollection} type.
@@ -47,6 +48,6 @@ public class MongoCollectionType implements CollectionType<Document> {
 
     @Override
     public void insertMany(final List<Document> items) {
-        collection.insertMany(items);
+        collection.insertMany(items, new InsertManyOptions().ordered(false));
     }
 }

--- a/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/MongoDBRyaBatchWriterIT.java
+++ b/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/MongoDBRyaBatchWriterIT.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.mongodb;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.log4j.BasicConfigurator;
+import org.apache.rya.api.domain.RyaStatement;
+import org.apache.rya.api.domain.RyaStatement.RyaStatementBuilder;
+import org.apache.rya.api.domain.RyaURI;
+import org.apache.rya.mongodb.batch.MongoDbBatchWriter;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.mongodb.MongoClient;
+
+/**
+ * Integration tests for the {@link MongoDbBatchWriter}.
+ */
+public class MongoDBRyaBatchWriterIT extends MongoTestBase {
+    private MongoDBRyaDAO dao;
+
+    private static void setupLogging() {
+        BasicConfigurator.configure();
+    }
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        setupLogging();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        conf.setBoolean("rya.mongodb.dao.flusheachupdate", false);
+        conf.setInt("rya.mongodb.dao.batchwriter.size", 50_000);
+        conf.setLong("rya.mongodb.dao.batchwriter.flushtime", 100L);
+
+        final MongoClient client = super.getMongoClient();
+        dao = new MongoDBRyaDAO(conf, client);
+    }
+
+    @Test
+    public void testDuplicateKeys() throws Exception {
+        final List<RyaStatement> statements = new ArrayList<>();
+        statements.add(statement(1));
+        statements.add(statement(2));
+        statements.add(statement(1));
+        statements.add(statement(3));
+        statements.add(statement(1));
+        statements.add(statement(4));
+        statements.add(statement(1));
+        statements.add(statement(5));
+        statements.add(statement(1));
+        statements.add(statement(6));
+
+        dao.add(statements.iterator());
+
+        dao.flush();
+
+        Assert.assertEquals(6, getRyaCollection().count());
+    }
+
+    private static RyaURI ryaURI(final int v) {
+        return new RyaURI("u:" + v);
+    }
+
+    private static RyaStatement statement(final int v) {
+        final RyaStatementBuilder builder = new RyaStatementBuilder();
+        builder.setPredicate(ryaURI(v));
+        builder.setSubject(ryaURI(v));
+        builder.setObject(ryaURI(v));
+        return builder.build();
+    }
+}

--- a/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/MongoDBRyaDAOIT.java
+++ b/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/MongoDBRyaDAOIT.java
@@ -36,6 +36,7 @@ import org.apache.rya.mongodb.document.util.AuthorizationsUtil;
 import org.apache.rya.mongodb.document.visibility.DocumentVisibility;
 import org.bson.Document;
 import org.calrissian.mango.collect.CloseableIterable;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -46,13 +47,18 @@ import com.mongodb.client.MongoDatabase;
 
 public class MongoDBRyaDAOIT extends MongoTestBase {
     private MongoClient client;
-    private MongoDBRyaDAO dao;
+    private static MongoDBRyaDAO dao;
 
     @Before
     public void setUp() throws IOException, RyaDAOException{
         conf.setAuths("A", "B", "C");
         client = super.getMongoClient();
         dao = new MongoDBRyaDAO(conf, client);
+    }
+
+    @AfterClass
+    public static void tearDown() throws RyaDAOException {
+        dao.destroy();
     }
 
     @Test

--- a/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/MongoTestBase.java
+++ b/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/MongoTestBase.java
@@ -19,10 +19,12 @@
 package org.apache.rya.mongodb;
 
 import org.apache.hadoop.conf.Configuration;
+import org.bson.Document;
 import org.junit.After;
 import org.junit.Before;
 
 import com.mongodb.MongoClient;
+import com.mongodb.client.MongoCollection;
 
 /**
  * A base class that may be used when implementing Mongo DB tests that use the
@@ -56,5 +58,12 @@ public class MongoTestBase {
      */
     public MongoClient getMongoClient() {
         return mongoClient;
+    }
+
+    /**
+     * @return The Rya triples {@link MongoCollection}.
+     */
+    public MongoCollection<Document> getRyaCollection() {
+        return mongoClient.getDatabase(conf.getMongoDBName()).getCollection(conf.getTriplesCollectionName());
     }
 }

--- a/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/MongoTestBase.java
+++ b/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/MongoTestBase.java
@@ -23,6 +23,7 @@ import org.bson.Document;
 import org.junit.After;
 import org.junit.Before;
 
+import com.mongodb.DBCollection;
 import com.mongodb.MongoClient;
 import com.mongodb.client.MongoCollection;
 
@@ -65,5 +66,12 @@ public class MongoTestBase {
      */
     public MongoCollection<Document> getRyaCollection() {
         return mongoClient.getDatabase(conf.getMongoDBName()).getCollection(conf.getTriplesCollectionName());
+    }
+
+    /**
+     * @return The Rya triples {@link DBCollection}.
+     */
+    public DBCollection getRyaDbCollection() {
+        return mongoClient.getDB(conf.getMongoDBName()).getCollection(conf.getTriplesCollectionName());
     }
 }

--- a/extras/indexing/src/main/java/org/apache/rya/indexing/mongodb/AbstractMongoIndexer.java
+++ b/extras/indexing/src/main/java/org/apache/rya/indexing/mongodb/AbstractMongoIndexer.java
@@ -121,6 +121,12 @@ public abstract class AbstractMongoIndexer<T extends IndexingMongoDBStorageStrat
 
     @Override
     public void close() throws IOException {
+        flush();
+        try {
+            mongoDbBatchWriter.shutdown();
+        } catch (final MongoDbBatchWriterException e) {
+            throw new IOException("Error shutting down MongoDB batch writer", e);
+        }
     }
 
     @Override


### PR DESCRIPTION
## Description
Fixed MongoDB DAO Batch Writer from dropping statements when batch contains duplicate keys.

### Tests
Integration Tests

### Links
[Jira](https://issues.apache.org/jira/browse/RYA-393)

### Checklist
- [ ] Code Review
- [ ] Squash Commits

#### People To Review
@amihalik 
@meiercaleb 
@pujav65 
@isper3at 
