### PR TITLE
RYA-356 Added a Twill App for running the periodic service

### DIFF
--- a/common/rya.api/pom.xml
+++ b/common/rya.api/pom.xml
@@ -32,6 +32,10 @@ under the License.
 
     <dependencies>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.calrissian.mango</groupId>
             <artifactId>mango-core</artifactId>
         </dependency>
@@ -60,7 +64,6 @@ under the License.
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.0</version>
         </dependency>
         <dependency>
             <groupId>com.github.stephenc.findbugs</groupId>
@@ -71,10 +74,9 @@ under the License.
             <artifactId>jcip-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.esotericsoftware.kryo</groupId>
+            <groupId>com.esotericsoftware</groupId>
             <artifactId>kryo</artifactId>
-            <version>2.24.0</version>
-		</dependency>
+        </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>

--- a/common/rya.api/src/main/java/org/apache/rya/api/client/LoadStatements.java
+++ b/common/rya.api/src/main/java/org/apache/rya/api/client/LoadStatements.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.api.client;
+
+import org.openrdf.model.Statement;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Loads a set of statements into an instance of Rya.
+ */
+@DefaultAnnotation(NonNull.class)
+public interface LoadStatements {
+
+    /**
+     * Loads a set of RDF statements into an instance of Rya.
+     *
+     * @param ryaInstanceName - The name of the Rya instance the statements will be loaded into. (not null)
+     * @param statements - An iterable of Statement objects that should be added to Rya.  (not null)
+     * @throws InstanceDoesNotExistException No instance of Rya exists for the provided name.
+     * @throws RyaClientException Something caused the command to fail.
+     */
+    public void loadStatements(String ryaInstanceName, Iterable<? extends Statement> statements) throws InstanceDoesNotExistException, RyaClientException;
+}

--- a/common/rya.api/src/main/java/org/apache/rya/api/client/RyaClient.java
+++ b/common/rya.api/src/main/java/org/apache/rya/api/client/RyaClient.java
@@ -44,6 +44,7 @@ public class RyaClient {
     private final AddUser addUser;
     private final RemoveUser removeUser;
     private final Uninstall uninstall;
+    private final LoadStatements loadStatements;
     private final LoadStatementsFile loadStatementsFile;
     private final ExecuteSparqlQuery executeSparqlQuery;
 
@@ -64,6 +65,7 @@ public class RyaClient {
             final AddUser addUser,
             final RemoveUser removeUser,
             final Uninstall uninstall,
+            final LoadStatements loadStatements,
             final LoadStatementsFile loadStatementsFile,
             final ExecuteSparqlQuery executeSparqlQuery) {
         this.install = requireNonNull(install);
@@ -79,6 +81,7 @@ public class RyaClient {
         this.addUser = requireNonNull(addUser);
         this.removeUser = requireNonNull(removeUser);
         this.uninstall = requireNonNull(uninstall);
+        this.loadStatements = requireNonNull(loadStatements);
         this.loadStatementsFile = requireNonNull(loadStatementsFile);
         this.executeSparqlQuery = requireNonNull(executeSparqlQuery);
     }
@@ -105,10 +108,10 @@ public class RyaClient {
     public DeletePCJ getDeletePCJ() {
         return deletePcj;
     }
-    
+
     /**
      * @return An instance of {@link CreatePeridodicPCJ} that is connected to a Rya Periodic Storage
-     */ 
+     */
     public CreatePeriodicPCJ getCreatePeriodicPCJ() {
         return createPeriodicPcj;
     }
@@ -119,7 +122,7 @@ public class RyaClient {
     public DeletePeriodicPCJ getDeletePeriodicPCJ() {
         return deletePeriodicPcj;
     }
-    
+
     /**
      * @return An instance of {@link ListIncrementalQueries} for displaying queries that are incrementallly
      * maintained by the Rya instance
@@ -127,7 +130,7 @@ public class RyaClient {
     public ListIncrementalQueries getListIncrementalQueries() {
         return listIncrementalQueries;
     }
-    
+
     /**
      * @return An instance of {@link BatchUpdatePCJ} that is connect to a Rya storage
      *   if the Rya instance supports PCJ indexing.
@@ -176,6 +179,13 @@ public class RyaClient {
      */
     public Uninstall getUninstall() {
         return uninstall;
+    }
+
+    /**
+     * @return An instance of {@link LoadStatements} that is connected to a Rya storage.
+     */
+    public LoadStatements getLoadStatements() {
+        return loadStatements;
     }
 
     /**

--- a/common/rya.api/src/main/java/org/apache/rya/api/resolver/RyaContext.java
+++ b/common/rya.api/src/main/java/org/apache/rya/api/resolver/RyaContext.java
@@ -8,9 +8,9 @@ package org.apache.rya.api.resolver;
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -39,11 +39,10 @@ import org.apache.rya.api.resolver.impl.RyaTypeResolverImpl;
 import org.apache.rya.api.resolver.impl.RyaURIResolver;
 import org.apache.rya.api.resolver.impl.ServiceBackedRyaTypeResolverMappings;
 import org.apache.rya.api.resolver.impl.ShortRyaTypeResolver;
-
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openrdf.model.URI;
 import org.openrdf.model.vocabulary.XMLSchema;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Date: 7/16/12
@@ -51,10 +50,10 @@ import org.openrdf.model.vocabulary.XMLSchema;
  */
 public class RyaContext {
 
-    public Log logger = LogFactory.getLog(RyaContext.class);
+    public Logger logger = LoggerFactory.getLogger(RyaContext.class);
 
-    private Map<URI, RyaTypeResolver> uriToResolver = new HashMap<URI, RyaTypeResolver>();
-    private Map<Byte, RyaTypeResolver> byteToResolver = new HashMap<Byte, RyaTypeResolver>();
+    private final Map<URI, RyaTypeResolver> uriToResolver = new HashMap<URI, RyaTypeResolver>();
+    private final Map<Byte, RyaTypeResolver> byteToResolver = new HashMap<Byte, RyaTypeResolver>();
     private RyaTypeResolver defaultResolver = new CustomDatatypeResolver();
 
     private RyaContext() {
@@ -91,47 +90,51 @@ public class RyaContext {
     public synchronized static RyaContext getInstance() {
         return RyaContextHolder.INSTANCE;
     }
-    
+
 
     //need to go from datatype->resolver
-    public RyaTypeResolver retrieveResolver(URI datatype) {
-        RyaTypeResolver ryaTypeResolver = uriToResolver.get(datatype);
-        if (ryaTypeResolver == null) return defaultResolver;
+    public RyaTypeResolver retrieveResolver(final URI datatype) {
+        final RyaTypeResolver ryaTypeResolver = uriToResolver.get(datatype);
+        if (ryaTypeResolver == null) {
+            return defaultResolver;
+        }
         return ryaTypeResolver;
     }
 
     //need to go from byte->resolver
-    public RyaTypeResolver retrieveResolver(byte markerByte) {
-        RyaTypeResolver ryaTypeResolver = byteToResolver.get(markerByte);
-        if (ryaTypeResolver == null) return defaultResolver;
+    public RyaTypeResolver retrieveResolver(final byte markerByte) {
+        final RyaTypeResolver ryaTypeResolver = byteToResolver.get(markerByte);
+        if (ryaTypeResolver == null) {
+            return defaultResolver;
+        }
         return ryaTypeResolver;
     }
 
-    public byte[] serialize(RyaType ryaType) throws RyaTypeResolverException {
-        RyaTypeResolver ryaTypeResolver = retrieveResolver(ryaType.getDataType());
+    public byte[] serialize(final RyaType ryaType) throws RyaTypeResolverException {
+        final RyaTypeResolver ryaTypeResolver = retrieveResolver(ryaType.getDataType());
         if (ryaTypeResolver != null) {
             return ryaTypeResolver.serialize(ryaType);
         }
         return null;
     }
 
-    public byte[][] serializeType(RyaType ryaType) throws RyaTypeResolverException {
-        RyaTypeResolver ryaTypeResolver = retrieveResolver(ryaType.getDataType());
+    public byte[][] serializeType(final RyaType ryaType) throws RyaTypeResolverException {
+        final RyaTypeResolver ryaTypeResolver = retrieveResolver(ryaType.getDataType());
         if (ryaTypeResolver != null) {
             return ryaTypeResolver.serializeType(ryaType);
         }
         return null;
     }
 
-    public RyaType deserialize(byte[] bytes) throws RyaTypeResolverException {
-        RyaTypeResolver ryaTypeResolver = retrieveResolver(bytes[bytes.length - 1]);
+    public RyaType deserialize(final byte[] bytes) throws RyaTypeResolverException {
+        final RyaTypeResolver ryaTypeResolver = retrieveResolver(bytes[bytes.length - 1]);
         if (ryaTypeResolver != null) {
             return ryaTypeResolver.deserialize(bytes);
         }
         return null;
     }
 
-    public void addRyaTypeResolverMapping(RyaTypeResolverMapping mapping) {
+    public void addRyaTypeResolverMapping(final RyaTypeResolverMapping mapping) {
         if (!uriToResolver.containsKey(mapping.getRyaDataType())) {
             if (logger.isDebugEnabled()) {
                 logger.debug("addRyaTypeResolverMapping uri:[" + mapping.getRyaDataType() + "] byte:[" + mapping.getMarkerByte() + "] for mapping[" + mapping + "]");
@@ -143,14 +146,14 @@ public class RyaContext {
         }
     }
 
-    public void addRyaTypeResolverMappings(List<RyaTypeResolverMapping> mappings) {
-        for (RyaTypeResolverMapping mapping : mappings) {
+    public void addRyaTypeResolverMappings(final List<RyaTypeResolverMapping> mappings) {
+        for (final RyaTypeResolverMapping mapping : mappings) {
             addRyaTypeResolverMapping(mapping);
         }
     }
 
-    public RyaTypeResolver removeRyaTypeResolver(URI dataType) {
-        RyaTypeResolver ryaTypeResolver = uriToResolver.remove(dataType);
+    public RyaTypeResolver removeRyaTypeResolver(final URI dataType) {
+        final RyaTypeResolver ryaTypeResolver = uriToResolver.remove(dataType);
         if (ryaTypeResolver != null) {
             if (logger.isDebugEnabled()) {
                 logger.debug("Removing ryaType Resolver uri[" + dataType + "] + [" + ryaTypeResolver + "]");
@@ -161,8 +164,8 @@ public class RyaContext {
         return null;
     }
 
-    public RyaTypeResolver removeRyaTypeResolver(byte markerByte) {
-        RyaTypeResolver ryaTypeResolver = byteToResolver.remove(markerByte);
+    public RyaTypeResolver removeRyaTypeResolver(final byte markerByte) {
+        final RyaTypeResolver ryaTypeResolver = byteToResolver.remove(markerByte);
         if (ryaTypeResolver != null) {
             if (logger.isDebugEnabled()) {
                 logger.debug("Removing ryaType Resolver byte[" + markerByte + "] + [" + ryaTypeResolver + "]");
@@ -174,8 +177,8 @@ public class RyaContext {
     }
 
     //transform range
-    public RyaRange transformRange(RyaRange range) throws RyaTypeResolverException {
-        RyaTypeResolver ryaTypeResolver = retrieveResolver(range.getStart().getDataType());
+    public RyaRange transformRange(final RyaRange range) throws RyaTypeResolverException {
+        final RyaTypeResolver ryaTypeResolver = retrieveResolver(range.getStart().getDataType());
         if (ryaTypeResolver != null) {
             return ryaTypeResolver.transformRange(range);
         }
@@ -186,7 +189,7 @@ public class RyaContext {
         return defaultResolver;
     }
 
-    public void setDefaultResolver(RyaTypeResolver defaultResolver) {
+    public void setDefaultResolver(final RyaTypeResolver defaultResolver) {
         this.defaultResolver = defaultResolver;
     }
 }

--- a/extras/indexing/pom.xml
+++ b/extras/indexing/pom.xml
@@ -149,6 +149,11 @@
                 <artifactId>maven-shade-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>map-reduce</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
                         <configuration>
                             <shadedArtifactAttached>true</shadedArtifactAttached>
                             <shadedClassifierName>map-reduce</shadedClassifierName>

--- a/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/AccumuloLoadStatements.java
+++ b/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/AccumuloLoadStatements.java
@@ -1,0 +1,123 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.api.client.accumulo;
+
+import static java.util.Objects.requireNonNull;
+
+import org.apache.accumulo.core.client.AccumuloException;
+import org.apache.accumulo.core.client.AccumuloSecurityException;
+import org.apache.accumulo.core.client.Connector;
+import org.apache.log4j.Logger;
+import org.apache.rya.accumulo.AccumuloRdfConfiguration;
+import org.apache.rya.api.client.InstanceDoesNotExistException;
+import org.apache.rya.api.client.InstanceExists;
+import org.apache.rya.api.client.LoadStatements;
+import org.apache.rya.api.client.RyaClientException;
+import org.apache.rya.api.persist.RyaDAOException;
+import org.apache.rya.rdftriplestore.inference.InferenceEngineException;
+import org.apache.rya.sail.config.RyaSailFactory;
+import org.openrdf.model.Statement;
+import org.openrdf.repository.RepositoryException;
+import org.openrdf.repository.sail.SailRepository;
+import org.openrdf.repository.sail.SailRepositoryConnection;
+import org.openrdf.sail.Sail;
+import org.openrdf.sail.SailException;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * An Accumulo implementation of the {@link LoadStatements} command.
+ */
+@DefaultAnnotation(NonNull.class)
+public class AccumuloLoadStatements extends AccumuloCommand implements LoadStatements {
+    private static final Logger log = Logger.getLogger(AccumuloLoadStatements.class);
+
+    private final InstanceExists instanceExists;
+
+    /**
+     * Constructs an instance of {@link AccumuloLoadStatements}.
+     *
+     * @param connectionDetails - Details about the values that were used to create
+     *   the connector to the cluster. (not null)
+     * @param connector - Provides programmatic access to the instance of Accumulo
+     *   that hosts Rya instance. (not null)
+     */
+    public AccumuloLoadStatements(final AccumuloConnectionDetails connectionDetails, final Connector connector) {
+        super(connectionDetails, connector);
+        instanceExists = new AccumuloInstanceExists(connectionDetails, connector);
+    }
+
+    @Override
+    public void loadStatements(final String ryaInstanceName, final Iterable<? extends Statement> statements) throws InstanceDoesNotExistException, RyaClientException {
+        requireNonNull(ryaInstanceName);
+        requireNonNull(statements);
+
+        // Ensure the Rya Instance exists.
+        if(!instanceExists.exists(ryaInstanceName)) {
+            throw new InstanceDoesNotExistException(String.format("There is no Rya instance named '%s'.", ryaInstanceName));
+        }
+
+        Sail sail = null;
+        SailRepository sailRepo = null;
+        SailRepositoryConnection sailRepoConn = null;
+
+        try {
+            // Get a Sail object that is connected to the Rya instance.
+            final AccumuloRdfConfiguration ryaConf = getAccumuloConnectionDetails().buildAccumuloRdfConfiguration(ryaInstanceName);
+            ryaConf.setFlush(false); //RYA-327 should address this hardcoded value.
+            sail = RyaSailFactory.getInstance(ryaConf);
+
+            // Load the file.
+            sailRepo = new SailRepository(sail);
+            sailRepoConn = sailRepo.getConnection();
+            sailRepoConn.add(statements);
+
+        } catch (final SailException | AccumuloException | AccumuloSecurityException | RyaDAOException | InferenceEngineException  e) {
+            log.warn("Exception while loading:", e);
+            throw new RyaClientException("A problem connecting to the Rya instance named '" + ryaInstanceName + "' has caused the load to fail.", e);
+        } catch (final Exception e) {
+            log.warn("Exception while loading:", e);
+            throw new RyaClientException("A problem processing the RDF statements has caused the load into Rya instance named " + ryaInstanceName + "to fail.", e);
+        } finally {
+            // Shut it all down.
+            if(sailRepoConn != null) {
+                try {
+                    sailRepoConn.close();
+                } catch (final RepositoryException e) {
+                    log.warn("Couldn't close the SailRepoConnection that is attached to the Rya instance.", e);
+                }
+            }
+            if(sailRepo != null) {
+                try {
+                    sailRepo.shutDown();
+                } catch (final RepositoryException e) {
+                    log.warn("Couldn't shut down the SailRepository that is attached to the Rya instance.", e);
+                }
+            }
+            if(sail != null) {
+                try {
+                    sail.shutDown();
+                } catch (final SailException e) {
+                    log.warn("Couldn't shut down the Sail that is attached to the Rya instance.", e);
+                }
+            }
+        }
+    }
+}

--- a/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/AccumuloRyaClientFactory.java
+++ b/extras/indexing/src/main/java/org/apache/rya/api/client/accumulo/AccumuloRyaClientFactory.java
@@ -62,6 +62,7 @@ public class AccumuloRyaClientFactory {
                 new AccumuloAddUser(connectionDetails, connector),
                 new AccumuloRemoveUser(connectionDetails, connector),
                 new AccumuloUninstall(connectionDetails, connector),
+                new AccumuloLoadStatements(connectionDetails, connector),
                 new AccumuloLoadStatementsFile(connectionDetails, connector),
                 new AccumuloExecuteSparqlQuery(connectionDetails, connector));
     }

--- a/extras/indexing/src/main/java/org/apache/rya/indexing/pcj/matching/AccumuloIndexSetProvider.java
+++ b/extras/indexing/src/main/java/org/apache/rya/indexing/pcj/matching/AccumuloIndexSetProvider.java
@@ -18,12 +18,11 @@
  */
 package org.apache.rya.indexing.pcj.matching;
 
-import static java.util.Objects.requireNonNull;
-
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
@@ -73,13 +72,11 @@ public class AccumuloIndexSetProvider implements ExternalSetProvider<ExternalTup
     private boolean init = false;
 
     public AccumuloIndexSetProvider(final Configuration conf) {
-        Preconditions.checkNotNull(conf);
-        this.conf = conf;
+        this.conf = Objects.requireNonNull(conf);
     }
 
     public AccumuloIndexSetProvider(final Configuration conf, final List<ExternalTupleSet> indices) {
-        Preconditions.checkNotNull(conf);
-        this.conf = conf;
+        this(conf);
         indexCache = indices;
         init = true;
     }
@@ -155,9 +152,9 @@ public class AccumuloIndexSetProvider implements ExternalSetProvider<ExternalTup
      */
     private List<ExternalTupleSet> getAccIndices() throws Exception {
 
-        requireNonNull(conf);
-        final String tablePrefix = requireNonNull(conf.get(RdfCloudTripleStoreConfiguration.CONF_TBL_PREFIX));
-        final Connector conn = requireNonNull(ConfigUtils.getConnector(conf));
+        Objects.requireNonNull(conf);
+        final String tablePrefix = Objects.requireNonNull(conf.get(RdfCloudTripleStoreConfiguration.CONF_TBL_PREFIX));
+        final Connector conn = Objects.requireNonNull(ConfigUtils.getConnector(conf));
         List<String> tables = null;
 
         if (conf instanceof RdfCloudTripleStoreConfiguration) {

--- a/extras/periodic.notification/api/pom.xml
+++ b/extras/periodic.notification/api/pom.xml
@@ -1,15 +1,23 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <!-- Licensed to the Apache Software Foundation (ASF) under one or more 
-        contributor license agreements. See the NOTICE file distributed with this 
-        work for additional information regarding copyright ownership. The ASF licenses 
-        this file to you under the Apache License, Version 2.0 (the "License"); you 
-        may not use this file except in compliance with the License. You may obtain 
-        a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless 
-        required by applicable law or agreed to in writing, software distributed 
-        under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES 
-        OR CONDITIONS OF ANY KIND, either express or implied. See the License for 
-        the specific language governing permissions and limitations under the License. -->
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
 
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.rya</groupId>
@@ -23,16 +31,13 @@
     <description>API for Periodic Notification Applications</description>
 
     <dependencies>
-
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.0</version>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.openrdf.sesame</groupId>
@@ -45,6 +50,13 @@
         <dependency>
             <groupId>org.apache.rya</groupId>
             <artifactId>rya.indexing.pcj</artifactId>
+        </dependency>
+        
+        <!--  testing dependencies  -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/extras/periodic.notification/api/src/main/java/org/apache/rya/periodic/notification/api/PeriodicNotificationClient.java
+++ b/extras/periodic.notification/api/src/main/java/org/apache/rya/periodic/notification/api/PeriodicNotificationClient.java
@@ -36,20 +36,20 @@ public interface PeriodicNotificationClient extends AutoCloseable {
      * Adds a new notification to be registered with the {@link NotificationCoordinatorExecutor}
      * @param notification - notification to be added
      */
-    public void addNotification(PeriodicNotification notification);
-    
+    void addNotification(PeriodicNotification notification);
+
     /**
      * Deletes a notification from the {@link NotificationCoordinatorExecutor}.
      * @param notification - notification to be deleted
      */
-    public void deleteNotification(BasicNotification notification);
-    
+    void deleteNotification(BasicNotification notification);
+
     /**
      * Deletes a notification from the {@link NotificationCoordinatorExecutor}.
      * @param notification - id corresponding to the notification to be deleted
      */
-    public void deleteNotification(String notificationId);
-    
+    void deleteNotification(String notificationId);
+
     /**
      * Adds a new notification with the indicated id and period to the {@link NotificationCoordinatorExecutor}
      * @param id - Periodic Query id
@@ -57,8 +57,5 @@ public interface PeriodicNotificationClient extends AutoCloseable {
      * @param delay - initial delay for starting periodic notifications
      * @param unit - time unit of delay and period
      */
-    public void addNotification(String id, long period, long delay, TimeUnit unit);
-    
-    public void close();
-    
+    void addNotification(String id, long period, long delay, TimeUnit unit);
 }

--- a/extras/periodic.notification/api/src/main/java/org/apache/rya/periodic/notification/registration/KafkaNotificationRegistrationClient.java
+++ b/extras/periodic.notification/api/src/main/java/org/apache/rya/periodic/notification/registration/KafkaNotificationRegistrationClient.java
@@ -31,50 +31,50 @@ import org.apache.rya.periodic.notification.notification.PeriodicNotification;
 
 /**
  *  Implementation of {@link PeriodicNotificaitonClient} used to register new notification
- *  requests with the PeriodicQueryService. 
+ *  requests with the PeriodicQueryService.
  *
  */
 public class KafkaNotificationRegistrationClient implements PeriodicNotificationClient {
 
-    private KafkaProducer<String, CommandNotification> producer;
-    private String topic;
-    
-    public KafkaNotificationRegistrationClient(String topic, KafkaProducer<String, CommandNotification> producer) {
+    private final KafkaProducer<String, CommandNotification> producer;
+    private final String topic;
+
+    public KafkaNotificationRegistrationClient(final String topic, final KafkaProducer<String, CommandNotification> producer) {
         this.topic = topic;
         this.producer = producer;
     }
-    
+
     @Override
-    public void addNotification(PeriodicNotification notification) {
+    public void addNotification(final PeriodicNotification notification) {
         processNotification(new CommandNotification(Command.ADD, notification));
 
     }
 
     @Override
-    public void deleteNotification(BasicNotification notification) {
+    public void deleteNotification(final BasicNotification notification) {
         processNotification(new CommandNotification(Command.DELETE, notification));
     }
 
     @Override
-    public void deleteNotification(String notificationId) {
+    public void deleteNotification(final String notificationId) {
         processNotification(new CommandNotification(Command.DELETE, new BasicNotification(notificationId)));
     }
 
     @Override
-    public void addNotification(String id, long period, long delay, TimeUnit unit) {
-        Notification notification = PeriodicNotification.builder().id(id).period(period).initialDelay(delay).timeUnit(unit).build();
+    public void addNotification(final String id, final long period, final long delay, final TimeUnit unit) {
+        final Notification notification = PeriodicNotification.builder().id(id).period(period).initialDelay(delay).timeUnit(unit).build();
         processNotification(new CommandNotification(Command.ADD, notification));
     }
-    
-   
-    private void processNotification(CommandNotification notification) {
+
+
+    private void processNotification(final CommandNotification notification) {
         producer.send(new ProducerRecord<String, CommandNotification>(topic, notification.getId(), notification));
     }
-    
+
     @Override
     public void close() {
+        // TODO scoping issue.  If we're closing this producer, we should also create it - otherwise other classes may be using it
+        // or we shouldn't implement autocloseable.
         producer.close();
     }
-    
-
 }

--- a/extras/periodic.notification/api/src/main/java/org/apache/rya/periodic/notification/serialization/BindingSetSerDe.java
+++ b/extras/periodic.notification/api/src/main/java/org/apache/rya/periodic/notification/serialization/BindingSetSerDe.java
@@ -25,12 +25,13 @@ import java.util.Map;
 
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serializer;
-import org.apache.log4j.Logger;
 import org.apache.rya.indexing.pcj.storage.accumulo.AccumuloPcjSerializer;
 import org.apache.rya.indexing.pcj.storage.accumulo.BindingSetConverter.BindingSetConversionException;
 import org.apache.rya.indexing.pcj.storage.accumulo.VariableOrder;
 import org.openrdf.query.BindingSet;
 import org.openrdf.query.algebra.evaluation.QueryBindingSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Joiner;
 import com.google.common.primitives.Bytes;
@@ -42,7 +43,7 @@ import com.google.common.primitives.Bytes;
  */
 public class BindingSetSerDe implements Serializer<BindingSet>, Deserializer<BindingSet> {
 
-    private static final Logger log = Logger.getLogger(BindingSetSerDe.class);
+    private static final Logger log = LoggerFactory.getLogger(BindingSetSerDe.class);
     private static final AccumuloPcjSerializer serializer =  new AccumuloPcjSerializer();
     private static final byte[] DELIM_BYTE = "\u0002".getBytes(StandardCharsets.UTF_8);
 
@@ -60,7 +61,7 @@ public class BindingSetSerDe implements Serializer<BindingSet>, Deserializer<Bin
             final int firstIndex = Bytes.indexOf(bsBytes, DELIM_BYTE);
             final byte[] varOrderBytes = Arrays.copyOf(bsBytes, firstIndex);
             final byte[] bsBytesNoVarOrder = Arrays.copyOfRange(bsBytes, firstIndex + 1, bsBytes.length);
-            final VariableOrder varOrder = new VariableOrder(new String(varOrderBytes,"UTF-8").split(";"));
+            final VariableOrder varOrder = new VariableOrder(new String(varOrderBytes, StandardCharsets.UTF_8).split(";"));
             return getBindingSet(varOrder, bsBytesNoVarOrder);
         } catch(final Exception e) {
             log.trace("Unable to deserialize BindingSet: " + bsBytes);
@@ -75,7 +76,7 @@ public class BindingSetSerDe implements Serializer<BindingSet>, Deserializer<Bin
     private byte[] getBytes(final VariableOrder varOrder, final BindingSet bs) throws UnsupportedEncodingException, BindingSetConversionException {
         final byte[] bsBytes = serializer.convert(bs, varOrder);
         final String varOrderString = Joiner.on(";").join(varOrder.getVariableOrders());
-        final byte[] varOrderBytes = varOrderString.getBytes("UTF-8");
+        final byte[] varOrderBytes = varOrderString.getBytes(StandardCharsets.UTF_8);
         return Bytes.concat(varOrderBytes, DELIM_BYTE, bsBytes);
     }
 

--- a/extras/periodic.notification/api/src/main/java/org/apache/rya/periodic/notification/serialization/CommandNotificationSerializer.java
+++ b/extras/periodic.notification/api/src/main/java/org/apache/rya/periodic/notification/serialization/CommandNotificationSerializer.java
@@ -18,7 +18,7 @@
  */
 package org.apache.rya.periodic.notification.serialization;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 import org.apache.kafka.common.serialization.Deserializer;
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonParseException;
 
 /**
  * Kafka {@link Serializer} and {@link Deserializer} for producing and consuming {@link CommandNotification}s
@@ -43,22 +44,23 @@ public class CommandNotificationSerializer implements Serializer<CommandNotifica
     private static final Logger LOG = LoggerFactory.getLogger(CommandNotificationSerializer.class);
 
     @Override
-    public CommandNotification deserialize(String topic, byte[] bytes) {
-        String json = null;
+    public CommandNotification deserialize(final String topic, final byte[] bytes) {
         try {
-            json = new String(bytes, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            LOG.info("Unable to deserialize notification for topic: " + topic);
+            final String json = new String(bytes, StandardCharsets.UTF_8);
+            return gson.fromJson(json, CommandNotification.class);
+        } catch (final JsonParseException e) {
+            LOG.warn("Unable to deserialize notification for topic: " + topic);
+            throw new RuntimeException(e);
         }
-        return gson.fromJson(json, CommandNotification.class);
+
     }
 
     @Override
-    public byte[] serialize(String topic, CommandNotification command) {
+    public byte[] serialize(final String topic, final CommandNotification command) {
         try {
-            return gson.toJson(command).getBytes("UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            LOG.info("Unable to serialize notification: " + command  + "for topic: " + topic);
+            return gson.toJson(command).getBytes(StandardCharsets.UTF_8);
+        } catch (final JsonParseException e) {
+            LOG.warn("Unable to serialize notification: " + command  + "for topic: " + topic);
             throw new RuntimeException(e);
         }
     }
@@ -67,10 +69,10 @@ public class CommandNotificationSerializer implements Serializer<CommandNotifica
     public void close() {
         // Do nothing. Nothing to close
     }
-    
+
     @Override
-    public void configure(Map<String, ?> arg0, boolean arg1) {
+    public void configure(final Map<String, ?> arg0, final boolean arg1) {
         // Do nothing. Nothing to configure
     }
-    
+
 }

--- a/extras/periodic.notification/pom.xml
+++ b/extras/periodic.notification/pom.xml
@@ -1,40 +1,43 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <!--
-Licensed to the Apache Software Foundation (ASF) under one
-or more contributor license agreements.  See the NOTICE file
-distributed with this work for additional information
-regarding copyright ownership.  The ASF licenses this file
-to you under the Apache License, Version 2.0 (the
-"License"); you may not use this file except in compliance
-with the License.  You may obtain a copy of the License at
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on an
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied.  See the License for the
-specific language governing permissions and limitations
-under the License.
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
 -->
-  <modelVersion>4.0.0</modelVersion>
-  <artifactId>rya.periodic.notification.parent</artifactId>
-  
-   <parent>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
         <groupId>org.apache.rya</groupId>
         <artifactId>rya.extras</artifactId>
         <version>3.2.12-incubating-SNAPSHOT</version>
     </parent>
-  
-  <name>Apache Rya Periodic Notification Parent</name>
-  <description>Parent POM for Rya Periodic Notification Projects</description>
-  
-  <packaging>pom</packaging>
+
+    <artifactId>rya.periodic.notification.parent</artifactId>
+
+    <name>Apache Rya Periodic Notification Parent</name>
+    <description>Parent POM for Rya Periodic Notification Projects</description>
+
+    <packaging>pom</packaging>
 
     <modules>
         <module>api</module>
         <module>service</module>
+        <module>twill</module>
+        <module>twill.yarn</module>
         <module>tests</module>
     </modules>
-  
 </project>

--- a/extras/periodic.notification/service/pom.xml
+++ b/extras/periodic.notification/service/pom.xml
@@ -1,15 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <!-- Licensed to the Apache Software Foundation (ASF) under one or more 
-        contributor license agreements. See the NOTICE file distributed with this 
-        work for additional information regarding copyright ownership. The ASF licenses 
-        this file to you under the Apache License, Version 2.0 (the "License"); you 
-        may not use this file except in compliance with the License. You may obtain 
-        a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless 
-        required by applicable law or agreed to in writing, software distributed 
-        under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES 
-        OR CONDITIONS OF ANY KIND, either express or implied. See the License for 
-        the specific language governing permissions and limitations under the License. -->
     <parent>
         <groupId>org.apache.rya</groupId>
         <artifactId>rya.periodic.notification.parent</artifactId>
@@ -22,40 +31,18 @@
     <description>Notifications for Rya Periodic Service</description>
 
     <dependencies>
-
+        <!--  compile dependencies -->
         <dependency>
-            <groupId>org.apache.twill</groupId>
-            <artifactId>twill-api</artifactId>
-            <version>0.11.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.twill</groupId>
-            <artifactId>twill-yarn</artifactId>
-            <version>0.11.0</version>
-            <exclusions>
-                <exclusion>
-                    <artifactId>kafka_2.10</artifactId>
-                    <groupId>org.apache.kafka</groupId>
-                </exclusion>
-            </exclusions>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.0</version>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.fluo</groupId>
             <artifactId>fluo-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.fluo</groupId>
-            <artifactId>fluo-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.rya</groupId>
@@ -71,13 +58,22 @@
         </dependency>
         <dependency>
             <groupId>org.apache.rya</groupId>
-            <artifactId>rya.pcj.fluo.app</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.rya</groupId>
             <artifactId>rya.periodic.notification.api</artifactId>
         </dependency>
+        
+        <!--  runtime dependencies -->
+        <dependency>
+            <groupId>org.apache.fluo</groupId>
+            <artifactId>fluo-core</artifactId>
+            <scope>runtime</scope>
+        </dependency>
 
+        <!--  testing dependencies -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extras/periodic.notification/service/src/main/java/org/apache/rya/periodic/notification/application/PeriodicNotificationApplication.java
+++ b/extras/periodic.notification/service/src/main/java/org/apache/rya/periodic/notification/application/PeriodicNotificationApplication.java
@@ -18,7 +18,10 @@
  */
 package org.apache.rya.periodic.notification.application;
 
-import org.apache.log4j.Logger;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
 import org.apache.rya.indexing.pcj.fluo.app.util.PeriodicQueryUtil;
 import org.apache.rya.periodic.notification.api.BinPruner;
 import org.apache.rya.periodic.notification.api.BindingSetRecord;
@@ -30,6 +33,8 @@ import org.apache.rya.periodic.notification.processor.NotificationProcessorExecu
 import org.apache.rya.periodic.notification.pruner.PeriodicQueryPrunerExecutor;
 import org.apache.rya.periodic.notification.registration.kafka.KafkaNotificationProvider;
 import org.openrdf.query.algebra.evaluation.function.Function;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
 
@@ -68,36 +73,40 @@ import com.google.common.base.Preconditions;
  * the period at which the user wants to receive updates, and the time unit. The
  * following query requests all observations that occurred within the last
  * minute and requests updates every 15 seconds. It also performs a count on
- * those observations. <br>
- * <br>
- * <li>prefix function: http://org.apache.rya/function#
- * <li>"prefix time: http://www.w3.org/2006/time#
- * <li>"select (count(?obs) as ?total) where {
- * <li>"Filter(function:periodic(?time, 1, .25, time:minutes))
- * <li>"?obs uri:hasTime ?time.
- * <li>"?obs uri:hasId ?id }
- * <li>
+ * those observations.
+ * <p>
+ * <pre>
+ * PREFIX function: http://org.apache.rya/function#
+ * PREFIX time: http://www.w3.org/2006/time#
+ * SELECT (count(?obs) as ?total) WHERE {
+ *     FILTER (function:periodic(?time, 1, .25, time:minutes))
+ *     ?obs uri:hasTime ?time.
+ *     ?obs uri:hasId ?id
+ * }
+ * </pre>
  */
 public class PeriodicNotificationApplication implements LifeCycle {
 
-    private static final Logger log = Logger.getLogger(PeriodicNotificationApplication.class);
-    private NotificationCoordinatorExecutor coordinator;
-    private KafkaNotificationProvider provider;
-    private PeriodicQueryPrunerExecutor pruner;
-    private NotificationProcessorExecutor processor;
-    private KafkaExporterExecutor exporter;
+    private static final Logger log = LoggerFactory.getLogger(PeriodicNotificationApplication.class);
+    private final NotificationCoordinatorExecutor coordinator;
+    private final KafkaNotificationProvider provider;
+    private final PeriodicQueryPrunerExecutor pruner;
+    private final NotificationProcessorExecutor processor;
+    private final KafkaExporterExecutor exporter;
     private boolean running = false;
+    private Optional<CompletableFuture<Void>> finished = Optional.empty();
+
 
     /**
      * Creates a PeriodicNotificationApplication
-     * @param provider - {@link KafkaNotificationProvider} that retrieves new Notificaiton requests from Kafka
+     * @param provider - {@link KafkaNotificationProvider} that retrieves new Notification requests from Kafka
      * @param coordinator - {NotificationCoordinator} that manages PeriodicNotifications.
      * @param processor - {@link NotificationProcessorExecutor} that processes PeriodicNotifications
      * @param exporter - {@link KafkaExporterExecutor} that exports periodic results
      * @param pruner - {@link PeriodicQueryPrunerExecutor} that cleans up old periodic bins
      */
-    public PeriodicNotificationApplication(KafkaNotificationProvider provider, NotificationCoordinatorExecutor coordinator,
-            NotificationProcessorExecutor processor, KafkaExporterExecutor exporter, PeriodicQueryPrunerExecutor pruner) {
+    public PeriodicNotificationApplication(final KafkaNotificationProvider provider, final NotificationCoordinatorExecutor coordinator,
+            final NotificationProcessorExecutor processor, final KafkaExporterExecutor exporter, final PeriodicQueryPrunerExecutor pruner) {
         this.provider = Preconditions.checkNotNull(provider);
         this.coordinator = Preconditions.checkNotNull(coordinator);
         this.processor = Preconditions.checkNotNull(processor);
@@ -115,18 +124,37 @@ public class PeriodicNotificationApplication implements LifeCycle {
             pruner.start();
             exporter.start();
             running = true;
+            finished = Optional.of(new CompletableFuture<>());
+        }
+    }
+
+    /**
+     * Blocks the current thread until another thread has called the {@link #stop()}.
+     * @throws ExecutionException
+     * @throws InterruptedException
+     * @throws IllegalStateException
+     */
+    public void blockUntilFinished() throws ExecutionException, InterruptedException, IllegalStateException {
+        if(finished.isPresent()) {
+            finished.get().get();
+        } else {
+            throw new IllegalStateException("Cannot block if the application has not been started yet");
         }
     }
 
     @Override
     public void stop() {
         log.info("Stopping PeriodicNotificationApplication.");
+        if(!finished.isPresent()) {
+            throw new IllegalStateException("Cannot stop if the application has not been started yet");
+        }
         provider.stop();
         coordinator.stop();
         processor.stop();
         pruner.stop();
         exporter.stop();
         running = false;
+        finished.get().complete(null);
     }
 
     /**
@@ -154,7 +182,7 @@ public class PeriodicNotificationApplication implements LifeCycle {
          * @param pruner - PeriodicQueryPrunerExecutor for cleaning up old periodic bins
          * @return this Builder for chaining method calls
          */
-        public Builder setPruner(PeriodicQueryPrunerExecutor pruner) {
+        public Builder setPruner(final PeriodicQueryPrunerExecutor pruner) {
             this.pruner = pruner;
             return this;
         }
@@ -164,12 +192,12 @@ public class PeriodicNotificationApplication implements LifeCycle {
          * @param provider - KafkaNotificationProvider for retrieving new periodic notification requests from Kafka
          * @return this Builder for chaining method calls
          */
-        public Builder setProvider(KafkaNotificationProvider provider) {
+        public Builder setProvider(final KafkaNotificationProvider provider) {
             this.provider = provider;
             return this;
         }
 
-        public Builder setProcessor(NotificationProcessorExecutor processor) {
+        public Builder setProcessor(final NotificationProcessorExecutor processor) {
             this.processor = processor;
             return this;
         }
@@ -179,7 +207,7 @@ public class PeriodicNotificationApplication implements LifeCycle {
          * @param exporter for exporting periodic query results to Kafka
          * @return this Builder for chaining method calls
          */
-        public Builder setExporter(KafkaExporterExecutor exporter) {
+        public Builder setExporter(final KafkaExporterExecutor exporter) {
             this.exporter = exporter;
             return this;
         }
@@ -189,7 +217,7 @@ public class PeriodicNotificationApplication implements LifeCycle {
          * @param coordinator for managing and generating periodic notifications
          * @return this Builder for chaining method calls
          */
-        public Builder setCoordinator(NotificationCoordinatorExecutor coordinator) {
+        public Builder setCoordinator(final NotificationCoordinatorExecutor coordinator) {
             this.coordinator = coordinator;
             return this;
         }

--- a/extras/periodic.notification/service/src/main/java/org/apache/rya/periodic/notification/application/PeriodicNotificationApplicationConfiguration.java
+++ b/extras/periodic.notification/service/src/main/java/org/apache/rya/periodic/notification/application/PeriodicNotificationApplicationConfiguration.java
@@ -18,35 +18,36 @@
  */
 package org.apache.rya.periodic.notification.application;
 
+import java.util.Objects;
 import java.util.Properties;
 
 import org.apache.rya.accumulo.AccumuloRdfConfiguration;
 
-import com.google.common.base.Preconditions;
 
 /**
  * Configuration object for creating a {@link PeriodicNotificationApplication}.
  */
 public class PeriodicNotificationApplicationConfiguration extends AccumuloRdfConfiguration {
 
-    public static String FLUO_APP_NAME = "fluo.app.name";
-    public static String FLUO_TABLE_NAME = "fluo.table.name";
-    public static String KAFKA_BOOTSTRAP_SERVERS = "kafka.bootstrap.servers";
-    public static String NOTIFICATION_TOPIC = "kafka.notification.topic";
-    public static String NOTIFICATION_GROUP_ID = "kafka.notification.group.id";
-    public static String NOTIFICATION_CLIENT_ID = "kafka.notification.client.id";
-    public static String COORDINATOR_THREADS = "cep.coordinator.threads";
-    public static String PRODUCER_THREADS = "cep.producer.threads";
-    public static String EXPORTER_THREADS = "cep.exporter.threads";
-    public static String PROCESSOR_THREADS = "cep.processor.threads";
-    public static String PRUNER_THREADS = "cep.pruner.threads";
-    
+    public static final String RYA_PERIODIC_PREFIX = "rya.periodic.notification.";
+    public static final String RYA_PCJ_PREFIX = "rya.pcj.";
+    public static final String FLUO_APP_NAME = RYA_PCJ_PREFIX +"fluo.app.name";
+    public static final String FLUO_TABLE_NAME = RYA_PCJ_PREFIX + "fluo.table.name";
+    public static final String KAFKA_BOOTSTRAP_SERVERS = RYA_PERIODIC_PREFIX + "kafka.bootstrap.servers";
+    public static final String NOTIFICATION_TOPIC = RYA_PERIODIC_PREFIX + "kafka.topic";
+    public static final String NOTIFICATION_GROUP_ID = RYA_PERIODIC_PREFIX + "kafka.group.id";
+    public static final String NOTIFICATION_CLIENT_ID = RYA_PERIODIC_PREFIX + "kafka.client.id";
+    public static final String COORDINATOR_THREADS = RYA_PERIODIC_PREFIX + "coordinator.threads";
+    public static final String PRODUCER_THREADS = RYA_PERIODIC_PREFIX + "producer.threads";
+    public static final String EXPORTER_THREADS = RYA_PERIODIC_PREFIX + "exporter.threads";
+    public static final String PROCESSOR_THREADS = RYA_PERIODIC_PREFIX + "processor.threads";
+    public static final String PRUNER_THREADS = RYA_PERIODIC_PREFIX + "pruner.threads";
+
     public PeriodicNotificationApplicationConfiguration() {}
-    
+
     /**
      * Creates an PeriodicNotificationApplicationConfiguration object from a Properties file.  This method assumes
      * that all values in the Properties file are Strings and that the Properties file uses the keys below.
-     * See rya.cep/cep.integration.tests/src/test/resources/properties/notification.properties for an example.
      * <br>
      * <ul>
      * <li>"accumulo.auths" - String of Accumulo authorizations. Default is empty String.
@@ -55,23 +56,22 @@ public class PeriodicNotificationApplicationConfiguration extends AccumuloRdfCon
      * <li>"accumulo.password" - Accumulo password (required)
      * <li>"accumulo.rya.prefix" - Prefix for Accumulo backed Rya instance.  Default is "rya_"
      * <li>"accumulo.zookeepers" - Zookeepers for underlying Accumulo instance (required)
-     * <li>"fluo.app.name" - Name of Fluo Application (required)
-     * <li>"fluo.table.name" - Name of Fluo Table (required)
-     * <li>"kafka.bootstrap.servers" - Kafka Bootstrap servers for Producers and Consumers (required)
-     * <li>"kafka.notification.topic" - Topic to which new Periodic Notifications are published. Default is "notifications".
-     * <li>"kafka.notification.client.id" - Client Id for notification topic.  Default is "consumer0"
-     * <li>"kafka.notification.group.id" - Group Id for notification topic.  Default is "group0"
-     * <li>"cep.coordinator.threads" - Number of threads used by coordinator. Default is 1.
-     * <li>"cep.producer.threads" - Number of threads used by producer.  Default is 1.
-     * <li>"cep.exporter.threads" - Number of threads used by exporter.  Default is 1.
-     * <li>"cep.processor.threads" - Number of threads used by processor.  Default is 1.
-     * <li>"cep.pruner.threads" - Number of threads used by pruner.  Default is 1.
+     * <li>"rya.pcj.fluo.app.name" - Name of Fluo Application (required)
+     * <li>"rya.pcj.fluo.table.name" - Name of Fluo Table (required)
+     * <li>"rya.periodic.notification.kafka.bootstrap.servers" - Kafka Bootstrap servers for Producers and Consumers (required)
+     * <li>"rya.periodic.notification.kafka.topic" - Topic to which new Periodic Notifications are published. Default is "notifications".
+     * <li>"rya.periodic.notification.kafka.client.id" - Client Id for notification topic.  Default is "consumer0"
+     * <li>"rya.periodic.notification.kafka.group.id" - Group Id for notification topic.  Default is "group0"
+     * <li>"rya.periodic.notification.coordinator.threads" - Number of threads used by coordinator. Default is 1.
+     * <li>"rya.periodic.notification.producer.threads" - Number of threads used by producer.  Default is 1.
+     * <li>"rya.periodic.notification.exporter.threads" - Number of threads used by exporter.  Default is 1.
+     * <li>"rya.periodic.notification.processor.threads" - Number of threads used by processor.  Default is 1.
+     * <li>"rya.periodic.notification.pruner.threads" - Number of threads used by pruner.  Default is 1.
      * </ul>
      * <br>
      * @param props - Properties file containing Accumulo specific configuration parameters
-     * @return AccumumuloRdfConfiguration with properties set
      */
-    public PeriodicNotificationApplicationConfiguration(Properties props) {
+    public PeriodicNotificationApplicationConfiguration(final Properties props) {
        super(fromProperties(props));
        setFluoAppName(props.getProperty(FLUO_APP_NAME));
        setFluoTableName(props.getProperty(FLUO_TABLE_NAME));
@@ -85,170 +85,170 @@ public class PeriodicNotificationApplicationConfiguration extends AccumuloRdfCon
        setPrunerThreads(Integer.parseInt(props.getProperty(PRUNER_THREADS, "1")));
        setCoordinatorThreads(Integer.parseInt(props.getProperty(COORDINATOR_THREADS, "1")));
     }
-    
+
     /**
      * Sets the name of the Fluo Application
-     * @param fluoAppName 
+     * @param fluoAppName
      */
-    public void setFluoAppName(String fluoAppName) {
-        set(FLUO_APP_NAME, Preconditions.checkNotNull(fluoAppName));
+    public void setFluoAppName(final String fluoAppName) {
+        set(FLUO_APP_NAME, Objects.requireNonNull(fluoAppName));
     }
-    
+
     /**
      * Sets the name of the Fluo table
      * @param fluoTableName
      */
-    public void setFluoTableName(String fluoTableName) {
-       set(FLUO_TABLE_NAME, Preconditions.checkNotNull(fluoTableName)); 
+    public void setFluoTableName(final String fluoTableName) {
+       set(FLUO_TABLE_NAME, Objects.requireNonNull(fluoTableName));
     }
-    
+
     /**
      * Sets the Kafka bootstrap servers
      * @param bootStrapServers
      */
-    public void setBootStrapServers(String bootStrapServers) {
-        set(KAFKA_BOOTSTRAP_SERVERS, Preconditions.checkNotNull(bootStrapServers)); 
+    public void setBootStrapServers(final String bootStrapServers) {
+        set(KAFKA_BOOTSTRAP_SERVERS, Objects.requireNonNull(bootStrapServers));
     }
-    
+
     /**
      * Sets the Kafka topic name for new notification requests
      * @param notificationTopic
      */
-    public void setNotificationTopic(String notificationTopic) {
-        set(NOTIFICATION_TOPIC, Preconditions.checkNotNull(notificationTopic));
+    public void setNotificationTopic(final String notificationTopic) {
+        set(NOTIFICATION_TOPIC, Objects.requireNonNull(notificationTopic));
     }
-    
+
     /**
      * Sets the GroupId for new notification request topic
      * @param notificationGroupId
      */
-    public void setNotificationGroupId(String notificationGroupId) {
-        set(NOTIFICATION_GROUP_ID, Preconditions.checkNotNull(notificationGroupId));
+    public void setNotificationGroupId(final String notificationGroupId) {
+        set(NOTIFICATION_GROUP_ID, Objects.requireNonNull(notificationGroupId));
     }
-    
+
     /**
      * Sets the ClientId for the Kafka notification topic
      * @param notificationClientId
      */
-    public void setNotificationClientId(String notificationClientId) {
-        set(NOTIFICATION_GROUP_ID, Preconditions.checkNotNull(notificationClientId));
+    public void setNotificationClientId(final String notificationClientId) {
+        set(NOTIFICATION_CLIENT_ID, Objects.requireNonNull(notificationClientId));
     }
-    
+
     /**
      * Sets the number of threads for the coordinator
      * @param threads
      */
-    public void setCoordinatorThreads(int threads) {
+    public void setCoordinatorThreads(final int threads) {
         setInt(COORDINATOR_THREADS, threads);
     }
-    
+
     /**
      * Sets the number of threads for the exporter
      * @param threads
      */
-    public void setExporterThreads(int threads) {
+    public void setExporterThreads(final int threads) {
         setInt(EXPORTER_THREADS, threads);
     }
-    
+
     /**
      * Sets the number of threads for the producer for reading new periodic notifications
      * @param threads
      */
-    public void setProducerThreads(int threads) {
+    public void setProducerThreads(final int threads) {
         setInt(PRODUCER_THREADS, threads);
     }
-    
+
     /**
      * Sets the number of threads for the bin pruner
      * @param threads
      */
-    public void setPrunerThreads(int threads) {
+    public void setPrunerThreads(final int threads) {
         setInt(PRUNER_THREADS, threads);
     }
-    
+
     /**
      * Sets the number of threads for the Notification processor
      * @param threads
      */
-    public void setProcessorThreads(int threads) {
+    public void setProcessorThreads(final int threads) {
         setInt(PROCESSOR_THREADS, threads);
     }
-    
+
     /**
      * @return name of the Fluo application
      */
     public String getFluoAppName() {
         return get(FLUO_APP_NAME);
     }
-    
+
     /**
      * @return name of the Fluo table
      */
     public String getFluoTableName() {
-       return get(FLUO_TABLE_NAME); 
+       return get(FLUO_TABLE_NAME);
     }
-    
+
     /**
      * @return Kafka bootstrap servers
      */
     public String getBootStrapServers() {
-        return get(KAFKA_BOOTSTRAP_SERVERS); 
+        return get(KAFKA_BOOTSTRAP_SERVERS);
     }
-    
+
     /**
      * @return notification topic
      */
     public String getNotificationTopic() {
         return get(NOTIFICATION_TOPIC, "notifications");
     }
-    
+
     /**
      * @return Kafka GroupId for the notificaton topic
      */
     public String getNotificationGroupId() {
         return get(NOTIFICATION_GROUP_ID, "group0");
     }
-    
+
     /**
      * @return Kafka ClientId for the notification topic
      */
     public String getNotificationClientId() {
         return get(NOTIFICATION_CLIENT_ID, "consumer0");
     }
-    
+
     /**
      * @return the number of threads for the coordinator
      */
     public int getCoordinatorThreads() {
         return getInt(COORDINATOR_THREADS, 1);
     }
-    
+
     /**
      * @return the number of threads for the exporter
      */
     public int getExporterThreads() {
         return getInt(EXPORTER_THREADS, 1);
     }
-    
+
     /**
      * @return the number of threads for the notification producer
      */
     public int getProducerThreads() {
         return getInt(PRODUCER_THREADS, 1);
     }
-    
+
     /**
      * @return the number of threads for the bin pruner
      */
     public int getPrunerThreads() {
         return getInt(PRUNER_THREADS, 1);
     }
-    
+
     /**
      * @return number of threads for the processor
      */
     public int getProcessorThreads() {
         return getInt(PROCESSOR_THREADS, 1);
     }
-    
+
 }

--- a/extras/periodic.notification/service/src/main/java/org/apache/rya/periodic/notification/exporter/KafkaExporterExecutor.java
+++ b/extras/periodic.notification/service/src/main/java/org/apache/rya/periodic/notification/exporter/KafkaExporterExecutor.java
@@ -20,57 +20,54 @@ package org.apache.rya.periodic.notification.exporter;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.kafka.clients.producer.KafkaProducer;
-import org.apache.log4j.Logger;
-import org.apache.rya.periodic.notification.api.BindingSetExporter;
 import org.apache.rya.periodic.notification.api.BindingSetRecord;
 import org.apache.rya.periodic.notification.api.LifeCycle;
 import org.openrdf.query.BindingSet;
-
-import com.google.common.base.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- * Executor service that runs {@link KafkaPeriodicBindingSetExporter}s.  
+ * Executor service that runs {@link KafkaPeriodicBindingSetExporter}s.
  *
  */
 public class KafkaExporterExecutor implements LifeCycle {
 
-    private static final Logger log = Logger.getLogger(BindingSetExporter.class);
-    private KafkaProducer<String, BindingSet> producer;
-    private BlockingQueue<BindingSetRecord> bindingSets;
+    private static final Logger log = LoggerFactory.getLogger(KafkaExporterExecutor.class);
+    private final KafkaProducer<String, BindingSet> producer;
+    private final BlockingQueue<BindingSetRecord> bindingSets;
     private ExecutorService executor;
-    private List<KafkaPeriodicBindingSetExporter> exporters;
-    private int num_Threads;
+    private final List<KafkaPeriodicBindingSetExporter> exporters;
+    private final int numThreads;
     private boolean running = false;
 
     /**
      * Creates a KafkaExporterExecutor for exporting periodic query results to Kafka.
      * @param producer for publishing results to Kafka
-     * @param num_Threads number of threads used to publish results
+     * @param numThreads number of threads used to publish results
      * @param bindingSets - work queue containing {@link BindingSet}s to be published
      */
-    public KafkaExporterExecutor(KafkaProducer<String, BindingSet> producer, int num_Threads, BlockingQueue<BindingSetRecord> bindingSets) {
-        Preconditions.checkNotNull(producer);
-        Preconditions.checkNotNull(bindingSets);
-        this.producer = producer;
-        this.bindingSets = bindingSets;
-        this.num_Threads = num_Threads;
+    public KafkaExporterExecutor(final KafkaProducer<String, BindingSet> producer, final int numThreads, final BlockingQueue<BindingSetRecord> bindingSets) {
+        this.producer = Objects.requireNonNull(producer);
+        this.bindingSets = Objects.requireNonNull(bindingSets);
+        this.numThreads = numThreads;
         this.exporters = new ArrayList<>();
     }
 
     @Override
     public void start() {
         if (!running) {
-            executor = Executors.newFixedThreadPool(num_Threads);
+            executor = Executors.newFixedThreadPool(numThreads);
 
-            for (int threadNumber = 0; threadNumber < num_Threads; threadNumber++) {
-                log.info("Creating exporter:" + threadNumber);
-                KafkaPeriodicBindingSetExporter exporter = new KafkaPeriodicBindingSetExporter(producer, threadNumber, bindingSets);
+            for (int threadNumber = 0; threadNumber < numThreads; threadNumber++) {
+                log.info("Creating exporter: {}", threadNumber);
+                final KafkaPeriodicBindingSetExporter exporter = new KafkaPeriodicBindingSetExporter(producer, threadNumber, bindingSets);
                 exporters.add(exporter);
                 executor.submit(exporter);
             }
@@ -98,7 +95,7 @@ public class KafkaExporterExecutor implements LifeCycle {
                 log.info("Timed out waiting for consumer threads to shut down, exiting uncleanly");
                 executor.shutdownNow();
             }
-        } catch (InterruptedException e) {
+        } catch (final InterruptedException e) {
             log.info("Interrupted during shutdown, exiting uncleanly");
         }
     }

--- a/extras/periodic.notification/service/src/main/java/org/apache/rya/periodic/notification/processor/TimestampedNotificationProcessor.java
+++ b/extras/periodic.notification/service/src/main/java/org/apache/rya/periodic/notification/processor/TimestampedNotificationProcessor.java
@@ -22,7 +22,6 @@ import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.apache.log4j.Logger;
 import org.apache.rya.indexing.pcj.storage.PeriodicQueryResultStorage;
 import org.apache.rya.indexing.pcj.storage.PrecomputedJoinStorage.CloseableIterator;
 import org.apache.rya.periodic.notification.api.BinPruner;
@@ -32,6 +31,8 @@ import org.apache.rya.periodic.notification.api.NotificationProcessor;
 import org.apache.rya.periodic.notification.exporter.KafkaPeriodicBindingSetExporter;
 import org.apache.rya.periodic.notification.notification.TimestampedNotification;
 import org.openrdf.query.BindingSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
 
@@ -46,19 +47,30 @@ import com.google.common.base.Preconditions;
  */
 public class TimestampedNotificationProcessor implements NotificationProcessor, Runnable {
 
-    private static final Logger log = Logger.getLogger(TimestampedNotificationProcessor.class);
-    private PeriodicQueryResultStorage periodicStorage;
-    private BlockingQueue<TimestampedNotification> notifications; // notifications
-                                                                  // to process
-    private BlockingQueue<NodeBin> bins; // entries to delete from Fluo
-    private BlockingQueue<BindingSetRecord> bindingSets; // query results to export
-    private AtomicBoolean closed = new AtomicBoolean(false);
-    private int threadNumber;
-    
+    private static final Logger log = LoggerFactory.getLogger(TimestampedNotificationProcessor.class);
+    private final PeriodicQueryResultStorage periodicStorage;
 
-    public TimestampedNotificationProcessor(PeriodicQueryResultStorage periodicStorage,
-            BlockingQueue<TimestampedNotification> notifications, BlockingQueue<NodeBin> bins, BlockingQueue<BindingSetRecord> bindingSets,
-            int threadNumber) {
+    /**
+     * notifications to process
+     */
+    private final BlockingQueue<TimestampedNotification> notifications;
+
+    /**
+     * entries to delete from Fluo
+     */
+    private final BlockingQueue<NodeBin> bins;
+
+    /**
+     * query results to export
+     */
+    private final BlockingQueue<BindingSetRecord> bindingSets;
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+    private final int threadNumber;
+
+
+    public TimestampedNotificationProcessor(final PeriodicQueryResultStorage periodicStorage,
+            final BlockingQueue<TimestampedNotification> notifications, final BlockingQueue<NodeBin> bins, final BlockingQueue<BindingSetRecord> bindingSets,
+            final int threadNumber) {
         this.notifications = Preconditions.checkNotNull(notifications);
         this.bins = Preconditions.checkNotNull(bins);
         this.bindingSets = Preconditions.checkNotNull(bindingSets);
@@ -75,13 +87,13 @@ public class TimestampedNotificationProcessor implements NotificationProcessor, 
      * bins can be deleted from Fluo and Accumulo.
      */
     @Override
-    public void processNotification(TimestampedNotification notification) {
+    public void processNotification(final TimestampedNotification notification) {
 
-        String id = notification.getId();
-        long ts = notification.getTimestamp().getTime();
-        long period = notification.getPeriod();
-        long bin = getBinFromTimestamp(ts, period);
-        NodeBin nodeBin = new NodeBin(id, bin);
+        final String id = notification.getId();
+        final long ts = notification.getTimestamp().getTime();
+        final long period = notification.getPeriod();
+        final long bin = getBinFromTimestamp(ts, period);
+        final NodeBin nodeBin = new NodeBin(id, bin);
 
         try (CloseableIterator<BindingSet> iter = periodicStorage.listResults(id, Optional.of(bin));) {
 
@@ -91,20 +103,20 @@ public class TimestampedNotificationProcessor implements NotificationProcessor, 
             // add NodeBin to BinPruner queue so that bin can be deleted from
             // Fluo and Accumulo
             bins.add(nodeBin);
-        } catch (Exception e) {
-            log.debug("Encountered error: " + e.getMessage() + " while accessing periodic results for bin: " + bin + " for query: " + id);
+        } catch (final Exception e) {
+            log.warn("Encountered exception while accessing periodic results for bin: " + bin + " for query: " + id, e);
         }
     }
 
     /**
      * Computes left bin end point containing event time ts
-     * 
+     *
      * @param ts - event time
      * @param start - time that periodic event began
      * @param period - length of period
      * @return left bin end point containing event time ts
      */
-    private long getBinFromTimestamp(long ts, long period) {
+    private long getBinFromTimestamp(final long ts, final long period) {
         Preconditions.checkArgument(period > 0);
         return (ts / period) * period;
     }
@@ -115,13 +127,13 @@ public class TimestampedNotificationProcessor implements NotificationProcessor, 
             while(!closed.get()) {
                 processNotification(notifications.take());
             }
-        } catch (Exception e) {
-            log.trace("Thread_" + threadNumber + " is unable to process next notification.");
+        } catch (final Exception e) {
+            log.warn("Thread {} is unable to process next notification.", threadNumber);
             throw new RuntimeException(e);
         }
 
     }
-    
+
     public void shutdown() {
         closed.set(true);
     }
@@ -130,7 +142,7 @@ public class TimestampedNotificationProcessor implements NotificationProcessor, 
         return new Builder();
     }
 
-  
+
 
     public static class Builder {
 
@@ -138,7 +150,7 @@ public class TimestampedNotificationProcessor implements NotificationProcessor, 
         private BlockingQueue<TimestampedNotification> notifications; // notifications to process
         private BlockingQueue<NodeBin> bins; // entries to delete from Fluo
         private BlockingQueue<BindingSetRecord> bindingSets; // query results to export
-                                                       
+
         private int threadNumber;
 
         /**
@@ -146,7 +158,7 @@ public class TimestampedNotificationProcessor implements NotificationProcessor, 
          * @param notifications - work queue containing notifications to be processed
          * @return this Builder for chaining method calls
          */
-        public Builder setNotifications(BlockingQueue<TimestampedNotification> notifications) {
+        public Builder setNotifications(final BlockingQueue<TimestampedNotification> notifications) {
             this.notifications = notifications;
             return this;
         }
@@ -156,7 +168,7 @@ public class TimestampedNotificationProcessor implements NotificationProcessor, 
          * @param bins - work queue containing NodeBins to be pruned
          * @return this Builder for chaining method calls
          */
-        public Builder setBins(BlockingQueue<NodeBin> bins) {
+        public Builder setBins(final BlockingQueue<NodeBin> bins) {
             this.bins = bins;
             return this;
         }
@@ -166,7 +178,7 @@ public class TimestampedNotificationProcessor implements NotificationProcessor, 
          * @param bindingSets - work queue containing BindingSets to be exported
          * @return this Builder for chaining method calls
          */
-        public Builder setBindingSets(BlockingQueue<BindingSetRecord> bindingSets) {
+        public Builder setBindingSets(final BlockingQueue<BindingSetRecord> bindingSets) {
             this.bindingSets = bindingSets;
             return this;
         }
@@ -176,17 +188,17 @@ public class TimestampedNotificationProcessor implements NotificationProcessor, 
          * @param threadNumber - number of threads used by this processor
          * @return - number of threads used by this processor
          */
-        public Builder setThreadNumber(int threadNumber) {
+        public Builder setThreadNumber(final int threadNumber) {
             this.threadNumber = threadNumber;
             return this;
         }
-        
+
         /**
          * Set the PeriodicStorage layer
          * @param periodicStorage - periodic storage layer that periodic results are read from
          * @return - this Builder for chaining method calls
          */
-        public Builder setPeriodicStorage(PeriodicQueryResultStorage periodicStorage) {
+        public Builder setPeriodicStorage(final PeriodicQueryResultStorage periodicStorage) {
             this.periodicStorage = periodicStorage;
             return this;
         }

--- a/extras/periodic.notification/service/src/main/java/org/apache/rya/periodic/notification/pruner/AccumuloBinPruner.java
+++ b/extras/periodic.notification/service/src/main/java/org/apache/rya/periodic/notification/pruner/AccumuloBinPruner.java
@@ -18,25 +18,25 @@
  */
 package org.apache.rya.periodic.notification.pruner;
 
-import org.apache.log4j.Logger;
+import java.util.Objects;
+
 import org.apache.rya.indexing.pcj.storage.PeriodicQueryResultStorage;
 import org.apache.rya.indexing.pcj.storage.PeriodicQueryStorageException;
 import org.apache.rya.periodic.notification.api.BinPruner;
 import org.apache.rya.periodic.notification.api.NodeBin;
-
-import com.google.common.base.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Deletes BindingSets from time bins in the indicated PCJ table
  */
 public class AccumuloBinPruner implements BinPruner {
 
-    private static final Logger log = Logger.getLogger(AccumuloBinPruner.class);
-    private PeriodicQueryResultStorage periodicStorage;
+    private static final Logger log = LoggerFactory.getLogger(AccumuloBinPruner.class);
+    private final PeriodicQueryResultStorage periodicStorage;
 
-    public AccumuloBinPruner(PeriodicQueryResultStorage periodicStorage) {
-        Preconditions.checkNotNull(periodicStorage);
-        this.periodicStorage = periodicStorage;
+    public AccumuloBinPruner(final PeriodicQueryResultStorage periodicStorage) {
+        this.periodicStorage = Objects.requireNonNull(periodicStorage);
     }
 
     /**
@@ -44,20 +44,20 @@ public class AccumuloBinPruner implements BinPruner {
      * table indicated by the id. It is assumed that all BindingSet entries for
      * the corresponding bin are written to the PCJ table so that the bin Id
      * occurs first.
-     * 
+     *
      * @param id
      *            - pcj table id
      * @param bin
      *            - temporal bin the BindingSets are contained in
      */
     @Override
-    public void pruneBindingSetBin(NodeBin nodeBin) {
-        Preconditions.checkNotNull(nodeBin);
-        String id = nodeBin.getNodeId();
-        long bin = nodeBin.getBin();
+    public void pruneBindingSetBin(final NodeBin nodeBin) {
+        Objects.requireNonNull(nodeBin);
+        final String id = nodeBin.getNodeId();
+        final long bin = nodeBin.getBin();
         try {
             periodicStorage.deletePeriodicQueryResults(id, bin);
-        } catch (PeriodicQueryStorageException e) {
+        } catch (final PeriodicQueryStorageException e) {
             log.trace("Unable to delete results from Peroidic Table: " + id + " for bin: " + bin);
             throw new RuntimeException(e);
         }

--- a/extras/periodic.notification/service/src/main/java/org/apache/rya/periodic/notification/registration/kafka/PeriodicNotificationConsumer.java
+++ b/extras/periodic.notification/service/src/main/java/org/apache/rya/periodic/notification/registration/kafka/PeriodicNotificationConsumer.java
@@ -25,9 +25,10 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.errors.WakeupException;
-import org.apache.log4j.Logger;
 import org.apache.rya.periodic.notification.api.NotificationCoordinatorExecutor;
 import org.apache.rya.periodic.notification.notification.CommandNotification;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Consumer for the {@link KafkaNotificationProvider}.  This consumer pull messages
@@ -35,52 +36,55 @@ import org.apache.rya.periodic.notification.notification.CommandNotification;
  *
  */
 public class PeriodicNotificationConsumer implements Runnable {
-    private KafkaConsumer<String, CommandNotification> consumer;
-    private int m_threadNumber;
-    private String topic;
+    private final KafkaConsumer<String, CommandNotification> consumer;
+    private final int threadNumber;
+    private final String topic;
     private final AtomicBoolean closed = new AtomicBoolean(false);
-    private NotificationCoordinatorExecutor coord;
-    private static final Logger LOG = Logger.getLogger(PeriodicNotificationConsumer.class);
+    private final NotificationCoordinatorExecutor coord;
+    private static final Logger LOG = LoggerFactory.getLogger(PeriodicNotificationConsumer.class);
 
     /**
      * Creates a new PeriodicNotificationConsumer for consuming new notification requests from
      * Kafka.
      * @param topic - new notification topic
      * @param consumer - consumer for pulling new requests from Kafka
-     * @param a_threadNumber - number of consumer threads to be used
+     * @param threadNumber - an identifier for this thread.
      * @param coord - notification coordinator for managing and generating notifications
      */
-    public PeriodicNotificationConsumer(String topic, KafkaConsumer<String, CommandNotification> consumer, int a_threadNumber,
-            NotificationCoordinatorExecutor coord) {
+    public PeriodicNotificationConsumer(final String topic, final KafkaConsumer<String, CommandNotification> consumer, final int threadNumber,
+            final NotificationCoordinatorExecutor coord) {
         this.topic = topic;
-        m_threadNumber = a_threadNumber;
+        this.threadNumber = threadNumber;
         this.consumer = consumer;
         this.coord = coord;
     }
 
+    @Override
     public void run() {
-        
+
         try {
-            LOG.info("Creating kafka stream for consumer:" + m_threadNumber);
+            LOG.info("Configuring KafkaConsumer on thread: {} to subscribe to topic: {}", threadNumber, topic);
             consumer.subscribe(Arrays.asList(topic));
             while (!closed.get()) {
-                ConsumerRecords<String, CommandNotification> records = consumer.poll(10000);
+                final ConsumerRecords<String, CommandNotification> records = consumer.poll(10000);
                 // Handle new records
-                for(ConsumerRecord<String, CommandNotification> record: records) {
-                    CommandNotification notification = record.value();
-                    LOG.info("Thread " + m_threadNumber + " is adding notification " + notification + " to queue.");
-                    LOG.info("Message: " + notification);
+                for(final ConsumerRecord<String, CommandNotification> record: records) {
+                    final CommandNotification notification = record.value();
+                    LOG.info("Thread {} is adding notification: {}", threadNumber, notification);
                     coord.processNextCommandNotification(notification);
                 }
             }
-        } catch (WakeupException e) {
+            LOG.info("Finished polling.");
+        } catch (final WakeupException e) {
             // Ignore exception if closing
-            if (!closed.get()) throw e;
+            if (!closed.get()) {
+                throw e;
+            }
         } finally {
             consumer.close();
         }
     }
-    
+
     public void shutdown() {
         closed.set(true);
         consumer.wakeup();

--- a/extras/periodic.notification/tests/pom.xml
+++ b/extras/periodic.notification/tests/pom.xml
@@ -1,14 +1,22 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor 
-    license agreements. See the NOTICE file distributed with this work for additional 
-    information regarding copyright ownership. The ASF licenses this file to 
-    you under the Apache License, Version 2.0 (the "License"); you may not use 
-    this file except in compliance with the License. You may obtain a copy of 
-    the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
-    by applicable law or agreed to in writing, software distributed under the 
-    License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
-    OF ANY KIND, either express or implied. See the License for the specific 
-    language governing permissions and limitations under the License. -->
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 

--- a/extras/periodic.notification/tests/src/test/java/org/apache/rya/periodic/notification/application/PeriodicNotificationApplicationIT.java
+++ b/extras/periodic.notification/tests/src/test/java/org/apache/rya/periodic/notification/application/PeriodicNotificationApplicationIT.java
@@ -126,7 +126,7 @@ public class PeriodicNotificationApplicationIT extends RyaExportITBase {
         producer = new KafkaProducer<>(kafkaProps, new StringSerializer(), new CommandNotificationSerializer());
 
         //extract kafka specific properties from application config
-        app = PeriodicNotificationApplicationFactory.getPeriodicApplication(props);
+        app = PeriodicNotificationApplicationFactory.getPeriodicApplication(conf);
         registrar = new KafkaNotificationRegistrationClient(conf.getNotificationTopic(), producer);
     }
 

--- a/extras/periodic.notification/tests/src/test/resources/notification.properties
+++ b/extras/periodic.notification/tests/src/test/resources/notification.properties
@@ -1,4 +1,3 @@
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -15,21 +14,21 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-#/
+
 accumulo.auths=
 accumulo.instance="instance"
 accumulo.user="root"
 accumulo.password="secret"
 accumulo.rya.prefix="rya_"
 accumulo.zookeepers=
-fluo.app.name="fluo_app"
-fluo.table.name="fluo_table"
-kafka.bootstrap.servers=127.0.0.1:9092
-kafka.notification.topic=notifications
-kafka.notification.client.id=consumer0
-kafka.notification.group.id=group0
-cep.coordinator.threads=1
-cep.producer.threads=1
-cep.exporter.threads=1
-cep.processor.threads=1
-cep.pruner.threads=1
+rya.pcj.fluo.app.name="fluo_app"
+rya.pcj.fluo.table.name="fluo_table"
+rya.periodic.notification.kafka.bootstrap.servers=127.0.0.1:9092
+rya.periodic.notification.kafka.topic=notifications
+rya.periodic.notification.kafka.client.id=consumer0
+rya.periodic.notification.kafka.group.id=group0
+rya.periodic.notification.coordinator.threads=1
+rya.periodic.notification.producer.threads=1
+rya.periodic.notification.exporter.threads=1
+rya.periodic.notification.processor.threads=1
+rya.periodic.notification.pruner.threads=1

--- a/extras/periodic.notification/twill.yarn/README.md
+++ b/extras/periodic.notification/twill.yarn/README.md
@@ -1,0 +1,18 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->

--- a/extras/periodic.notification/twill.yarn/pom.xml
+++ b/extras/periodic.notification/twill.yarn/pom.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.rya</groupId>
+        <artifactId>rya.periodic.notification.parent</artifactId>
+        <version>3.2.12-incubating-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>rya.periodic.notification.twill.yarn</artifactId>
+
+    <name>Apache Rya Periodic Notification Service on Twill on YARN </name>
+    <description>Twill Application for executing the Apache Rya Periodic Notification Service on YARN</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.beust</groupId>
+            <artifactId>jcommander</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>13.0.1</version> <!-- Override Rya's DependencyManagement. The Twill runtime requires 11.0 < guava < 14.0 (Service.listener) (AbstractExecutionThreadService.getServiceName) -->
+        </dependency>
+        <dependency>
+            <groupId>org.apache.twill</groupId>
+            <artifactId>twill-yarn</artifactId>
+            <version>0.12.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.rya</groupId>
+            <artifactId>rya.periodic.notification.twill</artifactId>
+            <version>3.2.12-incubating-SNAPSHOT</version>
+            <classifier>twill-app</classifier>
+            <scope>provided</scope>  <!--  prevent these dependencies from showing up on the classpath -->
+        </dependency>
+        
+        <!-- Add Accumulo as a runtime dependency -->
+        <dependency>
+            <groupId>org.apache.accumulo</groupId>
+            <artifactId>accumulo-core</artifactId>
+            <scope>runtime</scope>
+            <exclusions>
+                <!--  exclude logging implementations -->
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>create-binary-distribution</id>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <tarLongFileMode>gnu</tarLongFileMode>
+                            <descriptors>
+                                <descriptor>src/main/assembly/binary-release.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extras/periodic.notification/twill.yarn/src/main/assembly/binary-release.xml
+++ b/extras/periodic.notification/twill.yarn/src/main/assembly/binary-release.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+    <id>bin</id>
+    <formats>
+        <format>tar.gz</format>
+    </formats>
+    <includeBaseDirectory>true</includeBaseDirectory>
+    <componentDescriptors>
+        <componentDescriptor>src/main/assembly/component-release.xml</componentDescriptor>
+    </componentDescriptors>
+</assembly>

--- a/extras/periodic.notification/twill.yarn/src/main/assembly/component-release.xml
+++ b/extras/periodic.notification/twill.yarn/src/main/assembly/component-release.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<component
+    xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/component/1.1.3"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/component/1.1.3 http://maven.apache.org/xsd/component-1.1.3.xsd">
+    <fileSets>
+        <fileSet>
+            <directory>src/main/scripts</directory>
+            <outputDirectory>bin</outputDirectory>
+            <directoryMode>0755</directoryMode>
+            <fileMode>0755</fileMode>
+            <includes>
+                <include>*.sh</include>
+            </includes>
+            <lineEnding>unix</lineEnding>
+            <filtered>true</filtered>
+        </fileSet>
+        <fileSet>
+            <directory>src/main/config</directory>
+            <outputDirectory>conf</outputDirectory>
+            <directoryMode>0755</directoryMode>
+            <fileMode>0644</fileMode>
+            <includes>
+                <include>*.xml</include>
+                <include>*.properties</include>
+                <include>hadoop/*.xml</include>
+            </includes>
+            <lineEnding>unix</lineEnding>
+        </fileSet>
+        <fileSet>
+            <directory>src/main/config</directory>
+            <outputDirectory>conf</outputDirectory>
+            <directoryMode>0755</directoryMode>
+            <fileMode>0755</fileMode>
+            <includes>
+                <include>*.sh</include>
+            </includes>
+            <lineEnding>unix</lineEnding>
+        </fileSet>
+        
+        <!-- create an empty directory for log files -->
+        <fileSet>
+            <directory>src/main/assembly</directory>
+            <outputDirectory>logs</outputDirectory>
+            <directoryMode>755</directoryMode>
+            <excludes>
+                <exclude>*</exclude>
+            </excludes>
+        </fileSet>
+    </fileSets>
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>lib</outputDirectory>
+            <useTransitiveFiltering>true</useTransitiveFiltering>
+            <scope>runtime</scope>
+            <!-- exclude hadoop, zookeeper jars -->
+            <excludes>
+                <exclude>org.apache.accumulo:*</exclude>
+                <exclude>org.apache.hadoop:*</exclude>
+                <exclude>org.apache.zookeeper:*</exclude>
+            </excludes>
+        </dependencySet>
+        <dependencySet>
+            <outputDirectory>lib</outputDirectory>
+            <scope>provided</scope>
+            <includes>
+                <include>org.apache.rya:rya.periodic.notification.twill:*:twill-app</include>
+            </includes>
+        </dependencySet>
+        <dependencySet>
+            <outputDirectory>lib-ahz</outputDirectory>
+            <useTransitiveFiltering>true</useTransitiveFiltering>
+            <scope>runtime</scope>
+            <!-- store the hadoop, zookeeper jars in a specific dir -->
+            <includes>
+                <include>org.apache.accumulo:*</include>
+                <include>org.apache.hadoop:*</include>
+                <include>org.apache.zookeeper:*</include>
+            </includes>
+            <excludes>
+                <exclude>log4j:log4j</exclude> <!-- twill uses logback & slf4j. -->
+            </excludes>
+        </dependencySet>
+        
+    </dependencySets>
+</component>

--- a/extras/periodic.notification/twill.yarn/src/main/config/hadoop/core-site.xml
+++ b/extras/periodic.notification/twill.yarn/src/main/config/hadoop/core-site.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
+<configuration>
+    <property>
+        <name>fs.defaultFS</name>
+        <value>hdfs://hdfs-namenode-host:8020/</value>
+    </property>
+</configuration>

--- a/extras/periodic.notification/twill.yarn/src/main/config/hadoop/yarn-site.xml
+++ b/extras/periodic.notification/twill.yarn/src/main/config/hadoop/yarn-site.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
+<configuration>
+    <property>
+        <name>yarn.resourcemanager.hostname</name>
+        <value>yarn-resourcemanager-host</value>
+    </property>  
+</configuration>

--- a/extras/periodic.notification/twill.yarn/src/main/config/logback.xml
+++ b/extras/periodic.notification/twill.yarn/src/main/config/logback.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{48} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+        <file>logs/PeriodicNotificationApp.log</file>
+        <append>true</append>
+        <!-- encoders are assigned the type ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{48} - %msg%n</pattern>
+            <!-- set immediateFlush to false for much higher logging throughput -->
+            <immediateFlush>false</immediateFlush>
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
+
+    <logger name="org.apache.rya" level="DEBUG" />
+    <logger name="org.apache.accumulo" level="INFO" />
+    <logger name="org.apache.hadoop" level="INFO" />
+    <logger name="org.apache.fluo" level="INFO" />
+    <logger name="fluo.tx" level="INFO" />
+    <logger name="kafka" level="INFO" />
+    <logger name="org.apache.kafka" level="INFO" />
+    <logger name="org.apache.zookeeper" level="INFO" />
+    <logger name="org.apache.curator" level="INFO" />
+    <logger name="org.apache.twill" level="INFO" />
+
+    <root level="DEBUG">
+        <appender-ref ref="STDOUT" />
+        <appender-ref ref="FILE" />
+    </root>
+
+</configuration>

--- a/extras/periodic.notification/twill.yarn/src/main/config/notification.properties
+++ b/extras/periodic.notification/twill.yarn/src/main/config/notification.properties
@@ -1,0 +1,67 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# String of Accumulo authorizations.
+#accumulo.auths=
+
+# Accumulo instance name (required)
+accumulo.instance=
+
+# Accumulo user (required)
+accumulo.user=
+
+# Accumulo password (required)
+accumulo.password=
+
+# Prefix for Accumulo backed Rya instance.
+#accumulo.rya.prefix=rya_
+
+# Zookeepers for underlying Accumulo instance (required)
+accumulo.zookeepers=
+
+# Name of Fluo Application (required)
+rya.pcj.fluo.app.name=
+
+# Name of Fluo Table (required)
+rya.pcj.fluo.table.name=
+
+# Kafka Bootstrap servers for Producers and Consumers (required)
+rya.periodic.notification.kafka.bootstrap.servers=
+
+# Topic to which new Periodic Notifications are published.
+#rya.periodic.notification.kafka.topic=notifications
+
+# Client Id for notification topic.
+#rya.periodic.notification.kafka.client.id=consumer0
+
+# Group Id for notification topic.
+#rya.periodic.notification.kafka.group.id=group0
+
+# Number of threads used by coordinator.
+#rya.periodic.notification.coordinator.threads=1
+
+# Number of threads used by producer.
+#rya.periodic.notification.producer.threads=1
+
+# Number of threads used by exporter.
+#rya.periodic.notification.exporter.threads=1
+
+# Number of threads used by processor.
+#rya.periodic.notification.processor.threads=1
+
+# Number of threads used by pruner.
+#rya.periodic.notification.pruner.threads=1

--- a/extras/periodic.notification/twill.yarn/src/main/config/twill-env.sh
+++ b/extras/periodic.notification/twill.yarn/src/main/config/twill-env.sh
@@ -1,0 +1,63 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+#addToClasspath() 
+#{
+#  local dir=$1
+#  local filterRegex=$2
+
+
+#  if [ ! -d "$dir" ]; then
+#    echo "ERROR $dir does not exist or not a directory"
+#    exit 1
+#  fi
+
+#  for jar in $dir/*.jar; do
+#    if ! [[ $jar =~ $filterRegex ]]; then
+#       CLASSPATH="$CLASSPATH:$jar"
+#    fi
+#  done
+#}
+
+loadLocalAHZLibraries()
+{
+# Specify a hadoop configuration directory to use for connecting to the YARN cluster.
+# At a minimum, this directory should contain core-site.xml and yarn-site.xml.
+#HADOOP_CONF_DIR=/etc/hadoop/conf
+HADOOP_CONF_DIR=conf/hadoop
+
+# use local libraries (lib-ahz) for the classpath and append the hadoop conf directory
+TWILL_CP=lib/*:lib-ahz/*:$HADOOP_CONF_DIR
+}
+
+loadSystemAHZLibraries()
+{
+#EXCLUDE_RE="(.*log4j.*)|(.*asm.*)|(.*guava.*)|(.*gson.*)"
+#addToClasspath "$ACCUMULO_HOME/lib" $EXCLUDE_RE
+
+# or use the hadoop classpath as specified by your path's hadoop command
+# TODO add excludes for jars that should not be included
+HADOOP_CP=$(hadoop classpath)
+
+# use the 
+TWILL_CP=lib/*:$HADOOP_CP
+}
+
+# Select which method to use for resolving Accumulo, Hadoop, and Zookeeper libraries and configuration.
+loadLocalAHZLibraries
+#loadSystemAHZLibraries

--- a/extras/periodic.notification/twill.yarn/src/main/java/org/apache/rya/periodic/notification/twill/yarn/PeriodicNotificationTwillRunner.java
+++ b/extras/periodic.notification/twill.yarn/src/main/java/org/apache/rya/periodic/notification/twill/yarn/PeriodicNotificationTwillRunner.java
@@ -1,0 +1,315 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.periodic.notification.twill.yarn;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.Nullable;
+
+import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import org.apache.rya.periodic.notification.application.PeriodicNotificationApplicationConfiguration;
+import org.apache.rya.periodic.notification.twill.PeriodicNotificationTwillApp;
+import org.apache.rya.periodic.notification.twill.PeriodicNotificationTwillRunnable;
+import org.apache.twill.api.ClassAcceptor;
+import org.apache.twill.api.ResourceReport;
+import org.apache.twill.api.TwillController;
+import org.apache.twill.api.TwillRunResources;
+import org.apache.twill.api.TwillRunnerService;
+import org.apache.twill.api.logging.PrinterLogHandler;
+import org.apache.twill.yarn.YarnTwillRunnerService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParameterException;
+import com.beust.jcommander.Parameters;
+import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.Futures;
+
+/**
+ * This class is responsible for starting and stopping the {@link PeriodicNotificationTwillApp} on a Hadoop YARN cluster.
+ */
+public class PeriodicNotificationTwillRunner implements AutoCloseable {
+
+    public static final Logger LOG = LoggerFactory.getLogger(PeriodicNotificationTwillRunner.class);
+
+    private final YarnConfiguration yarnConfiguration;
+    private final TwillRunnerService twillRunner;
+    private final File configFile;
+
+    /**
+     *
+     * @param yarnZookeepers - The zookeeper connect string used by the Hadoop YARN cluster.
+     * @param configFile - The config file used by {@link PeriodicNotificationTwillApp}.  Typically notification.properties.
+     */
+    public PeriodicNotificationTwillRunner(final String yarnZookeepers, final File configFile) {
+        Preconditions.checkArgument(configFile.exists(), "Config File must exist");
+        Objects.requireNonNull(yarnZookeepers, "YARN Zookeepers must not be null.");
+        this.configFile = configFile;
+        yarnConfiguration = new YarnConfiguration();
+        twillRunner = new YarnTwillRunnerService(yarnConfiguration, yarnZookeepers);
+        twillRunner.start();
+
+        // sleep to give the YarnTwillRunnerService time to retrieve state from zookeeper
+        try {
+            Thread.sleep(1000);
+        } catch (final InterruptedException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    /**
+     * Start an instance of the {@link PeriodicNotificationTwillApp}.
+     *
+     * @param interactive - If true, this method will block until the user terminates this JVM, at which point the
+     *            {@link PeriodicNotificationTwillApp} on the YARN cluster will also be terminated. If false, this
+     *            method will return after startup.
+     */
+    public void startApp(final boolean interactive) {
+        final String yarnClasspath = yarnConfiguration.get(YarnConfiguration.YARN_APPLICATION_CLASSPATH,
+                Joiner.on(",").join(YarnConfiguration.DEFAULT_YARN_APPLICATION_CLASSPATH));
+        final List<String> applicationClassPaths = Lists.newArrayList();
+        Iterables.addAll(applicationClassPaths, Splitter.on(",").split(yarnClasspath));
+        final TwillController controller = twillRunner
+                .prepare(new PeriodicNotificationTwillApp(configFile))
+                .addLogHandler(new PrinterLogHandler(new PrintWriter(new OutputStreamWriter(System.out, StandardCharsets.UTF_8), true)))
+                .withApplicationClassPaths(applicationClassPaths)
+                //.withApplicationArguments(args)
+                //.withArguments(runnableName, args)
+                // .withBundlerClassAcceptor(new HadoopClassExcluder())
+                .start();
+
+        final ResourceReport r = getResourceReport(controller, 5, TimeUnit.MINUTES);
+        LOG.info("Received ResourceReport: {}", r);
+        LOG.info("{} started successfully!", PeriodicNotificationTwillApp.APPLICATION_NAME);
+
+        if(interactive) {
+            Runtime.getRuntime().addShutdownHook(new Thread() {
+                @Override
+                public void run() {
+                    try {
+                        Futures.getUnchecked(controller.terminate());
+                    } finally {
+                        twillRunner.stop();
+                    }
+                }
+            });
+
+            try {
+                LOG.info("{} waiting termination by user.  Type ctrl-c to terminate.", PeriodicNotificationTwillApp.class.getSimpleName());
+                controller.awaitTerminated();
+            } catch (final ExecutionException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    /**
+     * Terminates all instances of the {@link PeriodicNotificationTwillApp} on the YARN cluster.
+     */
+    public void stopApp() {
+        LOG.info("Stopping any running instances...");
+
+        int counter = 0;
+        // It is possible that we have launched multiple instances of the app.  For now, stop them all, one at a time.
+        for(final TwillController c : twillRunner.lookup(PeriodicNotificationTwillApp.APPLICATION_NAME)) {
+            final ResourceReport report = c.getResourceReport();
+            LOG.info("Attempting to stop {} with YARN ApplicationId: {} and Twill RunId: {}", PeriodicNotificationTwillApp.APPLICATION_NAME, report.getApplicationId(), c.getRunId());
+            Futures.getUnchecked(c.terminate());
+            LOG.info("Stopped {} with YARN ApplicationId: {} and Twill RunId: {}", PeriodicNotificationTwillApp.APPLICATION_NAME, report.getApplicationId(), c.getRunId());
+            counter++;
+        }
+
+        LOG.info("Stopped {} instance(s) of {}", counter, PeriodicNotificationTwillApp.APPLICATION_NAME);
+    }
+
+    /**
+     * Blocks until a non-null Resource report is returned.
+     * @param controller - The controller to interrogate.
+     * @param timeout - The maximum time to poll {@controller}.  Use -1 for infinite polling.
+     * @param timeoutUnits - The units of {@code timeout}.
+     * @return The ResourceReport for the application.
+     * @throws IllegalStateException If a timeout occurs before a ResourceReport is returned.
+     */
+    private ResourceReport getResourceReport(final TwillController controller, final long timeout, final TimeUnit timeoutUnits) {
+        Preconditions.checkArgument(timeout >= -1, "timeout cannot be less than -1");
+        final long timeoutMillis = TimeUnit.MILLISECONDS.convert(timeout, timeoutUnits);
+        final long sleepMillis = 1000; // how long to sleep between retrieval attempts.
+        long totalElapsedMillis = 0;
+        ResourceReport report = controller.getResourceReport();
+        while (reportIsLoading(report)) {
+            try {
+                Thread.sleep(sleepMillis);
+            } catch (final InterruptedException e) {
+                throw new IllegalStateException(e);
+            }
+            totalElapsedMillis += sleepMillis;
+            if ((timeout != -1) && (totalElapsedMillis >= timeoutMillis)) {
+                final String errorMessage = "Timeout while waiting for the Twill Application to start on YARN.  Total elapsed time: " + TimeUnit.SECONDS.convert(totalElapsedMillis, TimeUnit.MILLISECONDS) + "s.";
+                LOG.error(errorMessage);
+                throw new IllegalStateException(errorMessage);
+            }
+            if ((totalElapsedMillis % 5000) == 0) {
+                LOG.info("Waiting for the Twill Application to start on YARN... Total elapsed time: {}s.", TimeUnit.SECONDS.convert(totalElapsedMillis, TimeUnit.MILLISECONDS));
+            }
+            report = controller.getResourceReport();
+        }
+        return report;
+    }
+
+    /**
+     * Checks to see if the report has loaded.
+     * @param report - The {@link ResourceReport} for this Twill Application.
+     * @return Return true if the report is null or incomplete.  Return false if the report is completely loaded.
+     */
+    private boolean reportIsLoading(@Nullable final ResourceReport report) {
+        if(report == null) {
+            return true;
+        }
+
+        final String yarnApplicationID = report.getApplicationId();
+        final Collection<TwillRunResources> runnableResources = report.getResources().get(PeriodicNotificationTwillRunnable.TWILL_RUNNABLE_NAME);
+
+        if(runnableResources == null || runnableResources.isEmpty()) {
+            LOG.info("Received Resource Report for YARN ApplicationID: {}, runnable resources are still loading...", yarnApplicationID);
+            return true;
+        } else {
+            LOG.info("Received Resource Report for YARN ApplicationID: {}, runnable resources are loaded.", yarnApplicationID);
+            return false;
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        if(twillRunner != null) {
+            twillRunner.stop();
+        }
+    }
+
+    private static class MainOptions {
+        @Parameter(names = { "-c", "--config-file" }, description = "PeriodicNotification Application config file", required = true)
+        private File configFile;
+
+        @Parameter(names = { "-z", "--yarn-zookeepers" }, description = "(Optional) YARN Zookeepers connect string.  If not specified, the value of 'accumulo.zookeepers' from the specified '--config-file' will be reused.", required = false)
+        private String zookeepers;
+    }
+
+
+    @Parameters(commandNames = { "start" }, separators = "=", commandDescription = "Start the PeriodicNotification Application on YARN")
+    private static class CommandStart {
+        @Parameter(names = { "-i", "--interactive" }, description = "(Optional) Interactive.  If specified, blocks the console until the user types ctrl-c.", required = false)
+        private boolean interactive;
+
+        //TODO future feature.
+        //@Parameter(names = { "-p", "--accumulo.password"}, description = "Leave value blank to be prompted interactively for the 'accumulo.password' of the 'accumulo.user' specified by the '--config-file'", password = true, required = true)
+        //private String password;
+    }
+
+    @Parameters(commandNames = { "stop" }, commandDescription = "Stops PeriodicNotification Applications on YARN")
+    private static class CommandStop {
+        //TODO future feature.
+        //@Parameter(names = { "-a", "--all" }, description = "Stops all PeriodicNotification Application instances.", required = false)
+        //private boolean all = true;
+
+        //@Parameter(names = { "-i", "--instances"}, description = "CSV List of application instances to be stopped", required = false)
+        //private List<String> instanceList;
+    }
+
+
+    public static void main(final String[] args) {
+
+        final MainOptions options = new MainOptions();
+        final String START = "start";
+        final String STOP = "stop";
+        String parsedCommand = null;
+        final CommandStart commandStart = new CommandStart();
+        final CommandStop commandStop = new CommandStop();
+        final JCommander cli = new JCommander(options);
+        cli.addCommand(START, commandStart);
+        cli.addCommand(STOP, commandStop);
+        cli.setProgramName(PeriodicNotificationTwillRunner.class.getName());
+        try {
+            cli.parse(args);
+            parsedCommand = cli.getParsedCommand();
+            if(parsedCommand == null) {
+                throw new ParameterException("A command must be specified.");
+            }
+        } catch (final ParameterException e) {
+            System.err.println("Error! Invalid input: " + e.getMessage());
+            cli.usage();
+            System.exit(1);
+        }
+
+        // load the config file
+        PeriodicNotificationApplicationConfiguration conf = null;
+        try (FileInputStream fin = new FileInputStream(options.configFile)) {
+            final Properties p = new Properties();
+            p.load(fin);
+            conf = new PeriodicNotificationApplicationConfiguration(p);
+        } catch (final Exception e) {
+            LOG.warn("Unable to load specified properties file", e);
+            System.exit(1);
+        }
+
+        // pick the correct zookeepers
+        String zookeepers;
+        if(options.zookeepers != null && !options.zookeepers.isEmpty()) {
+            zookeepers = options.zookeepers;
+        } else {
+            zookeepers = conf.getAccumuloZookeepers();
+        }
+
+        try (final PeriodicNotificationTwillRunner app = new PeriodicNotificationTwillRunner(zookeepers, options.configFile)) {
+            if(START.equals(parsedCommand)) {
+                app.startApp(commandStart.interactive);
+            } else if(STOP.equals(parsedCommand)) {
+                app.stopApp();
+            } else {
+                throw new IllegalStateException("Invalid Command."); // this state should be impossible.
+            }
+        } catch (final Exception e) {
+            LOG.warn("Error occurred.", e);
+            System.exit(1);
+        }
+    }
+
+    static class HadoopClassExcluder extends ClassAcceptor {
+        @Override
+        public boolean accept(final String className, final URL classUrl, final URL classPathUrl) {
+            // exclude hadoop but not hbase package
+            return !(className.startsWith("org.apache.hadoop") && !className.startsWith("org.apache.hadoop.hbase"));
+        }
+    }
+}

--- a/extras/periodic.notification/twill.yarn/src/main/scripts/periodicNotificationTwillApp.sh
+++ b/extras/periodic.notification/twill.yarn/src/main/scripts/periodicNotificationTwillApp.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# navigate to the project directory
+PROJECT_HOME=$(dirname $(cd $(dirname $0) && pwd))
+cd $PROJECT_HOME
+
+# setup the twill classpath
+. conf/twill-env.sh
+
+# echo "Using classpath: $TWILL_CP"
+
+# run the program
+$JAVA_HOME/bin/java -cp $TWILL_CP \
+  -Dlogback.configurationFile=conf/logback.xml \
+  org.apache.rya.periodic.notification.twill.yarn.PeriodicNotificationTwillRunner "$@"

--- a/extras/periodic.notification/twill/README.md
+++ b/extras/periodic.notification/twill/README.md
@@ -1,0 +1,36 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+## rya.periodic.notification.twill
+
+This project serves two purposes:
+
+1) Store all `org.apache.twill:twill-api` specific code to decouple this execution 
+environment dependency from the rest of Rya's implemenation logic.  This way it 
+should be easy to integrate Rya code with alternative execution environments.
+
+2) It can be tricky to shield Twill applications from the constraints of the Twill 
+runtime environment (specifically a Guava 13.0 dependency, among potentially others).  
+By controlling the packaging of this project and leveraging the maven-shade-plugin's 
+relocation capability, we can avoid current and future classpath conflicts and allow
+for a cleaner integration with Twill than we might get with the `BundledJarRunner`
+from `org.apache.twill:twill-ext`.
+
+Note, the distribution of this twill application can be found in 
+`rya.periodic.notification.twill.yarn`.

--- a/extras/periodic.notification/twill/pom.xml
+++ b/extras/periodic.notification/twill/pom.xml
@@ -1,0 +1,177 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.rya</groupId>
+        <artifactId>rya.periodic.notification.parent</artifactId>
+        <version>3.2.12-incubating-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>rya.periodic.notification.twill</artifactId>
+
+    <name>Apache Rya Periodic Notification Service on Twill </name>
+    <description>Twill Application for executing the Apache Rya Periodic Notification Service</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <!--  redirect any other logging frameworks to slf4j within the Twill runtime -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>log4j-over-slf4j</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- 
+        <dependency>
+            <groupId>org.apache.rya</groupId>
+            <artifactId>rya.periodic.notification.api</artifactId>
+        </dependency>
+        -->
+        <dependency>
+            <groupId>org.apache.rya</groupId>
+            <artifactId>rya.periodic.notification.service</artifactId>
+            <exclusions>
+                <!--  exclude logging implementations -->
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.twill</groupId>
+            <artifactId>twill-api</artifactId>
+            <version>0.12.0</version>
+        </dependency>
+
+        <!-- Mark Accumulo Hadoop and Zookeeper as provided dependencies -->
+        <dependency>
+            <groupId>org.apache.accumulo</groupId>
+            <artifactId>accumulo-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-client</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- 
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.3.7</version>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <id>bundle</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>bundle</goal>
+                        </goals>
+                        <configuration>
+                            <classifier>bundle</classifier>
+                            <instructions>
+                                <Embed-Dependency>*;inline=false</Embed-Dependency>
+                                <Embed-Transitive>true</Embed-Transitive>
+                                <Embed-Directory>lib</Embed-Directory>
+                            </instructions>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>twill-app</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <shadedClassifierName>twill-app</shadedClassifierName>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer" />
+                            </transformers>
+                            <relocations>
+                                <!--  relocate the more modern version of guava to avoid classpath conflicts -->
+                                <relocation>
+                                    <pattern>com.google.common</pattern>
+                                    <shadedPattern>org.apache.rya.shaded.com.google.common</shadedPattern>
+                                </relocation>
+                            </relocations>
+                            <artifactSet>
+                                <excludes>
+                                    <!--  exclude logging implementations if the above exclusions/scoping don't catch them -->
+                                    <exclude>commons-logging:commons-logging</exclude>
+                                    <exclude>org.slf4j:slf4j-log4j12</exclude>
+                                    <exclude>log4j:log4j</exclude>
+                                </excludes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extras/periodic.notification/twill/src/main/java/org/apache/rya/periodic/notification/twill/PeriodicNotificationTwillApp.java
+++ b/extras/periodic.notification/twill/src/main/java/org/apache/rya/periodic/notification/twill/PeriodicNotificationTwillApp.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.periodic.notification.twill;
+
+import java.io.File;
+
+import org.apache.twill.api.ResourceSpecification;
+import org.apache.twill.api.ResourceSpecification.SizeUnit;
+import org.apache.twill.api.TwillApplication;
+import org.apache.twill.api.TwillSpecification;
+
+public class PeriodicNotificationTwillApp implements TwillApplication {
+
+
+    private final File configFile;
+    public static final String APPLICATION_NAME = PeriodicNotificationTwillApp.class.getSimpleName();
+
+    public PeriodicNotificationTwillApp(final File configFile) {
+        this.configFile = configFile;
+    }
+
+    @Override
+    public TwillSpecification configure() {
+        return TwillSpecification.Builder.with()
+                .setName(APPLICATION_NAME)
+                .withRunnable()
+                    .add(PeriodicNotificationTwillRunnable.TWILL_RUNNABLE_NAME,
+                            new PeriodicNotificationTwillRunnable(),
+                            ResourceSpecification.Builder.with()
+                                .setVirtualCores(2)
+                                .setMemory(2, SizeUnit.GIGA)
+                                .setInstances(1)
+                                .build())
+                    .withLocalFiles()
+                    .add(PeriodicNotificationTwillRunnable.CONFIG_FILE_NAME, configFile)
+                    .apply()
+                .anyOrder()
+                .build();
+    }
+
+}

--- a/extras/periodic.notification/twill/src/main/java/org/apache/rya/periodic/notification/twill/PeriodicNotificationTwillRunnable.java
+++ b/extras/periodic.notification/twill/src/main/java/org/apache/rya/periodic/notification/twill/PeriodicNotificationTwillRunnable.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.periodic.notification.twill;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+
+import org.apache.rya.periodic.notification.application.PeriodicApplicationException;
+import org.apache.rya.periodic.notification.application.PeriodicNotificationApplication;
+import org.apache.rya.periodic.notification.application.PeriodicNotificationApplicationConfiguration;
+import org.apache.rya.periodic.notification.application.PeriodicNotificationApplicationFactory;
+import org.apache.twill.api.AbstractTwillRunnable;
+import org.apache.twill.api.Command;
+import org.apache.twill.api.TwillContext;
+import org.apache.twill.api.TwillRunnable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class PeriodicNotificationTwillRunnable extends AbstractTwillRunnable {
+
+    private static final Logger logger = LoggerFactory.getLogger(PeriodicNotificationTwillRunnable.class);
+
+    public static final String TWILL_RUNNABLE_NAME = PeriodicNotificationTwillRunnable.class.getSimpleName();
+    public static final String CONFIG_FILE_NAME = "notification.properties";
+
+    private PeriodicNotificationApplication app;
+
+    /**
+     * Called when the container process starts. Executed in container machine. If any exception is thrown from this
+     * method, this runnable won't get retry.
+     *
+     * @param context Contains information about the runtime context.
+     */
+    @Override
+    public void initialize(final TwillContext context) {
+        logger.info("Initializing the PeriodicNotificationApplication.");
+
+        final File propsFile = new File(CONFIG_FILE_NAME);
+        final PeriodicNotificationApplicationConfiguration conf;
+        try (final FileInputStream fin = new FileInputStream(propsFile)) {
+            final Properties p = new Properties();
+            p.load(fin);
+            logger.debug("Loaded properties: {}", p);
+            conf = new PeriodicNotificationApplicationConfiguration(p);
+        } catch (final Exception e) {
+            logger.error("Error loading notification properties", e);
+            throw new RuntimeException(e); // kill the Runnable
+        }
+
+        try {
+            this.app = PeriodicNotificationApplicationFactory.getPeriodicApplication(conf);
+        } catch (final PeriodicApplicationException e) {
+            logger.error("Error occurred creating PeriodicNotificationApplication", e);
+            throw new RuntimeException(e);  // kill the Runnable
+        }
+    }
+
+    /**
+     * Called when a command is received. A normal return denotes the command has been processed successfully, otherwise
+     * {@link Exception} should be thrown.
+     * @param command Contains details of the command.
+     * @throws Exception
+     */
+    @Override
+    public void handleCommand(final Command command) throws Exception {
+        // no-op
+    }
+
+    @Override
+    public void run() {
+        logger.info("Starting up the PeriodicNotificationApplication.");
+        app.start();
+        try {
+            logger.info("Blocking thread termination until the PeriodicNotificationApplication is stopped.");
+            app.blockUntilFinished();
+        } catch (IllegalStateException | ExecutionException | InterruptedException e) {
+            logger.error("An error occurred while blocking on the PeriodicNotificationApplication", e);
+        }
+        logger.info("Exiting the PeriodicNotificationApplication.");
+    }
+
+    /**
+     * Requests to stop the running service.
+     */
+    @Override
+    public void stop() {
+        logger.info("Stopping the PeriodicNotificationApplication...");
+        app.stop();
+    }
+
+    /**
+     * Called when the {@link TwillRunnable#run()} completed. Useful for doing
+     * resource cleanup. This method would only get called if the call to {@link #initialize(TwillContext)} was
+     * successful.
+     */
+    @Override
+    public void destroy() {
+        // no-op
+    }
+}

--- a/extras/rya.benchmark/README.md
+++ b/extras/rya.benchmark/README.md
@@ -1,0 +1,77 @@
+<!-- 
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License. 
+-->
+
+Benchmark Optimizations
+
+
+## KafkaLatencyBenchmark
+
+Several strategies for partitioning the rya_pcj_updater table.  If other tablet start hot spotting, they can be further split similar to how `STATEMENT_PATTERN_` is shown.
+```
+addsplits AGGREGATION_ JOIN_ PROJECTION_ QUERY_ STATEMENT_PATTERN_ urn -t rya_pcj_updater
+
+# or
+addsplits AGGREGATION_ JOIN_ PROJECTION_ QUERY_ STATEMENT_PATTERN_0 STATEMENT_PATTERN_4 STATEMENT_PATTERN_8 STATEMENT_PATTERN_c urn -t rya_pcj_updater
+
+# or
+addsplits AGGREGATION_ JOIN_ PROJECTION_ QUERY_ STATEMENT_PATTERN_0 STATEMENT_PATTERN_1 STATEMENT_PATTERN_2 STATEMENT_PATTERN_3 STATEMENT_PATTERN_4 STATEMENT_PATTERN_5 STATEMENT_PATTERN_6 STATEMENT_PATTERN_7 STATEMENT_PATTERN_8 STATEMENT_PATTERN_9 STATEMENT_PATTERN_a STATEMENT_PATTERN_b STATEMENT_PATTERN_c STATEMENT_PATTERN_d STATEMENT_PATTERN_e STATEMENT_PATTERN_f urn -t rya_pcj_updater
+
+# then ensure the splits have been applied.
+compact -t rya_pcj_updater
+```
+
+It is also possible to lower the table's split threshold to generate more tablets.
+```
+root@accumulo> config -t rya_pcj_updater -s table.split.threshold=100M
+```
+
+Identify which tablets are on what hosts and what particular data you might be 
+hotspotting on.  Note that the tablet splits are ordered lexicographically, and 
+the split point is exclusive.  So the tablet that contains AGGREGATION_ data is
+ actually contained on the tablet with the split point label: 4qn;JOIN_.
+```
+root@accumulo> tables -l
+...
+rya_osp       =>       4qr
+rya_pcj_updater =>       4qn
+rya_po        =>       4qq
+...
+
+root@accumulo> scan -t accumulo.metadata -b 4qn; -e 4qn< -c loc
+4qn;AGGREGATION_ loc:25e09c3a40b000e []    10.10.10.10:9997
+4qn;JOIN_ loc:45e09c3a2260012 []    10.10.10.11:9997
+4qn;PROJECTION_ loc:55e09c3a2cf0014 []    10.10.10.12:9997
+4qn;QUERY_ loc:35e09c3a2080021 []    10.10.10.13:9997
+4qn;STATEMENT_PATTERN_0 loc:16e09c3a436001d []    10.10.10.14:9997
+4qn;STATEMENT_PATTERN_4 loc:17e09c3a436001d []    10.10.10.15:9997
+4qn;STATEMENT_PATTERN_8 loc:18e09c3a436001d []    10.10.10.16:9997
+4qn;STATEMENT_PATTERN_c loc:19e09c3a436001d []    10.10.10.17:9997
+4qn;urn loc:15e09c3a4360019 []    10.10.10.18:9997
+4qn< loc:55e09c3a2cf0012 []    10.10.10.19:9997
+```
+
+Use the `RegexGroupBalancer` to ensure all STATEMENT_PATTERN_x tablets are evenly distributed between all available tablet servers.  This distribution strategy will also apply to other groups that are specified in the regex.
+```
+root@accumulo> config -t rya_pcj_updater -s table.custom.balancer.group.regex.pattern=(AGGREGATION_|JOIN_|PROJECTION_|QUERY_|STATEMENT_PATTERN_|urn).*
+#root@accumulo> config -t rya_pcj_updater -s table.custom.balancer.group.regex.default=AGGREGATION_
+root@accumulo> config -t rya_pcj_updater -s table.balancer=org.apache.accumulo.server.master.balancer.RegexGroupBalancer
+```
+References:  
+https://blogs.apache.org/accumulo/entry/balancing_groups_of_tablets  
+https://reviews.apache.org/r/29230/diff/2#index_header

--- a/extras/rya.benchmark/pom.xml
+++ b/extras/rya.benchmark/pom.xml
@@ -55,6 +55,13 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
+        
+        <!-- Fluo runtime dependency -->
+        <dependency>
+            <groupId>org.apache.fluo</groupId>
+            <artifactId>fluo-core</artifactId>
+            <scope>runtime</scope>
+        </dependency>
 
         <!-- Testing -->
         <dependency>
@@ -140,7 +147,6 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
-                            <finalName>benchmarks</finalName>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>org.openjdk.jmh.Main</mainClass>
@@ -160,6 +166,23 @@
                                     </excludes>
                                 </filter>
                             </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>create-binary-distribution</id>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>src/main/assembly/binary-release.xml</descriptor>
+                            </descriptors>
                         </configuration>
                     </execution>
                 </executions>

--- a/extras/rya.benchmark/src/main/assembly/binary-release.xml
+++ b/extras/rya.benchmark/src/main/assembly/binary-release.xml
@@ -1,0 +1,33 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<assembly
+    xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+    <id>bin</id>
+    <formats>
+        <format>tar.gz</format>
+    </formats>
+    <includeBaseDirectory>true</includeBaseDirectory>
+    <componentDescriptors>
+        <componentDescriptor>src/main/assembly/component-release.xml</componentDescriptor>
+    </componentDescriptors>
+</assembly>

--- a/extras/rya.benchmark/src/main/assembly/component-release.xml
+++ b/extras/rya.benchmark/src/main/assembly/component-release.xml
@@ -1,0 +1,81 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<component
+    xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/component/1.1.3"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/component/1.1.3 http://maven.apache.org/xsd/component-1.1.3.xsd">
+    <fileSets>
+        <fileSet>
+            <directory>src/main/config</directory>
+            <outputDirectory>conf</outputDirectory>
+            <directoryMode>0755</directoryMode>
+            <fileMode>0644</fileMode>
+            <lineEnding>unix</lineEnding>
+            <filtered>false</filtered>
+            <includes>
+                <include>*.options</include>
+                <include>*.properties</include>
+            </includes>
+        </fileSet>
+        <fileSet>
+            <directory>src/main/scripts</directory>
+            <outputDirectory>bin</outputDirectory>
+            <directoryMode>0755</directoryMode>
+            <fileMode>0755</fileMode>
+            <includes>
+                <include>*.sh</include>
+            </includes>
+            <lineEnding>unix</lineEnding>
+            <filtered>true</filtered>
+        </fileSet>
+        <fileSet>
+            <directory>src/main/scripts</directory>
+            <outputDirectory>bin</outputDirectory>
+            <directoryMode>0755</directoryMode>
+            <fileMode>0644</fileMode>
+            <includes>
+                <include>*.bat</include>
+            </includes>
+            <lineEnding>dos</lineEnding>
+            <filtered>true</filtered>
+        </fileSet>
+
+        <!-- create an empty directory for log files -->
+        <fileSet>
+            <directory>src/main/assembly</directory>
+            <outputDirectory>logs</outputDirectory>
+            <directoryMode>755</directoryMode>
+            <excludes>
+                <exclude>*</exclude>
+            </excludes>
+        </fileSet>
+
+        <fileSet>
+            <directory>${project.build.directory}</directory>
+            <outputDirectory>lib</outputDirectory>
+            <directoryMode>755</directoryMode>
+            <fileMode>0644</fileMode>
+            <includes>
+                <include>${project.artifactId}-${project.version}-shaded.jar</include>
+            </includes>
+        </fileSet>
+    </fileSets>
+</component>

--- a/extras/rya.benchmark/src/main/config/common.options
+++ b/extras/rya.benchmark/src/main/config/common.options
@@ -1,0 +1,44 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# This file contains example configuration values and should
+# be modified to target your Rya/Kafka environment.
+
+--zookeepers
+zoo1,zoo2,zoo3,zoo4,zoo5
+
+--kafka-bootstrap-servers
+kafka1:9092,kafka2:9092
+
+--accumulo-instance
+accumuloInstance
+
+--rya-instance
+rya_
+
+--username
+accumuloUser
+
+# specifying --password here prompts the user to enter 
+# the accumulo password interactively on the shell
+--password
+
+# local directory for storing benchmark output
+--output-directory
+results

--- a/extras/rya.benchmark/src/main/config/log4j.properties
+++ b/extras/rya.benchmark/src/main/config/log4j.properties
@@ -1,0 +1,41 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Valid levels:
+# TRACE, DEBUG, INFO, WARN, ERROR and FATAL
+log4j.rootCategory=INFO, CONSOLE, LOGFILE
+
+# CONSOLE is set to be a ConsoleAppender using a PatternLayout.
+log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
+#log4j.appender.CONSOLE.layout.ConversionPattern=[%p] %m%n
+log4j.appender.CONSOLE.layout.ConversionPattern=%d [%t] %-5p %c %x - %m%n
+
+# LOGFILE is set to be a File appender using a PatternLayout.
+log4j.appender.LOGFILE=org.apache.log4j.FileAppender
+log4j.appender.LOGFILE.File=logs/benchmark.log
+#log4j.appender.LOGFILE.Threshold=DEBUG
+log4j.appender.LOGFILE.Append=true
+
+log4j.appender.LOGFILE.layout=org.apache.log4j.PatternLayout
+log4j.appender.LOGFILE.layout.ConversionPattern=%d [%t] %-5p %c - %m%n
+
+#log4j.appender.LOGFILE.layout=org.apache.log4j.EnhancedPatternLayout
+#log4j.appender.LOGFILE.layout.ConversionPattern=%d [%t] %-5p %c{1.} - %m%n
+

--- a/extras/rya.benchmark/src/main/config/periodic.options
+++ b/extras/rya.benchmark/src/main/config/periodic.options
@@ -1,0 +1,49 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+--ingest-iterations
+1000
+
+--ingest-observations-per-type
+10
+
+--ingest-types
+5
+
+--ingest-type-prefix
+car_
+
+--ingest-period-sec
+30
+
+--report-period-sec
+10
+
+--periodic-query-window
+15
+
+#every 30 seconds
+--periodic-query-period
+.5
+
+--periodic-query-time-units
+minutes
+
+--periodic-query-registration-topic
+notifications

--- a/extras/rya.benchmark/src/main/config/projection.options
+++ b/extras/rya.benchmark/src/main/config/projection.options
@@ -1,0 +1,36 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+--ingest-iterations
+1000
+
+--ingest-observations-per-type
+10
+
+--ingest-types
+5
+
+--ingest-type-prefix
+car_
+
+--ingest-period-sec
+30
+
+--report-period-sec
+10

--- a/extras/rya.benchmark/src/main/java/org/apache/rya/benchmark/periodic/BenchmarkOptions.java
+++ b/extras/rya.benchmark/src/main/java/org/apache/rya/benchmark/periodic/BenchmarkOptions.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.benchmark.periodic;
+
+import com.beust.jcommander.Parameter;
+import com.google.common.base.Objects;
+
+public class BenchmarkOptions {
+    @Parameter(names = { "-ii", "--ingest-iterations" }, description = "Number of ingest iterations.  Total data published is -i x -obs x -t", required = true)
+    private int numIterations;
+
+    @Parameter(names = { "-iobs", "--ingest-observations-per-type" }, description = "Observations per Type per Iteration to generate.", required = true)
+    private int observationsPerTypePerIteration;
+
+    @Parameter(names = { "-it", "--ingest-types" }, description = "The number of unique types to generate.", required = true)
+    private int numTypes;
+
+    @Parameter(names = { "-itp", "--ingest-type-prefix" }, description = "The prefix to use for a type, for example 'car_'", required = true)
+    private String typePrefix;
+
+    @Parameter(names = { "-ip", "--ingest-period-sec" }, description = "The period, in seconds between ingests of the data generated for one iteration.", required = true)
+    private int ingestPeriodSeconds;
+
+    @Parameter(names = { "-rp", "--report-period-sec" }, description = "The period, in seconds between persisting reports of the current state.", required = true)
+    private int resultPeriodSeconds;
+
+    public int getNumIterations() {
+        return numIterations;
+    }
+
+    public int getObservationsPerTypePerIteration() {
+        return observationsPerTypePerIteration;
+    }
+
+    public int getNumTypes() {
+        return numTypes;
+    }
+
+    public String getTypePrefix() {
+        return typePrefix;
+    }
+
+    public int getIngestPeriodSeconds() {
+        return ingestPeriodSeconds;
+    }
+
+    public int getResultPeriodSeconds() {
+        return resultPeriodSeconds;
+    }
+
+    @Override
+    public String toString() {
+        return Objects.toStringHelper(this)
+                .add("numIterations", numIterations)
+                .add("observationsPerTypePerIteration", observationsPerTypePerIteration)
+                .add("numTypes", numTypes)
+                .add("typePrefix", typePrefix)
+                .add("ingestPeriodSeconds", ingestPeriodSeconds)
+                .add("resultPeriodSeconds", resultPeriodSeconds)
+                .toString();
+    }
+}

--- a/extras/rya.benchmark/src/main/java/org/apache/rya/benchmark/periodic/BenchmarkStatementGenerator.java
+++ b/extras/rya.benchmark/src/main/java/org/apache/rya/benchmark/periodic/BenchmarkStatementGenerator.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.benchmark.periodic;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import javax.xml.datatype.DatatypeConfigurationException;
+import javax.xml.datatype.DatatypeFactory;
+
+import org.openrdf.model.Literal;
+import org.openrdf.model.Statement;
+import org.openrdf.model.ValueFactory;
+import org.openrdf.model.impl.ValueFactoryImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Lists;
+
+/**
+ * Generates sets of statements used for benchmarking
+ */
+public class BenchmarkStatementGenerator {
+
+    private static final Logger logger = LoggerFactory.getLogger(BenchmarkStatementGenerator.class);
+
+    private final ValueFactory vf;
+    private final DatatypeFactory dtf;
+
+    public BenchmarkStatementGenerator() throws DatatypeConfigurationException {
+        vf = new ValueFactoryImpl();
+        dtf = DatatypeFactory.newInstance();
+    }
+
+    /**
+     * Generates (numObservationsPerType x numTypes) statements of the form:
+     *
+     * <pre>
+     * urn:obs_n uri:hasTime zonedTime
+     * urn:obs_n uri:hasObsType typePrefix_m
+     * </pre>
+     *
+     * Where the n in urn:obs_n is the ith value in 0 to (numObservationsPerType x numTypes) with an offset specified by
+     * observationOffset, and where m in typePrefix_m is the jth value in 0 to numTypes.
+     *
+     * @param numObservationsPerType - The quantity of observations per type to generate.
+     * @param numTypes - The number of types to generate observations for.
+     * @param typePrefix - The prefix to be used for the type literal in the statement.
+     * @param observationOffset - The offset to be used for determining the value of n in the above statements.
+     * @param zonedTime - The time to be used for all observations generated.
+     * @return A new list of all generated Statements.
+     */
+    public List<Statement> generate(final long numObservationsPerType, final int numTypes, final String typePrefix, final long observationOffset, final ZonedDateTime zonedTime) {
+        final String time = zonedTime.format(DateTimeFormatter.ISO_INSTANT);
+        final Literal litTime = vf.createLiteral(dtf.newXMLGregorianCalendar(time));
+        final List<Statement> statements = Lists.newArrayList();
+
+        for (long i = 0; i < numObservationsPerType; i++) {
+            for(int j = 0; j < numTypes; j++) {
+                final long observationId = observationOffset + i*numTypes + j;
+                //final String obsId = "urn:obs_" + Long.toHexString(observationId)  + "_" + observationId;
+                //final String obsId = "urn:obs_" + observationId;
+                final String obsId = "urn:obs_" + String.format("%020d", observationId);
+                final String type = typePrefix + j;
+                //logger.info(obsId + " " + type + " " + litTime);
+                statements.add(vf.createStatement(vf.createURI(obsId), vf.createURI("uri:hasTime"), litTime));
+                statements.add(vf.createStatement(vf.createURI(obsId), vf.createURI("uri:hasObsType"), vf.createLiteral(type)));
+            }
+        }
+
+        return statements;
+    }
+}

--- a/extras/rya.benchmark/src/main/java/org/apache/rya/benchmark/periodic/CommonOptions.java
+++ b/extras/rya.benchmark/src/main/java/org/apache/rya/benchmark/periodic/CommonOptions.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.benchmark.periodic;
+
+import java.io.File;
+import java.util.Properties;
+import java.util.UUID;
+
+import org.apache.accumulo.core.client.AccumuloException;
+import org.apache.accumulo.core.client.AccumuloSecurityException;
+import org.apache.accumulo.core.client.Instance;
+import org.apache.accumulo.core.client.ZooKeeperInstance;
+import org.apache.accumulo.core.client.security.tokens.PasswordToken;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.rya.api.client.RyaClient;
+import org.apache.rya.api.client.accumulo.AccumuloConnectionDetails;
+import org.apache.rya.api.client.accumulo.AccumuloRyaClientFactory;
+
+import com.beust.jcommander.Parameter;
+import com.google.common.base.Objects;
+
+public class CommonOptions {
+
+    @Parameter(names = { "-u", "--username" }, description = "Accumulo Username", required = true)
+    private String username;
+
+    @Parameter(names = { "-p", "--password" }, description = "Accumulo Password", required = true, password=true)
+    private String password;
+
+    @Parameter(names = { "-ai", "--accumulo-instance" }, description = "Accumulo Instance", required = true)
+    private String accumuloInstance;
+
+    @Parameter(names = { "-ri", "--rya-instance" }, description = "Rya Instance", required = true)
+    private String ryaInstance;
+
+    @Parameter(names = { "-z", "--zookeepers" }, description = "Accumulo Zookeepers", required = true)
+    private String zookeepers;
+
+    @Parameter(names = { "-k", "--kafka-bootstrap-servers" }, description = "Kafka bootstrap server string, for example: kafka1:9092,kafka2:9092", required = true)
+    private String kafkaBootstrap;
+
+    @Parameter(names = { "-o", "--output-directory" }, description = "The directory that output should be persisted to.", required = true)
+    private File outputDirectory;
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getAccumuloInstance() {
+        return accumuloInstance;
+    }
+
+    public String getRyaInstance() {
+        return ryaInstance;
+    }
+
+    public String getZookeepers() {
+        return zookeepers;
+    }
+
+    public String getKafkaBootstrap() {
+        return kafkaBootstrap;
+    }
+
+    public File getOutputDirectory() {
+        return outputDirectory;
+    }
+
+    public RyaClient buildRyaClient() throws AccumuloException, AccumuloSecurityException {
+        final Instance instance = new ZooKeeperInstance(accumuloInstance, zookeepers);
+        final AccumuloConnectionDetails accumuloDetails = new AccumuloConnectionDetails(username, password.toCharArray(), accumuloInstance, zookeepers);
+        return AccumuloRyaClientFactory.build(accumuloDetails, instance.getConnector(username, new PasswordToken(password)));
+    }
+
+    public Properties getKafkaConsumerProperties() {
+        final Properties consumerProps = new Properties();
+        consumerProps.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaBootstrap);
+        consumerProps.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, UUID.randomUUID().toString());
+        consumerProps.setProperty(ConsumerConfig.GROUP_ID_CONFIG, UUID.randomUUID().toString());
+        consumerProps.setProperty(ConsumerConfig.METADATA_MAX_AGE_CONFIG, "5000");  // reduce this value to 5 seconds for the scenario where we subscribe before the topic exists.
+        consumerProps.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        return consumerProps;
+    }
+
+    @Override
+    public String toString() {
+        return Objects.toStringHelper(this)
+                .add("username", username)
+                .add("password", "[redacted]")
+                .add("accumuloInstance", accumuloInstance)
+                .add("ryaInstance", ryaInstance)
+                .add("zookeepers", zookeepers)
+                .add("kafkaBootstrap", kafkaBootstrap)
+                .add("outputDirectory", outputDirectory)
+                .toString();
+    }
+}

--- a/extras/rya.benchmark/src/main/java/org/apache/rya/benchmark/periodic/KafkaLatencyBenchmark.java
+++ b/extras/rya.benchmark/src/main/java/org/apache/rya/benchmark/periodic/KafkaLatencyBenchmark.java
@@ -1,0 +1,445 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.benchmark.periodic;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.List;
+import java.util.LongSummaryStatistics;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import javax.xml.datatype.DatatypeConfigurationException;
+
+import org.apache.accumulo.core.client.AccumuloException;
+import org.apache.accumulo.core.client.AccumuloSecurityException;
+import org.apache.commons.io.FileUtils;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.rya.api.client.CreatePCJ.ExportStrategy;
+import org.apache.rya.api.client.InstanceDoesNotExistException;
+import org.apache.rya.api.client.LoadStatements;
+import org.apache.rya.api.client.RyaClient;
+import org.apache.rya.api.client.RyaClientException;
+import org.apache.rya.indexing.pcj.fluo.app.export.kafka.KryoVisibilityBindingSetSerializer;
+import org.apache.rya.indexing.pcj.storage.accumulo.VisibilityBindingSet;
+import org.apache.rya.periodic.notification.serialization.BindingSetSerDe;
+import org.openrdf.model.Statement;
+import org.openrdf.query.BindingSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.ParameterException;
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+/**
+ * This benchmark is useful for determining the performance characteristics of a Rya Triplestore under continuous ingest
+ * that has a PCJ Query that is incrementally updated by the Rya PCJ Fluo App (aka PCJ Updater).
+ * <p>
+ * This benchmark periodically loads a batch of data into Rya and reports the delay of the following query
+ *
+ * <pre>
+ * PREFIX time: &lt;http://www.w3.org/2006/time#&gt;
+ * SELECT ?type (count(?obs) as ?total)
+ * WHERE {
+ *   ?obs &lt;uri:hasTime&gt; ?time .
+ *   ?obs &lt;uri:hasObsType&gt; ?type .
+ * }
+ * GROUP BY ?type
+ * </pre>
+ * <p>
+ * This benchmark is useful for characterizing any latency between Truth (data ingested to Rya) and Reported (query
+ * result published to Kafka).
+ * <p>
+ * This benchmark is also useful for stress testing a Fluo App configuration and Accumulo Tablet configuration.
+ * <p>
+ * This benchmark expects the provided RyaInstance to have already been constructed and an appropriately configured Rya
+ * PCJ Fluo App for that RyaInstance to be deployed on your YARN cluster.
+ */
+public class KafkaLatencyBenchmark implements AutoCloseable {
+
+    public static final Logger logger = LoggerFactory.getLogger(KafkaLatencyBenchmark.class);
+
+    /**
+     * Data structure for storing Type
+     */
+    private final Map<String, Stat> typeToStatMap = Maps.newTreeMap();
+
+    /**
+     * ThreadPool for publishing data and logging stats.
+     */
+    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(20);
+
+    private final CommonOptions options;
+    private final BenchmarkOptions benchmarkOptions;
+    private final RyaClient client;
+    DateTimeFormatter fsFormatter = DateTimeFormatter.ofPattern( "uuuu-MM-dd'T'HH-mm-ss" );
+    private final LocalDateTime startTime;
+    List<ScheduledFuture<?>> futureList = Lists.newArrayList();
+
+    public KafkaLatencyBenchmark(final CommonOptions options, final BenchmarkOptions benchmarkOptions) throws AccumuloException, AccumuloSecurityException {
+        this.options = Objects.requireNonNull(options);
+        this.benchmarkOptions = Objects.requireNonNull(benchmarkOptions);
+        this.client = Objects.requireNonNull(options.buildRyaClient());
+        this.startTime = LocalDateTime.now();
+
+        logger.info("Running {} with the following input parameters:\n{}\n{}", this.getClass(), options, benchmarkOptions);
+    }
+
+    @Override
+    public void close() throws Exception {
+        logger.info("Stopping threads.");
+        scheduler.shutdown();
+
+        cancelAllScheduledTasks();
+        logger.info("Waiting for all threads to terminate...");
+        scheduler.awaitTermination(1, TimeUnit.DAYS);
+        logger.info("All threads terminated.");
+    }
+
+    private void cancelAllScheduledTasks() {
+        logger.info("Canceling all tasks");
+        for(final ScheduledFuture<?> task : futureList) {
+            task.cancel(false);
+        }
+        futureList.clear();
+    }
+
+
+    public void start() throws InstanceDoesNotExistException, RyaClientException {
+        logger.info("Issuing Query");
+        String topic;
+        boolean periodic;
+        if(benchmarkOptions instanceof PeriodicQueryCommand) {
+            topic = issuePeriodicQuery((PeriodicQueryCommand) benchmarkOptions);
+            periodic = true;
+        } else {
+            topic = issueQuery();
+            periodic = false;
+        }
+        logger.info("Query Issued. Received PCJ ID: {}", topic);
+        startDataIngestTask();
+        startStatsPrinterTask();
+        startCsvPrinterTask();
+
+        if(periodic) {
+            updatePeriodicStatsFromKafka(topic);  // blocking operation.
+        } else {
+            updateStatsFromKafka(topic);  // blocking operation.
+        }
+
+    }
+
+    private String issueQuery() throws InstanceDoesNotExistException, RyaClientException {
+        final String sparql = "prefix time: <http://www.w3.org/2006/time#> "
+                + "select ?type (count(?obs) as ?total) where { "
+                + "    ?obs <uri:hasTime> ?time. "
+                + "    ?obs <uri:hasObsType> ?type "
+                + "} "
+                + "group by ?type";
+
+        logger.info("Query: {}", sparql);
+        return client.getCreatePCJ().createPCJ(options.getRyaInstance(), sparql, ImmutableSet.of(ExportStrategy.KAFKA));
+    }
+
+    private String issuePeriodicQuery(final PeriodicQueryCommand periodicOptions) throws InstanceDoesNotExistException, RyaClientException {
+        final String sparql = "prefix function: <http://org.apache.rya/function#> "
+                + "prefix time: <http://www.w3.org/2006/time#> "
+                + "select ?type (count(?obs) as ?total) where {"
+                + "Filter(function:periodic(?time, " +  periodicOptions.getPeriodicQueryWindow() + ", " + periodicOptions.getPeriodicQueryPeriod() + ", time:" + periodicOptions.getPeriodicQueryTimeUnits() + ")) "
+                + "?obs <uri:hasTime> ?time. "
+                + "?obs <uri:hasObsType> ?type } "
+                + "group by ?type";
+        logger.info("Query: {}", sparql);
+        final String queryId = client.getCreatePeriodicPCJ().createPeriodicPCJ(options.getRyaInstance(), sparql, periodicOptions.getPeriodicQueryRegistrationTopic(), options.getKafkaBootstrap());
+        logger.info("Received query id: {}", queryId);
+        return queryId.substring("QUERY_".length());  // remove the QUERY_ prefix.
+    }
+
+
+    private void startDataIngestTask() {
+        final int initialPublishDelaySeconds = 1;
+
+        final LoadStatements loadCommand = client.getLoadStatements();
+
+        // initialize the stats map
+        for(int typeId = 0; typeId < benchmarkOptions.getNumTypes(); typeId++) {
+            final String type = benchmarkOptions.getTypePrefix() + typeId;
+            typeToStatMap.put(type, new Stat(type));
+        }
+
+        final LoaderTask loaderTask = new LoaderTask(benchmarkOptions.getNumIterations(),
+                benchmarkOptions.getObservationsPerTypePerIteration(), benchmarkOptions.getNumTypes(),
+                benchmarkOptions.getTypePrefix(), loadCommand, options.getRyaInstance());
+
+        final ScheduledFuture<?> loaderTaskFuture = scheduler.scheduleAtFixedRate(loaderTask, initialPublishDelaySeconds, benchmarkOptions.getIngestPeriodSeconds(), TimeUnit.SECONDS);
+        futureList.add(loaderTaskFuture);
+
+        loaderTask.setShutdownOperation(() -> {
+            cancelAllScheduledTasks();
+        });
+    }
+
+    private void startStatsPrinterTask() {
+        final Runnable statLogger = () -> {
+            final StringBuilder sb = new StringBuilder();
+            sb.append("Results\n");
+            for(final Stat s : typeToStatMap.values()) {
+                sb.append(s).append("\n");
+            }
+            logger.info("{}",sb);
+        };
+
+        final int initialPrintDelaySeconds = 11;
+
+        final ScheduledFuture<?> statLoggerFuture = scheduler.scheduleAtFixedRate(statLogger, initialPrintDelaySeconds, benchmarkOptions.getResultPeriodSeconds(), TimeUnit.SECONDS);
+        futureList.add(statLoggerFuture);
+    }
+
+    private void startCsvPrinterTask() {
+
+        final int initialPrintDelaySeconds = 11;
+        final long printPeriodSeconds = benchmarkOptions.getResultPeriodSeconds();
+
+        final Runnable csvPrinterTask = new Runnable() {
+            private final AtomicInteger printCounter = new AtomicInteger(0);
+            private final File outFile = new File(options.getOutputDirectory(), "run-" + fsFormatter.format(startTime) + ".csv");
+
+            @Override
+            public void run() {
+                final int count = printCounter.getAndIncrement();
+                final StringBuilder sb = new StringBuilder();
+                if(count == 0) {
+                    sb.append("elapsed-seconds");
+                    for(final Stat s : typeToStatMap.values()) {
+                      sb.append(",").append(s.getCsvStringHeader());
+                    }
+                    sb.append("\n");
+                }
+
+                sb.append(count*printPeriodSeconds);
+                for(final Stat s : typeToStatMap.values()) {
+                    sb.append(",").append(s.getCsvString());
+                }
+                sb.append("\n");
+                try {
+                    FileUtils.write(outFile, sb.toString(), StandardCharsets.UTF_8, true);
+                } catch (final IOException e) {
+                    logger.warn("Error writing to file " + outFile, e);
+                }
+            }
+        };
+
+        final ScheduledFuture<?> csvPrinterFuture = scheduler.scheduleAtFixedRate(csvPrinterTask, initialPrintDelaySeconds, printPeriodSeconds, TimeUnit.SECONDS);
+        futureList.add(csvPrinterFuture);
+    }
+
+
+
+    private void updateStatsFromKafka(final String topic) {
+        try (KafkaConsumer<String, VisibilityBindingSet> consumer = new KafkaConsumer<>(options.getKafkaConsumerProperties(), new StringDeserializer(), new KryoVisibilityBindingSetSerializer())) {
+            consumer.subscribe(Arrays.asList(topic));
+            while (!futureList.isEmpty()) {
+                final ConsumerRecords<String, VisibilityBindingSet> records = consumer.poll(500);  // check kafka at most twice a second.
+                handle(records);
+            }
+        } catch (final Exception e) {
+            logger.warn("Exception occurred", e);
+        }
+    }
+
+    private void updatePeriodicStatsFromKafka(final String topic) {
+        try (KafkaConsumer<String, BindingSet> consumer = new KafkaConsumer<>(options.getKafkaConsumerProperties(), new StringDeserializer(), new BindingSetSerDe())) {
+            consumer.subscribe(Arrays.asList(topic));
+            while (!futureList.isEmpty()) {
+                final ConsumerRecords<String, BindingSet> records = consumer.poll(500);  // check kafka at most twice a second.
+                handle(records);
+            }
+        } catch (final Exception e) {
+            logger.warn("Exception occurred", e);
+        }
+    }
+
+    private void handle(final ConsumerRecords<String, ? extends BindingSet> records) {
+        if(records.count() > 0) {
+            logger.debug("Received {} records", records.count());
+        }
+        for(final ConsumerRecord<String, ? extends BindingSet> record: records){
+            final BindingSet result = record.value();
+            logger.debug("Received BindingSet: {}", result);
+
+            final String type = result.getBinding("type").getValue().stringValue();
+            final long total = Long.parseLong(result.getBinding("total").getValue().stringValue());
+
+            final Stat stat = typeToStatMap.get(type);
+            if(stat == null) {
+                logger.warn("Not expecting to receive type: {}", type);
+            } else {
+                stat.fluoTotal.set(total);
+            }
+        }
+    }
+
+    private class LoaderTask implements Runnable {
+        private final AtomicLong iterations = new AtomicLong(0);
+        private final int numIterations;
+        private final int numTypes;
+        private final String typePrefix;
+        private final long observationsPerTypePerIteration;
+
+        private final LoadStatements loadStatements;
+        private final String ryaInstanceName;
+        private Runnable shutdownOperation;
+
+        public LoaderTask(final int numIterations, final long observationsPerTypePerIteration, final int numTypes, final String typePrefix, final LoadStatements loadStatements, final String ryaInstanceName) {
+            this.numIterations = numIterations;
+            this.observationsPerTypePerIteration = observationsPerTypePerIteration;
+            this.numTypes = numTypes;
+            this.typePrefix = typePrefix;
+            this.loadStatements = loadStatements;
+            this.ryaInstanceName = ryaInstanceName;
+        }
+
+        @Override
+        public void run() {
+            try {
+                final BenchmarkStatementGenerator gen = new BenchmarkStatementGenerator();
+
+                final long i = iterations.getAndIncrement();
+                logger.info("Publishing iteration [{} of {}]", i, numIterations);
+                if(i >= numIterations) {
+                    logger.info("Reached maximum iterations...");
+                    shutdownOperation.run();
+                    return;
+                }
+                final long observationsPerIteration = observationsPerTypePerIteration * numTypes;
+                final long iterationOffset = i * observationsPerIteration;
+                logger.info("Generating {} Observations", observationsPerIteration);
+                final Iterable<Statement> statements = gen.generate(observationsPerTypePerIteration, numTypes, typePrefix, iterationOffset, ZonedDateTime.now());
+                logger.info("Publishing {} Observations", observationsPerIteration);
+                final long t1 = System.currentTimeMillis();
+                loadStatements.loadStatements(ryaInstanceName, statements);
+                logger.info("Published {} observations in in {}s", observationsPerIteration, ((System.currentTimeMillis() - t1)/1000.0));
+                logger.info("Updating published totals...");
+                for(int typeId = 0; typeId < numTypes; typeId++) {
+                    typeToStatMap.get(typePrefix + typeId).total.addAndGet(observationsPerTypePerIteration);
+                }
+                logger.info("Finished publishing.");
+            } catch (final RyaClientException e) {
+                logger.warn("Error while writing statements", e);
+            } catch (final DatatypeConfigurationException e) {
+                logger.warn("Error creating generator", e);
+            }
+
+        }
+
+        public void setShutdownOperation(final Runnable f) {
+            this.shutdownOperation = f;
+        }
+    }
+
+
+    /**
+     * Simple data structure for storing and reporting statistics for a Type.
+     */
+    private class Stat {
+        protected final AtomicLong fluoTotal = new AtomicLong(0);
+        protected final AtomicLong total = new AtomicLong(0);
+        private final String type;
+        private final LongSummaryStatistics diffStats = new LongSummaryStatistics();
+        public Stat(final String type) {
+            this.type = type;
+        }
+
+        @Override
+        public String toString() {
+            final long t = total.get();
+            final long ft = fluoTotal.get();
+            final long diff = t - ft;
+            diffStats.accept(diff);
+            return type + " published total: " + t + " fluo: " + ft + " difference: " + diff + " diffStats: " + diffStats;
+        }
+
+        public String getCsvString() {
+            final long t = total.get();
+            final long ft = fluoTotal.get();
+            final long diff = t - ft;
+            return Joiner.on(",").join(type, t, ft, diff);
+        }
+
+        public String getCsvStringHeader() {
+            return "type,published_total,fluo_total_" + type + ",difference_" + type;
+        }
+    }
+
+    public static void main(final String[] args) {
+
+        final CommonOptions options = new CommonOptions();
+        final ProjectionQueryCommand projectionCommand = new ProjectionQueryCommand();
+        final PeriodicQueryCommand periodicCommand = new PeriodicQueryCommand();
+
+        BenchmarkOptions parsedCommand = null;
+        final JCommander cli = new JCommander();
+        cli.addObject(options);
+        cli.addCommand(projectionCommand);
+        cli.addCommand(periodicCommand);
+        cli.setProgramName(KafkaLatencyBenchmark.class.getName());
+
+        try {
+            cli.parse(args);
+            final String parsedName = cli.getParsedCommand();
+            if ("periodic".equals(parsedName)) {
+                parsedCommand = periodicCommand;
+            }
+            if ("projection".equals(parsedName)) {
+                parsedCommand = projectionCommand;
+            }
+            if (parsedCommand == null) {
+                throw new ParameterException("A command must be specified.");
+            }
+        } catch (final ParameterException e) {
+            System.err.println("Error! Invalid input: " + e.getMessage());
+            cli.usage();
+            System.exit(1);
+        }
+
+        try (KafkaLatencyBenchmark benchmark = new KafkaLatencyBenchmark(options, parsedCommand)) {
+            benchmark.start();
+        } catch (final Exception e) {
+          logger.warn("Exception occured.", e);
+        }
+    }
+}

--- a/extras/rya.benchmark/src/main/java/org/apache/rya/benchmark/periodic/PeriodicQueryCommand.java
+++ b/extras/rya.benchmark/src/main/java/org/apache/rya/benchmark/periodic/PeriodicQueryCommand.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.benchmark.periodic;
+
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.google.common.base.Objects;
+
+@Parameters(commandNames = { "periodic" }, commandDescription = "Run benchmark with a PeriodicQuery that uses Filter(function:periodic(?temporalVariable, <windowSize>, <updatePeriod>, <timeUnits>)).  This requires the Rya Periodic Notification Twill YARN Application to be running in addition to the Rya PCJ Updater Incremental Join Application.")
+public class PeriodicQueryCommand extends BenchmarkOptions {
+
+    @Parameter(names = { "-pqw", "--periodic-query-window" }, description = "The window size, in --periodic-query-time-units, for returning query results.", required = true)
+    private double periodicQueryWindow;
+
+    @Parameter(names = { "-pqp", "--periodic-query-period" }, description = "The period, in --periodic-query-time-units, for results of the windowed query to be returned.", required = true)
+    private double periodicQueryPeriod;
+
+    @Parameter(names = { "-pqtu", "--periodic-query-time-units" }, description = "The unit in time (days,hours,minutes)", required = true)
+    private PeriodicQueryTimeUnits periodicQueryTimeUnits;
+
+    @Parameter(names = { "-pqrt", "--periodic-query-registration-topic" }, description = "The kafka topic which periodic notification registration requests are published to.  (typically 'notifications')", required = true)
+    private String periodicQueryRegistrationTopic;
+
+    public enum PeriodicQueryTimeUnits {
+        days, hours, minutes;
+    }
+
+    public PeriodicQueryTimeUnits getPeriodicQueryTimeUnits() {
+        return periodicQueryTimeUnits;
+    }
+
+    public double getPeriodicQueryWindow() {
+        return periodicQueryWindow;
+    }
+
+    public double getPeriodicQueryPeriod() {
+        return periodicQueryPeriod;
+    }
+
+    public String getPeriodicQueryRegistrationTopic() {
+        return periodicQueryRegistrationTopic;
+    }
+
+    @Override
+    public String toString() {
+        return Objects.toStringHelper(this)
+                .add("periodicQueryWindow", periodicQueryWindow)
+                .add("periodicQueryPeriod", periodicQueryPeriod)
+                .add("periodicQueryTimeUnits", periodicQueryTimeUnits)
+                .add("periodicQueryRegistrationTopic", periodicQueryRegistrationTopic)
+                .toString() + super.toString();
+    }
+}

--- a/extras/rya.benchmark/src/main/java/org/apache/rya/benchmark/periodic/ProjectionQueryCommand.java
+++ b/extras/rya.benchmark/src/main/java/org/apache/rya/benchmark/periodic/ProjectionQueryCommand.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.benchmark.periodic;
+
+import com.beust.jcommander.Parameters;
+import com.google.common.base.Objects;
+
+@Parameters(commandNames = { "projection" }, commandDescription = "Run benchmark with a simple projection query.  This requires the Rya PCJ Updater Incremental Join Application to be running.")
+public class ProjectionQueryCommand extends BenchmarkOptions {
+
+    @Override
+    public String toString() {
+        return Objects.toStringHelper(this).toString() + super.toString();
+    }
+}

--- a/extras/rya.benchmark/src/main/scripts/periodicNotificationBenchmark.sh
+++ b/extras/rya.benchmark/src/main/scripts/periodicNotificationBenchmark.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# navigate to the project directory
+PROJECT_HOME=$(dirname $(cd $(dirname $0) && pwd))
+cd $PROJECT_HOME
+
+
+# run the program
+$JAVA_HOME/bin/java -cp .:lib/* \
+  -Dlog4j.configuration=conf/log4j.properties \
+  org.apache.rya.benchmark.periodic.KafkaLatencyBenchmark \
+  @conf/common.options \
+  periodic \
+  @conf/periodic.options \
+  "$@"

--- a/extras/rya.benchmark/src/main/scripts/projectionNotificationBenchmark.sh
+++ b/extras/rya.benchmark/src/main/scripts/projectionNotificationBenchmark.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# navigate to the project directory
+PROJECT_HOME=$(dirname $(cd $(dirname $0) && pwd))
+cd $PROJECT_HOME
+
+
+# run the program
+$JAVA_HOME/bin/java -cp .:lib/* \
+  -Dlog4j.configuration=conf/log4j.properties \
+  org.apache.rya.benchmark.periodic.KafkaLatencyBenchmark \
+  @conf/common.options \
+  projection \
+  @conf/projection.options \
+  "$@"

--- a/extras/rya.export/export.client/conf/config.xml
+++ b/extras/rya.export/export.client/conf/config.xml
@@ -16,18 +16,18 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License. -->
 <MergeToolConfiguration xmlns="http://mergeconfig">
-    <parentHostname>10.63.8.102</parentHostname>
-    <parentUsername>SPEAR</parentUsername>
-    <parentPassword>spear</parentPassword>
-    <parentRyaInstanceName>spear_instance</parentRyaInstanceName>
-    <parentTablePrefix>asmith_demo_export_</parentTablePrefix>
-    <parentTomcatUrl>http://10.63.8.102:8080</parentTomcatUrl>
+    <parentHostname>10.10.10.100</parentHostname>
+    <parentUsername>accumuloUsername</parentUsername>
+    <parentPassword>accumuloPassword</parentPassword>
+    <parentRyaInstanceName>accumuloInstance</parentRyaInstanceName>
+    <parentTablePrefix>rya_demo_export_</parentTablePrefix>
+    <parentTomcatUrl>http://10.10.10.100:8080</parentTomcatUrl>
     <parentDBType>accumulo</parentDBType>
     <parentPort>1111</parentPort>
-    <childHostname>localhost</childHostname>
+    <childHostname>10.10.10.101</childHostname>
     <childRyaInstanceName>rya_demo_child</childRyaInstanceName>
-    <childTablePrefix>asmith_demo_export_</childTablePrefix>
-    <childTomcatUrl>http://localhost:8080</childTomcatUrl>
+    <childTablePrefix>rya_demo_export_</childTablePrefix>
+    <childTomcatUrl>http://10.10.10.101:8080</childTomcatUrl>
     <childDBType>mongo</childDBType>
     <childPort>27017</childPort>
     <mergePolicy>timestamp</mergePolicy>

--- a/extras/rya.manual/src/site/markdown/pcj-updater.md
+++ b/extras/rya.manual/src/site/markdown/pcj-updater.md
@@ -211,14 +211,16 @@ Add the following entries under Observer properties in the
 # fluo.observer.0=com.foo.Observer1
 # Can optionally have configuration key values
 # fluo.observer.1=com.foo.Observer2,configKey1=configVal1,configKey2=configVal2
-fluo.observer.0=org.apache.rya.indexing.pcj.fluo.app.observers.TripleObserver
-fluo.observer.1=org.apache.rya.indexing.pcj.fluo.app.observers.StatementPatternObserver
-fluo.observer.2=org.apache.rya.indexing.pcj.fluo.app.observers.JoinObserver
-fluo.observer.3=org.apache.rya.indexing.pcj.fluo.app.observers.FilterObserver
-fluo.observer.4=org.apache.rya.indexing.pcj.fluo.app.observers.AggregationObserver
-fluo.observer.5=org.apache.rya.indexing.pcj.fluo.app.observers.ProjectionObserver
-#fluo.observer.5=org.apache.rya.indexing.pcj.fluo.app.observers.ConstructQueryResultObserver
-fluo.observer.6=org.apache.rya.indexing.pcj.fluo.app.observers.QueryResultObserver,pcj.fluo.export.rya.enabled=true,pcj.fluo.export.rya.ryaInstanceName=rya_,pcj.fluo.export.rya.accumuloInstanceName=myAccumuloInstance,pcj.fluo.export.rya.zookeeperServers=zoo1;zoo2;zoo3,pcj.fluo.export.rya.exporterUsername=myUserName,pcj.fluo.export.rya.exporterPassword=myPassword,pcj.fluo.export.kafka.enabled=true,bootstrap.servers=myKafkaBroker:9092,key.serializer=org.apache.kafka.common.serialization.ByteArraySerializer,value.serializer=org.apache.rya.indexing.pcj.fluo.app.export.kafka.KryoVisibilityBindingSetSerializer
+fluo.observer.0=org.apache.rya.indexing.pcj.fluo.app.batch.BatchObserver
+fluo.observer.1=org.apache.rya.indexing.pcj.fluo.app.observers.TripleObserver
+fluo.observer.2=org.apache.rya.indexing.pcj.fluo.app.observers.StatementPatternObserver
+fluo.observer.3=org.apache.rya.indexing.pcj.fluo.app.observers.JoinObserver
+fluo.observer.4=org.apache.rya.indexing.pcj.fluo.app.observers.FilterObserver
+fluo.observer.5=org.apache.rya.indexing.pcj.fluo.app.observers.AggregationObserver
+fluo.observer.6=org.apache.rya.indexing.pcj.fluo.app.observers.PeriodicQueryObserver
+fluo.observer.7=org.apache.rya.indexing.pcj.fluo.app.observers.ProjectionObserver
+#fluo.observer.8=org.apache.rya.indexing.pcj.fluo.app.observers.ConstructQueryResultObserver
+fluo.observer.8=org.apache.rya.indexing.pcj.fluo.app.observers.QueryResultObserver,pcj.fluo.export.rya.enabled=true,pcj.fluo.export.rya.ryaInstanceName=rya_,pcj.fluo.export.rya.fluo.application.name=rya_pcj_updater,pcj.fluo.export.rya.accumuloInstanceName=myAccumuloInstance,pcj.fluo.export.rya.zookeeperServers=zoo1;zoo2;zoo3;zoo4;zoo5,pcj.fluo.export.rya.exporterUsername=myUserName,pcj.fluo.export.rya.exporterPassword=myPassword,pcj.fluo.export.rya.bindingset.enabled=true,pcj.fluo.export.periodic.bindingset.enabled=true,pcj.fluo.export.kafka.subgraph.enabled=true,pcj.fluo.export.kafka.bindingset.enabled=true,bootstrap.servers=kafka1:9092
 ```
 
 Description of configuration keys for the 

--- a/extras/rya.pcj.fluo/pcj.fluo.app/pom.xml
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/pom.xml
@@ -35,9 +35,7 @@
         A Fluo implementation of Rya Precomputed Join Indexing. This module produces
         a jar that may be executed by the 'fluo' command line tool as a YARN job.
     </description>
-    <properties>
-        <kryo.version>3.0.3</kryo.version>
-    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -81,7 +79,6 @@
         <dependency>
             <groupId>com.esotericsoftware</groupId>
             <artifactId>kryo</artifactId>
-            <version>${kryo.version}</version>
         </dependency>
 
         <!-- Testing dependencies. -->

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/batch/AbstractSpanBatchInformation.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/batch/AbstractSpanBatchInformation.java
@@ -23,8 +23,6 @@ import java.util.Objects;
 import org.apache.fluo.api.data.Column;
 import org.apache.fluo.api.data.Span;
 
-import com.google.common.base.Preconditions;
-
 /**
  * Abstract class for generating span based notifications.  A spanned notification
  * uses a {@link Span} to begin processing a Fluo Column at the position designated by the Span.
@@ -43,7 +41,7 @@ public abstract class AbstractSpanBatchInformation extends BasicBatchInformation
      */
     public AbstractSpanBatchInformation(int batchSize, Task task, Column column, Span span) {
         super(batchSize, task, column);
-        this.span = Preconditions.checkNotNull(span);
+        this.span = Objects.requireNonNull(span);
     }
 
     public AbstractSpanBatchInformation(Task task, Column column, Span span) {

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/batch/JoinBatchInformation.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/batch/JoinBatchInformation.java
@@ -23,11 +23,8 @@ import org.apache.fluo.api.data.Column;
 import org.apache.fluo.api.data.Span;
 import org.apache.rya.indexing.pcj.fluo.app.JoinResultUpdater.Side;
 import org.apache.rya.indexing.pcj.fluo.app.query.JoinMetadata.JoinType;
-import org.apache.rya.indexing.pcj.storage.accumulo.VariableOrder;
 import org.apache.rya.indexing.pcj.storage.accumulo.VisibilityBindingSet;
 import org.openrdf.query.Binding;
-
-import com.google.common.base.Preconditions;
 
 /**
  * This class updates join results based on parameters specified for the join's
@@ -66,9 +63,9 @@ public class JoinBatchInformation extends AbstractSpanBatchInformation {
      */
     public JoinBatchInformation(int batchSize, Task task, Column column, Span span, VisibilityBindingSet bs, Side side, JoinType join) {
         super(batchSize, task, column, span);
-        this.bs = Preconditions.checkNotNull(bs);
-        this.side = Preconditions.checkNotNull(side);
-        this.join = Preconditions.checkNotNull(join);
+        this.bs = Objects.requireNonNull(bs);
+        this.side = Objects.requireNonNull(side);
+        this.join = Objects.requireNonNull(join);
     }
     
     public JoinBatchInformation(Task task, Column column, Span span, VisibilityBindingSet bs, Side side, JoinType join) {

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/export/kafka/KafkaBindingSetExporterFactory.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/export/kafka/KafkaBindingSetExporterFactory.java
@@ -21,11 +21,12 @@ package org.apache.rya.indexing.pcj.fluo.app.export.kafka;
 import org.apache.fluo.api.observer.Observer.Context;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.log4j.Logger;
 import org.apache.rya.indexing.pcj.fluo.app.export.IncrementalBindingSetExporter;
 import org.apache.rya.indexing.pcj.fluo.app.export.IncrementalResultExporter;
 import org.apache.rya.indexing.pcj.fluo.app.export.IncrementalResultExporterFactory;
 import org.apache.rya.indexing.pcj.storage.accumulo.VisibilityBindingSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Optional;
 
@@ -42,18 +43,19 @@ import com.google.common.base.Optional;
  *     producerConfig.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArraySerializer");
  *     producerConfig.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");
  * </pre>
- * 
+ *
  * @see ProducerConfig
  */
 public class KafkaBindingSetExporterFactory implements IncrementalResultExporterFactory {
-    private static final Logger log = Logger.getLogger(KafkaBindingSetExporterFactory.class);
+    private static final Logger log = LoggerFactory.getLogger(KafkaBindingSetExporterFactory.class);
+
     @Override
-    public Optional<IncrementalResultExporter> build(Context context) throws IncrementalExporterFactoryException, ConfigurationException {
+    public Optional<IncrementalResultExporter> build(final Context context) throws IncrementalExporterFactoryException, ConfigurationException {
         final KafkaBindingSetExporterParameters exportParams = new KafkaBindingSetExporterParameters(context.getObserverConfiguration().toMap());
-        log.debug("KafkaResultExporterFactory.build(): params.isExportToKafka()=" + exportParams.getUseKafkaBindingSetExporter());
         if (exportParams.getUseKafkaBindingSetExporter()) {
+            log.info("Exporter is enabled.");
             // Setup Kafka connection
-            KafkaProducer<String, VisibilityBindingSet> producer = new KafkaProducer<String, VisibilityBindingSet>(exportParams.listAllConfig());
+            final KafkaProducer<String, VisibilityBindingSet> producer = new KafkaProducer<>(exportParams.listAllConfig());
             // Create the exporter
             final IncrementalBindingSetExporter exporter = new KafkaBindingSetExporter(producer);
             return Optional.of(exporter);

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/export/kafka/KafkaExportParameterBase.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/export/kafka/KafkaExportParameterBase.java
@@ -19,14 +19,13 @@
 package org.apache.rya.indexing.pcj.fluo.app.export.kafka;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 
 import org.apache.fluo.api.observer.Observer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.rya.indexing.pcj.fluo.app.export.ParametersBase;
-
-import com.google.common.base.Preconditions;
 
 /**
  * Provides read/write functions to the parameters map that is passed into an
@@ -46,7 +45,7 @@ public class KafkaExportParameterBase extends ParametersBase {
      * @param bootstrapServers - connect string for Kafka brokers
      */
     public void setKafkaBootStrapServers(String bootstrapServers) {
-        params.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, Preconditions.checkNotNull(bootstrapServers));
+        params.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, Objects.requireNonNull(bootstrapServers));
     }
     
     /**

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/export/kafka/KafkaRyaSubGraphExporter.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/export/kafka/KafkaRyaSubGraphExporter.java
@@ -26,37 +26,42 @@ import java.util.concurrent.TimeUnit;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
-import org.apache.log4j.Logger;
 import org.apache.rya.api.client.CreatePCJ.ExportStrategy;
 import org.apache.rya.api.client.CreatePCJ.QueryType;
 import org.apache.rya.api.domain.RyaSubGraph;
 import org.apache.rya.indexing.pcj.fluo.app.export.IncrementalBindingSetExporter.ResultExportException;
+import org.apache.rya.indexing.pcj.fluo.app.export.IncrementalRyaSubGraphExporter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Sets;
 
-import org.apache.rya.indexing.pcj.fluo.app.export.IncrementalRyaSubGraphExporter;
-
 /**
- * Exports {@link RyaSubGraph}s to Kafka from Rya Fluo Application 
+ * Exports {@link RyaSubGraph}s to Kafka from Rya Fluo Application
  *
  */
 public class KafkaRyaSubGraphExporter implements IncrementalRyaSubGraphExporter {
 
     private final KafkaProducer<String, RyaSubGraph> producer;
-    private static final Logger log = Logger.getLogger(KafkaRyaSubGraphExporter.class);
+    private static final Logger log = LoggerFactory.getLogger(KafkaRyaSubGraphExporter.class);
 
-    public KafkaRyaSubGraphExporter(KafkaProducer<String, RyaSubGraph> producer) {
+
+    /**
+     *
+     * @param producer - The producer used by this exporter.
+     */
+    public KafkaRyaSubGraphExporter(final KafkaProducer<String, RyaSubGraph> producer) {
         checkNotNull(producer);
         this.producer = producer;
     }
-    
+
     /**
      * Exports the RyaSubGraph to a Kafka topic equivalent to the result returned by {@link RyaSubGraph#getId()}
      * @param subgraph - RyaSubGraph exported to Kafka
      * @param contructID - rowID of result that is exported. Used for logging purposes.
      */
     @Override
-    public void export(String constructID, RyaSubGraph subGraph) throws ResultExportException {
+    public void export(final String constructID, final RyaSubGraph subGraph) throws ResultExportException {
         checkNotNull(constructID);
         checkNotNull(subGraph);
         try {
@@ -67,7 +72,7 @@ public class KafkaRyaSubGraphExporter implements IncrementalRyaSubGraphExporter 
             // Don't let the export return until the result has been written to the topic. Otherwise we may lose results.
             future.get();
 
-            log.debug("Producer successfully sent record with id: " + constructID + " and statements: " + subGraph.getStatements());
+            log.debug("Producer successfully sent record with id: {} and statements: {}", constructID, subGraph.getStatements());
 
         } catch (final Throwable e) {
             throw new ResultExportException("A result could not be exported to Kafka.", e);

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/export/kafka/KafkaRyaSubGraphExporterFactory.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/export/kafka/KafkaRyaSubGraphExporterFactory.java
@@ -19,11 +19,12 @@ package org.apache.rya.indexing.pcj.fluo.app.export.kafka;
  */
 import org.apache.fluo.api.observer.Observer.Context;
 import org.apache.kafka.clients.producer.KafkaProducer;
-import org.apache.log4j.Logger;
 import org.apache.rya.api.domain.RyaSubGraph;
 import org.apache.rya.indexing.pcj.fluo.app.export.IncrementalResultExporter;
 import org.apache.rya.indexing.pcj.fluo.app.export.IncrementalResultExporterFactory;
 import org.apache.rya.indexing.pcj.fluo.app.export.IncrementalRyaSubGraphExporter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Optional;
 
@@ -34,10 +35,10 @@ import com.google.common.base.Optional;
  */
 public class KafkaRyaSubGraphExporterFactory implements IncrementalResultExporterFactory {
 
-    private static final Logger log = Logger.getLogger(KafkaRyaSubGraphExporterFactory.class);
+    private static final Logger log = LoggerFactory.getLogger(KafkaRyaSubGraphExporterFactory.class);
     public static final String CONF_USE_KAFKA_SUBGRAPH_EXPORTER = "pcj.fluo.export.kafka.subgraph.enabled";
     public static final String CONF_KAFKA_SUBGRAPH_SERIALIZER = "pcj.fluo.export.kafka.subgraph.serializer";
-    
+
     /**
      * Builds a {@link KafkaRyaSubGraphExporter}.
      * @param context - {@link Context} object used to pass configuration parameters
@@ -46,12 +47,12 @@ public class KafkaRyaSubGraphExporterFactory implements IncrementalResultExporte
      * @throws ConfigurationException
      */
     @Override
-    public Optional<IncrementalResultExporter> build(Context context) throws IncrementalExporterFactoryException, ConfigurationException {
+    public Optional<IncrementalResultExporter> build(final Context context) throws IncrementalExporterFactoryException, ConfigurationException {
         final KafkaSubGraphExporterParameters exportParams = new KafkaSubGraphExporterParameters(context.getObserverConfiguration().toMap());
-        log.debug("KafkaRyaSubGraphExporterFactory.build(): params.isExportToKafka()=" + exportParams.getUseKafkaSubgraphExporter());
+        log.info("Exporter is enabled: {}", exportParams.getUseKafkaSubgraphExporter());
         if (exportParams.getUseKafkaSubgraphExporter()) {
             // Setup Kafka connection
-            KafkaProducer<String, RyaSubGraph> producer = new KafkaProducer<String, RyaSubGraph>(exportParams.listAllConfig());
+            final KafkaProducer<String, RyaSubGraph> producer = new KafkaProducer<String, RyaSubGraph>(exportParams.listAllConfig());
             // Create the exporter
             final IncrementalRyaSubGraphExporter exporter = new KafkaRyaSubGraphExporter(producer);
             return Optional.of(exporter);

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/export/kafka/KryoVisibilityBindingSetSerializer.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/export/kafka/KryoVisibilityBindingSetSerializer.java
@@ -25,7 +25,6 @@ import java.util.Map;
 
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serializer;
-import org.apache.log4j.Logger;
 import org.apache.rya.api.domain.RyaType;
 import org.apache.rya.api.resolver.RdfToRyaConversions;
 import org.apache.rya.indexing.pcj.storage.accumulo.VisibilityBindingSet;
@@ -51,7 +50,7 @@ public class KryoVisibilityBindingSetSerializer implements Serializer<Visibility
     private static final ThreadLocal<Kryo> kryos = new ThreadLocal<Kryo>() {
         @Override
         protected Kryo initialValue() {
-            Kryo kryo = new Kryo();
+            final Kryo kryo = new Kryo();
             return kryo;
         };
     };
@@ -60,7 +59,7 @@ public class KryoVisibilityBindingSetSerializer implements Serializer<Visibility
      * Deserialize a VisibilityBindingSet using Kyro lib. Exporting results of queries.
      * If you don't want to use Kyro, here is an alternative:
      * return (new VisibilityBindingSetStringConverter()).convert(new String(data, StandardCharsets.UTF_8), null);
-     * 
+     *
      * @param topic
      *            ignored
      * @param data
@@ -68,9 +67,9 @@ public class KryoVisibilityBindingSetSerializer implements Serializer<Visibility
      * @return deserialized instance of VisibilityBindingSet
      */
     @Override
-    public VisibilityBindingSet deserialize(String topic, byte[] data) {
-        KryoInternalSerializer internalSerializer = new KryoInternalSerializer();
-        Input input = new Input(new ByteArrayInputStream(data));
+    public VisibilityBindingSet deserialize(final String topic, final byte[] data) {
+        final KryoInternalSerializer internalSerializer = new KryoInternalSerializer();
+        final Input input = new Input(new ByteArrayInputStream(data));
         return internalSerializer.read(kryos.get(), input, VisibilityBindingSet.class);
     }
 
@@ -78,7 +77,7 @@ public class KryoVisibilityBindingSetSerializer implements Serializer<Visibility
      * Ignored. Nothing to configure.
      */
     @Override
-    public void configure(Map<String, ?> configs, boolean isKey) {
+    public void configure(final Map<String, ?> configs, final boolean isKey) {
         // Do nothing.
     }
 
@@ -86,7 +85,7 @@ public class KryoVisibilityBindingSetSerializer implements Serializer<Visibility
      * Serialize a VisibilityBindingSet using Kyro lib. Exporting results of queries.
      * If you don't want to use Kyro, here is an alternative:
      * return (new VisibilityBindingSetStringConverter()).convert(data, null).getBytes(StandardCharsets.UTF_8);
-     * 
+     *
      * @param topic
      *            ignored
      * @param data
@@ -94,13 +93,13 @@ public class KryoVisibilityBindingSetSerializer implements Serializer<Visibility
      * @return Serialized form of VisibilityBindingSet
      */
     @Override
-    public byte[] serialize(String topic, VisibilityBindingSet data) {
-        KryoInternalSerializer internalSerializer = new KryoInternalSerializer();
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        Output output = new Output(baos);
+    public byte[] serialize(final String topic, final VisibilityBindingSet data) {
+        final KryoInternalSerializer internalSerializer = new KryoInternalSerializer();
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        final Output output = new Output(baos);
         internalSerializer.write(kryos.get(), output, data);
         output.flush();
-        byte[] array = baos.toByteArray();
+        final byte[] array = baos.toByteArray();
         return array;
     }
 
@@ -127,14 +126,12 @@ public class KryoVisibilityBindingSetSerializer implements Serializer<Visibility
      *
      */
     private static class KryoInternalSerializer extends com.esotericsoftware.kryo.Serializer<VisibilityBindingSet> {
-        private static final Logger log = Logger.getLogger(KryoVisibilityBindingSetSerializer.class);
         @Override
-        public void write(Kryo kryo, Output output, VisibilityBindingSet visBindingSet) {
-            log.debug("Serializer writing visBindingSet" + visBindingSet);
+        public void write(final Kryo kryo, final Output output, final VisibilityBindingSet visBindingSet) {
             output.writeString(visBindingSet.getVisibility());
             // write the number count for the reader.
             output.writeInt(visBindingSet.size());
-            for (Binding binding : visBindingSet) {
+            for (final Binding binding : visBindingSet) {
                 output.writeString(binding.getName());
                 final RyaType ryaValue = RdfToRyaConversions.convertValue(binding.getValue());
                 final String valueString = ryaValue.getData();
@@ -145,19 +142,18 @@ public class KryoVisibilityBindingSetSerializer implements Serializer<Visibility
         }
 
         @Override
-        public VisibilityBindingSet read(Kryo kryo, Input input, Class<VisibilityBindingSet> aClass) {
-            log.debug("Serializer reading visBindingSet");
-            String visibility = input.readString();
-            int bindingCount = input.readInt();
-            ArrayList<String> namesList = new ArrayList<String>(bindingCount);
-            ArrayList<Value> valuesList = new ArrayList<Value>(bindingCount);
+        public VisibilityBindingSet read(final Kryo kryo, final Input input, final Class<VisibilityBindingSet> aClass) {
+            final String visibility = input.readString();
+            final int bindingCount = input.readInt();
+            final ArrayList<String> namesList = new ArrayList<String>(bindingCount);
+            final ArrayList<Value> valuesList = new ArrayList<Value>(bindingCount);
             for (int i = bindingCount; i > 0; i--) {
                 namesList.add(input.readString());
-                String valueString = input.readString();
+                final String valueString = input.readString();
                 final URI type = new URIImpl(input.readString());
                 valuesList.add(makeValue(valueString, type));
             }
-            BindingSet bindingSet = new ListBindingSet(namesList, valuesList);
+            final BindingSet bindingSet = new ListBindingSet(namesList, valuesList);
             return new VisibilityBindingSet(bindingSet, visibility);
         }
     }

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/export/rya/RyaBindingSetExporterFactory.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/export/rya/RyaBindingSetExporterFactory.java
@@ -30,10 +30,8 @@ import org.apache.fluo.api.observer.Observer.Context;
 import org.apache.rya.indexing.pcj.fluo.app.export.IncrementalBindingSetExporter;
 import org.apache.rya.indexing.pcj.fluo.app.export.IncrementalResultExporter;
 import org.apache.rya.indexing.pcj.fluo.app.export.IncrementalResultExporterFactory;
-import org.apache.rya.indexing.pcj.storage.PeriodicQueryResultStorage;
 import org.apache.rya.indexing.pcj.storage.PrecomputedJoinStorage;
 import org.apache.rya.indexing.pcj.storage.accumulo.AccumuloPcjStorage;
-import org.apache.rya.indexing.pcj.storage.accumulo.AccumuloPeriodicQueryResultStorage;
 
 import com.google.common.base.Optional;
 
@@ -45,7 +43,6 @@ public class RyaBindingSetExporterFactory implements IncrementalResultExporterFa
     @Override
     public Optional<IncrementalResultExporter> build(final Context context) throws IncrementalExporterFactoryException, ConfigurationException {
         checkNotNull(context);
-
         // Wrap the context's parameters for parsing.
         final RyaExportParameters params = new RyaExportParameters( context.getObserverConfiguration().toMap() );
 
@@ -64,7 +61,7 @@ public class RyaBindingSetExporterFactory implements IncrementalResultExporterFa
                 // Setup Rya PCJ Storage.
                 final String ryaInstanceName = params.getRyaInstanceName().get();
                 final PrecomputedJoinStorage pcjStorage = new AccumuloPcjStorage(accumuloConn, ryaInstanceName);
-                
+
                 // Make the exporter.
                 final IncrementalBindingSetExporter exporter = new RyaBindingSetExporter(pcjStorage);
                 return Optional.of(exporter);

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/observers/TripleObserver.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/observers/TripleObserver.java
@@ -31,7 +31,6 @@ import org.apache.fluo.api.data.Bytes;
 import org.apache.fluo.api.data.Column;
 import org.apache.fluo.api.data.Span;
 import org.apache.fluo.api.observer.AbstractObserver;
-import org.apache.log4j.Logger;
 import org.apache.rya.api.domain.RyaStatement;
 import org.apache.rya.indexing.pcj.fluo.app.IncUpdateDAO;
 import org.apache.rya.indexing.pcj.fluo.app.query.FluoQueryColumns;
@@ -41,6 +40,8 @@ import org.apache.rya.indexing.pcj.storage.accumulo.VariableOrder;
 import org.apache.rya.indexing.pcj.storage.accumulo.VisibilityBindingSet;
 import org.apache.rya.indexing.pcj.storage.accumulo.VisibilityBindingSetSerDe;
 import org.apache.rya.indexing.pcj.storage.accumulo.VisibilityBindingSetStringConverter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Charsets;
 import com.google.common.collect.Maps;
@@ -51,7 +52,7 @@ import com.google.common.collect.Maps;
  * the new result is stored as a binding set for the pattern.
  */
 public class TripleObserver extends AbstractObserver {
-    private static final Logger log = Logger.getLogger(TripleObserver.class);
+    private static final Logger log = LoggerFactory.getLogger(TripleObserver.class);
 
     private static final VisibilityBindingSetSerDe BS_SERDE = new VisibilityBindingSetSerDe();
     private static final FluoQueryMetadataDAO QUERY_METADATA_DAO = new FluoQueryMetadataDAO();
@@ -68,9 +69,7 @@ public class TripleObserver extends AbstractObserver {
     public void process(final TransactionBase tx, final Bytes brow, final Column column) {
         // Get string representation of triple.
         final RyaStatement ryaStatement = IncUpdateDAO.deserializeTriple(brow);
-        log.trace(
-                "Transaction ID: " + tx.getStartTimestamp() + "\n" +
-                "Rya Statement: " + ryaStatement + "\n");
+        log.trace("Transaction ID: {}\nRya Statement: {}\n", tx.getStartTimestamp(), ryaStatement);
 
         final String triple = IncUpdateDAO.getTripleString(ryaStatement);
 
@@ -114,10 +113,8 @@ public class TripleObserver extends AbstractObserver {
                     try {
                         final Bytes valueBytes = BS_SERDE.serialize(visBindingSet);
 
-                        log.trace(
-                                "Transaction ID: " + tx.getStartTimestamp() + "\n" +
-                                        "Matched Statement Pattern: " + spID + "\n" +
-                                        "Binding Set: " + visBindingSet + "\n");
+                        log.trace("Transaction ID: {}\nMatched Statement Pattern: {}\nBinding Set: {}\n",
+                                tx.getStartTimestamp(), spID, visBindingSet);
 
                         tx.set(rowBytes, FluoQueryColumns.STATEMENT_PATTERN_BINDING_SET, valueBytes);
                     } catch(final Exception e) {

--- a/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/query/FluoQuery.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.app/src/main/java/org/apache/rya/indexing/pcj/fluo/app/query/FluoQuery.java
@@ -81,7 +81,7 @@ public class FluoQuery {
             final Optional<PeriodicQueryMetadata> periodicQueryMetadata,
             final ImmutableMap<String, StatementPatternMetadata> statementPatternMetadata,
             final ImmutableMap<String, FilterMetadata> filterMetadata,
-            final ImmutableMap<String, JoinMetadata> joinMetadata, 
+            final ImmutableMap<String, JoinMetadata> joinMetadata,
             final ImmutableMap<String, AggregationMetadata> aggregationMetadata) {
                 this.aggregationMetadata = requireNonNull(aggregationMetadata);
         this.queryMetadata = requireNonNull(queryMetadata);
@@ -94,7 +94,7 @@ public class FluoQuery {
         this.joinMetadata = requireNonNull(joinMetadata);
         this.type = queryMetadata.getQueryType();
     }
-    
+
     /**
      * Returns the {@link QueryType} of this query
      * @return the QueryType of this query (either Construct or Projection}
@@ -102,7 +102,7 @@ public class FluoQuery {
     public QueryType getQueryType() {
         return type;
     }
-    
+
     /**
      * @return the unique id of this query
      */
@@ -116,66 +116,66 @@ public class FluoQuery {
     public QueryMetadata getQueryMetadata() {
         return queryMetadata;
     }
-    
+
     /**
      * @param nodeId - node id of the query metadata
      * @return Optional containing the queryMetadata if it matches the specified nodeId
      */
-    public Optional<QueryMetadata> getQueryMetadata(String nodeId) {
+    public Optional<QueryMetadata> getQueryMetadata(final String nodeId) {
         if(queryMetadata.getNodeId().equals(nodeId)) {
             return Optional.of(queryMetadata);
         } else {
             return Optional.absent();
         }
     }
-    
+
     /**
      * @return construct query metadata for generating subgraphs
      */
     public Optional<ConstructQueryMetadata> getConstructQueryMetadata() {
         return constructMetadata;
     }
-    
+
     /**
      * @param nodeId - node id of the ConstructMetadata
      * @return Optional containing the ConstructMetadata if it is present and has the given nodeId
      */
-    public Optional<ConstructQueryMetadata> getConstructQueryMetadata(String nodeId) {
+    public Optional<ConstructQueryMetadata> getConstructQueryMetadata(final String nodeId) {
         if(constructMetadata.isPresent() && constructMetadata.get().getNodeId().equals(nodeId)) {
             return constructMetadata;
         } else {
             return Optional.absent();
         }
     }
-    
+
     /**
      * @param nodeId - id of the Projection metadata you want (not null)
      * @return projection metadata corresponding to give nodeId
      */
-    public Optional<ProjectionMetadata> getProjectionMetadata(String nodeId) {
+    public Optional<ProjectionMetadata> getProjectionMetadata(final String nodeId) {
         return Optional.fromNullable(projectionMetadata.get(nodeId));
     }
-    
+
     /**
      * @return All of the projection metadata that is stored for the query
      */
     public Collection<ProjectionMetadata> getProjectionMetadata() {
         return projectionMetadata.values();
     }
-    
+
     /**
      * @return All of the Periodic Query metadata that is stored for the query.
      */
     public Optional<PeriodicQueryMetadata> getPeriodicQueryMetadata() {
         return periodicQueryMetadata;
     }
-    
+
     /**
      * @param nodeId - id of the PeriodicQueryMetadata
      * @return Optional containing the PeriodicQueryMetadata if it is present and has the given nodeId
      */
-    public Optional<PeriodicQueryMetadata> getPeriodicQueryMetadata(String nodeId) {
-        
+    public Optional<PeriodicQueryMetadata> getPeriodicQueryMetadata(final String nodeId) {
+
         if(periodicQueryMetadata.isPresent() && periodicQueryMetadata.get().getNodeId().equals(nodeId)) {
             return periodicQueryMetadata;
         } else {
@@ -294,17 +294,17 @@ public class FluoQuery {
 
         builder.append(queryMetadata.toString());
         builder.append("\n");
-        
+
         for(final ProjectionMetadata metadata : projectionMetadata.values()) {
             builder.append(metadata);
             builder.append("\n");
         }
-        
+
         if(constructMetadata.isPresent()) {
             builder.append( constructMetadata.get().toString() );
             builder.append("\n");
         }
-        
+
         if(periodicQueryMetadata.isPresent()) {
             builder.append(periodicQueryMetadata.get());
             builder.append("\n");
@@ -372,20 +372,20 @@ public class FluoQuery {
         public QueryMetadata.Builder getQueryBuilder() {
             return queryBuilder;
         }
-        
+
         /**
          * @param nodeId - id of the QueryMetadata.Builder
          * @return Optional containing the QueryMetadata.Builder if it has the specified nodeId
          */
-        public Optional<QueryMetadata.Builder> getQueryBuilder(String nodeId) {
+        public Optional<QueryMetadata.Builder> getQueryBuilder(final String nodeId) {
             if(queryBuilder.getNodeId().equals(nodeId)) {
                 return Optional.of(queryBuilder);
             } else {
                 return Optional.absent();
             }
-            
+
         }
-        
+
         /**
          * Sets the {@link ProjectionMetadata.Builder} that is used by this builder.
          *
@@ -401,11 +401,11 @@ public class FluoQuery {
         /**
          * @return The ProjectionMetadata builder if one has been set.
          */
-        public Optional<ProjectionMetadata.Builder> getProjectionBuilder(String nodeId) {
+        public Optional<ProjectionMetadata.Builder> getProjectionBuilder(final String nodeId) {
             requireNonNull(nodeId);
             return Optional.fromNullable( projectionBuilders.get(nodeId) );
         }
-        
+
         /**
          * Sets the {@link ConstructQueryMetadata.Builder} that is used by this builder.
          *
@@ -421,21 +421,21 @@ public class FluoQuery {
          * @param id of the ConstructQueryMetadata.Builder
          * @return Optional containing the ConstructQueryMetadata.Builder if it has been set and has the given nodeId.
          */
-        public Optional<ConstructQueryMetadata.Builder> getConstructQueryBuilder(String nodeId) {
+        public Optional<ConstructQueryMetadata.Builder> getConstructQueryBuilder(final String nodeId) {
             if(constructBuilder != null && constructBuilder.getNodeId().equals(nodeId)) {
                 return Optional.of(constructBuilder);
             } else {
                 return Optional.absent();
             }
         }
-        
+
         /**
          * @return The Construct Query metadata builder if one has been set.
          */
         public Optional<ConstructQueryMetadata.Builder> getConstructQueryBuilder() {
             return Optional.fromNullable( constructBuilder );
         }
-        
+
 
         /**
          * Adds a new {@link StatementPatternMetadata.Builder} to this builder.
@@ -505,7 +505,7 @@ public class FluoQuery {
             requireNonNull(nodeId);
             return Optional.fromNullable( joinBuilders.get(nodeId) );
         }
-        
+
         /**
          * Get an Aggregate builder from this builder.
          *
@@ -528,7 +528,7 @@ public class FluoQuery {
             this.aggregationBuilders.put(aggregationBuilder.getNodeId(), aggregationBuilder);
             return this;
         }
-        
+
         /**
          * Adds a new {@link PeriodicQueryMetadata.Builder} to this builder.
          *
@@ -549,33 +549,33 @@ public class FluoQuery {
         public Optional<PeriodicQueryMetadata.Builder> getPeriodicQueryBuilder() {
             return Optional.fromNullable( periodicQueryBuilder);
         }
-        
+
         /**
          * @param - id of the PeriodicQueryMetadata.Builder
          * @return - Optional containing the PeriodicQueryMetadata.Builder if one has been set and it has the given nodeId
          */
-        public Optional<PeriodicQueryMetadata.Builder> getPeriodicQueryBuilder(String nodeId) {
-            
+        public Optional<PeriodicQueryMetadata.Builder> getPeriodicQueryBuilder(final String nodeId) {
+
             if(periodicQueryBuilder != null && periodicQueryBuilder.getNodeId().equals(nodeId)) {
                 return Optional.of(periodicQueryBuilder);
             } else {
                 return Optional.absent();
             }
         }
-        
+
         /**
          * @return Creates a {@link FluoQuery} using the values that have been supplied to this builder.
-         * @throws UnsupportedQueryException 
+         * @throws UnsupportedQueryException
          */
         public FluoQuery build() throws UnsupportedQueryException {
             checkArgument((projectionBuilders.size() > 0 || constructBuilder != null));
-            
-            Optional<PeriodicQueryMetadata.Builder> optionalPeriodicQueryBuilder = getPeriodicQueryBuilder();
+
+            final Optional<PeriodicQueryMetadata.Builder> optionalPeriodicQueryBuilder = getPeriodicQueryBuilder();
             PeriodicQueryMetadata periodicQueryMetadata = null;
             if(optionalPeriodicQueryBuilder.isPresent()) {
                 periodicQueryMetadata = optionalPeriodicQueryBuilder.get().build();
             }
-            
+
             final ImmutableMap.Builder<String, ProjectionMetadata> projectionMetadata = ImmutableMap.builder();
             for(final Entry<String, ProjectionMetadata.Builder> entry : projectionBuilders.entrySet()) {
                 projectionMetadata.put(entry.getKey(), entry.getValue().build());
@@ -601,8 +601,8 @@ public class FluoQuery {
                 aggregateMetadata.put(entry.getKey(), entry.getValue().build());
             }
 
-            QueryMetadata qMetadata = queryBuilder.build();
-            
+            final QueryMetadata qMetadata = queryBuilder.build();
+
             if(constructBuilder != null) {
                 if(periodicQueryMetadata != null) {
                     throw new UnsupportedQueryException("Queries containing sliding window filters and construct query patterns are not supported.");
@@ -612,10 +612,10 @@ public class FluoQuery {
                 if(aggregationBuilders.size() > 0 && qMetadata.getQueryType() == QueryType.PROJECTION && qMetadata.getExportStrategies().contains(ExportStrategy.RYA)) {
                     throw new UnsupportedQueryException("Exporting to Rya PCJ tables is currently not supported for queries containing aggregations.");
                 }
-                
-                return new FluoQuery(queryBuilder.build(), projectionMetadata.build(), Optional.absent(), Optional.fromNullable(periodicQueryMetadata), spMetadata.build(), filterMetadata.build(), joinMetadata.build(), aggregateMetadata.build());
+
+                return new FluoQuery(qMetadata, projectionMetadata.build(), Optional.absent(), Optional.fromNullable(periodicQueryMetadata), spMetadata.build(), filterMetadata.build(), joinMetadata.build(), aggregateMetadata.build());
             }
-            
+
         }
     }
 }

--- a/extras/rya.pcj.fluo/pcj.fluo.integration/src/test/java/org/apache/rya/indexing/pcj/fluo/integration/KafkaExportIT.java
+++ b/extras/rya.pcj.fluo/pcj.fluo.integration/src/test/java/org/apache/rya/indexing/pcj/fluo/integration/KafkaExportIT.java
@@ -29,9 +29,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
-import org.apache.fluo.api.client.FluoClient;
-import org.apache.fluo.core.client.FluoClientImpl;
-import org.apache.fluo.recipes.test.FluoITHelper;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
@@ -92,8 +89,6 @@ public class KafkaExportIT extends KafkaExportITBase {
         // Create the PCJ in Fluo and load the statements into Rya.
         final String pcjId = loadDataAndCreateQuery(sparql, statements);
 
-        FluoITHelper.printFluoTable(super.getFluoConfiguration());
-        
         // The expected results of the SPARQL query once the PCJ has been computed.
         final Set<BindingSet> expectedResult = new HashSet<>();
 
@@ -249,10 +244,6 @@ public class KafkaExportIT extends KafkaExportITBase {
 
         // Create the PCJ in Fluo and load the statements into Rya.
         final String pcjId = loadDataAndCreateQuery(sparql, statements);
-        
-        try(FluoClient fluo = new FluoClientImpl(super.getFluoConfiguration())) {
-            FluoITHelper.printFluoTable(fluo);
-        }
 
         // Create the expected results of the SPARQL query once the PCJ has been computed.
         final MapBindingSet expectedResult = new MapBindingSet();
@@ -433,7 +424,7 @@ public class KafkaExportIT extends KafkaExportITBase {
         assertEquals(expectedResults, results);
     }
 
-    
+
     @Test
     public void nestedGroupByManyBindings_averages() throws Exception {
         // A query that groups what is aggregated by two of the keys.
@@ -493,7 +484,7 @@ public class KafkaExportIT extends KafkaExportITBase {
         bs.addBinding("location", vf.createLiteral("France", XMLSchema.STRING));
         bs.addBinding("averagePrice", vf.createLiteral("4.49", XMLSchema.DECIMAL));
         expectedResults.add( new VisibilityBindingSet(bs) );
-        
+
         bs = new MapBindingSet();
         bs.addBinding("type", vf.createLiteral("cheese", XMLSchema.STRING));
         bs.addBinding("location", vf.createLiteral("USA", XMLSchema.STRING));
@@ -504,11 +495,11 @@ public class KafkaExportIT extends KafkaExportITBase {
         final Set<VisibilityBindingSet> results = readGroupedResults(pcjId, new VariableOrder("type", "location"));
         assertEquals(expectedResults, results);
     }
-    
-    
+
+
     @Test
     public void nestedWithJoinGroupByManyBindings_averages() throws Exception {
-       
+
         // A query that groups what is aggregated by two of the keys.
         final String sparql =
                 "SELECT ?type ?location ?averagePrice ?milkType {" +
@@ -524,7 +515,7 @@ public class KafkaExportIT extends KafkaExportITBase {
         // Create the Statements that will be loaded into Rya.
         final ValueFactory vf = new ValueFactoryImpl();
         final Collection<Statement> statements = Sets.newHashSet(
-               
+
                 vf.createStatement(vf.createURI("urn:1"), vf.createURI("urn:type"), vf.createURI("urn:blue")),
                 vf.createStatement(vf.createURI("urn:1"), vf.createURI("urn:location"), vf.createLiteral("France")),
                 vf.createStatement(vf.createURI("urn:1"), vf.createURI("urn:price"), vf.createLiteral(8.5)),
@@ -543,7 +534,7 @@ public class KafkaExportIT extends KafkaExportITBase {
                 vf.createStatement(vf.createURI("urn:4"), vf.createURI("urn:location"), vf.createLiteral("France")),
                 vf.createStatement(vf.createURI("urn:4"), vf.createURI("urn:price"), vf.createLiteral(6.5)),
                 vf.createStatement(vf.createURI("urn:goat"), vf.createURI("urn:hasMilkType"), vf.createLiteral("goat", XMLSchema.STRING)),
-                
+
                 vf.createStatement(vf.createURI("urn:5"), vf.createURI("urn:type"), vf.createURI("urn:fontina")),
                 vf.createStatement(vf.createURI("urn:5"), vf.createURI("urn:location"), vf.createLiteral("Italy")),
                 vf.createStatement(vf.createURI("urn:5"), vf.createURI("urn:price"), vf.createLiteral(3.99)),
@@ -572,7 +563,7 @@ public class KafkaExportIT extends KafkaExportITBase {
         bs.addBinding("averagePrice", vf.createLiteral("6.5", XMLSchema.DECIMAL));
         bs.addBinding("milkType", vf.createLiteral("goat", XMLSchema.STRING));
         expectedResults.add( new VisibilityBindingSet(bs) );
-        
+
         bs = new MapBindingSet();
         bs.addBinding("type", vf.createURI("urn:fontina"));
         bs.addBinding("location", vf.createLiteral("Italy", XMLSchema.STRING));

--- a/extras/shell/src/main/java/org/apache/rya/shell/RyaAdminCommands.java
+++ b/extras/shell/src/main/java/org/apache/rya/shell/RyaAdminCommands.java
@@ -99,7 +99,8 @@ public class RyaAdminCommands implements CommandMarker {
      */
     @CliAvailabilityIndicator({
         LIST_INSTANCES_CMD,
-        INSTALL_CMD })
+        INSTALL_CMD,
+        INSTALL_PARAMETERS_CMD})
     public boolean areStorageCommandsAvailable() {
         switch(state.getShellState().getConnectionState()) {
             case CONNECTED_TO_STORAGE:

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,7 @@ under the License.
         <gmaven.version>1.3</gmaven.version> <!-- Newest: 1.5 -->
 
         <guava.version>14.0.1</guava.version> <!-- Newest: 18.0 -->
+        <gson.version>2.8.1</gson.version>
 
         <httpcomponents.httpclient.version>4.5.2</httpcomponents.httpclient.version> <!-- Newest: 4.5.3 -->
         <httpcomponents.httpcore.version>4.4.4</httpcomponents.httpcore.version> <!-- Newest: 4.4.6 -->
@@ -115,7 +116,7 @@ under the License.
         <junit.version>4.12</junit.version> <!-- Newest: 4.12 -->
         <mockito.version>1.10.19</mockito.version> <!-- Newest: 1.10.19 -->
         <mrunit.version>1.1.0</mrunit.version> <!-- Newest: 1.1.0 -->
-        <slf4j.version>1.6.6</slf4j.version> <!-- Newest: 1.7.13 -->
+        <slf4j.version>1.7.25</slf4j.version> <!-- Newest: 1.7.13 -->
         <powermock.version>1.6.1</powermock.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -129,7 +130,7 @@ under the License.
         <plexus.version>3.0.8</plexus.version>
         <thrift.version>0.9.1</thrift.version>
         <commons.cli.version>1.2</commons.cli.version>
-        <jcommander.version>1.48</jcommander.version>
+        <jcommander.version>1.60</jcommander.version> <!--  geowave declares a 1.48 dependency and does not support a version higher than 1.60 -->
         <twitter4jstream.version>4.0.1</twitter4jstream.version>
 
         <jmh.version>1.13</jmh.version>
@@ -137,7 +138,7 @@ under the License.
         <jsr305.version>1.3.9-1</jsr305.version>
         <jcip.version>1.0-1</jcip.version>
         <kafka.version>0.10.0.1</kafka.version>
-        <jopt-simple.version>4.9</jopt-simple.version>
+        <kryo.version>3.0.3</kryo.version>
         
         <!-- set profile property defaults -->
         <skip.rya.it>true</skip.rya.it>  <!-- modified by  -P enable-it  -->
@@ -239,11 +240,6 @@ under the License.
                 <artifactId>mongodb.rya</artifactId>
                 <version>${project.version}</version>
                 <type>test-jar</type>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.rya</groupId>
-                <artifactId>accumulo.utils</artifactId>
-                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.rya</groupId>
@@ -449,6 +445,11 @@ under the License.
                 <version>${guava.version}</version>
             </dependency>
             <dependency>
+                <groupId>com.google.code.gson</groupId>
+                <artifactId>gson</artifactId>
+                <version>${gson.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest-all</artifactId>
                 <version>${hamcrest.version}</version>
@@ -475,7 +476,22 @@ under the License.
                 <artifactId>slf4j-log4j12</artifactId>
                 <version>${slf4j.version}</version>
             </dependency>
-
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>log4j-over-slf4j</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>jcl-over-slf4j</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>jul-to-slf4j</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            
             <dependency>
                 <groupId>org.apache.hadoop</groupId>
                 <artifactId>hadoop-common</artifactId>
@@ -491,6 +507,26 @@ under the License.
             <dependency>
                 <groupId>org.apache.hadoop</groupId>
                 <artifactId>hadoop-client</artifactId>
+                <version>${hadoop.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.hadoop</groupId>
+                <artifactId>hadoop-hdfs</artifactId>
+                <version>${hadoop.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.hadoop</groupId>
+                <artifactId>hadoop-yarn-client</artifactId>
+                <version>${hadoop.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.hadoop</groupId>
+                <artifactId>hadoop-yarn-common</artifactId>
+                <version>${hadoop.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.hadoop</groupId>
+                <artifactId>hadoop-yarn-api</artifactId>
                 <version>${hadoop.version}</version>
             </dependency>
             <dependency>
@@ -816,6 +852,11 @@ under the License.
                 <version>${kafka.version}</version>
                 <classifier>test</classifier>
             </dependency>
+            <dependency>
+                <groupId>com.esotericsoftware</groupId>
+                <artifactId>kryo</artifactId>
+                <version>${kryo.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -943,14 +984,6 @@ under the License.
                     <configuration>
                         <shadedArtifactAttached>true</shadedArtifactAttached>
                     </configuration>
-                    <executions>
-                        <execution>
-                            <phase>package</phase>
-                            <goals>
-                                <goal>shade</goal>
-                            </goals>
-                        </execution>
-                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
@@ -1151,6 +1184,13 @@ under the License.
                                         value="com[.]beust[.]jcommander[.]internal[.]" />
                                     <property name="message"
                                         value="Please use Guava imports instead of com.beust.jcommander.internal.*" />
+                                </module>
+                                <module name="RegexpSinglelineJava">
+                                    <property name="format"
+                                        value="FluoITHelper[.]printFluoTable" />
+                                    <property name="message"
+                                        value="Please comment out stdout debugging utilities like FluoITHelper.printFluoTable()" />
+                                    <property name="ignoreComments" value="true" />
                                 </module>
                                 <!-- 
                                 <module name="RegexpSinglelineJava">


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

  http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
## Description
- Added the projects rya.periodic.notification.twill and rya.periodic.notification.twill.yarn for deploying the rya.periodic.notification.service on a YARN cluster.
- Added the KafkaLatencyBenchmark for stress testing the rya.pcj.fluo.app and rya.periodic.notification.service when deployed on a cluster.
- Added deployment packaging to the rya.benchmark project.
- Updated the periodic notification service to use slf4j-api so we are logging implementation agnostic (twill uses logback).
- Added the LoadStatements interface to the RyaClient API, so statements can be added programmatically.

### Tests
>Coverage?

[Description of what tests were written]

### Links
[Jira](https://issues.apache.org/jira/browse/RYA-356)

### Checklist
- [ ] Code Review
- [ ] Squash Commits

#### People To Reivew
@amihalik 
@meiercaleb 
