### PR TITLE
RYA-410 Add geo profile dependency management to the rya-project pom file.

### DIFF
--- a/extras/rya.geoindexing/geo.common/pom.xml
+++ b/extras/rya.geoindexing/geo.common/pom.xml
@@ -28,4 +28,14 @@
     <artifactId>rya.geo.common</artifactId>
     <name>Apache Rya Geo Indexing Common Code</name>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.rya</groupId>
+            <artifactId>rya.indexing</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.vividsolutions</groupId>
+            <artifactId>jts</artifactId>
+        </dependency>
+    </dependencies>
 </project>

--- a/extras/rya.geoindexing/geo.geomesa/pom.xml
+++ b/extras/rya.geoindexing/geo.geomesa/pom.xml
@@ -34,8 +34,15 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.rya</groupId>
+            <artifactId>rya.indexing</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.rya</groupId>
+            <artifactId>accumulo.rya</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.rya</groupId>
             <artifactId>rya.geo.common</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
@@ -50,6 +57,11 @@
             <groupId>org.geotools</groupId>
             <artifactId>gt-api</artifactId>
             <version>${geotools.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/extras/rya.geoindexing/geo.geowave/pom.xml
+++ b/extras/rya.geoindexing/geo.geowave/pom.xml
@@ -34,19 +34,24 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.rya</groupId>
+            <artifactId>rya.indexing</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.rya</groupId>
+            <artifactId>accumulo.rya</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.rya</groupId>
             <artifactId>rya.geo.common</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>mil.nga.giat</groupId>
             <artifactId>geowave-datastore-accumulo</artifactId>
-            <version>${geowave.version}</version>
         </dependency>
         <dependency>
             <groupId>mil.nga.giat</groupId>
             <artifactId>geowave-adapter-vector</artifactId>
-            <version>${geowave.version}</version>
         </dependency>
         <dependency>
             <groupId>org.geotools.xsd</groupId>
@@ -57,6 +62,12 @@
             <groupId>org.geotools</groupId>
             <artifactId>gt-api</artifactId>
             <version>${geotools.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/extras/rya.geoindexing/geo.mongo/pom.xml
+++ b/extras/rya.geoindexing/geo.mongo/pom.xml
@@ -35,13 +35,32 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.rya</groupId>
+            <artifactId>rya.indexing</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.rya</groupId>
+            <artifactId>mongodb.rya</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.rya</groupId>
             <artifactId>rya.geo.common</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.geotools.xsd</groupId>
             <artifactId>gt-xsd-gml3</artifactId>
             <version>${geotools.version}</version>
+        </dependency>
+
+        <!-- Testing dependencies. -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.rya</groupId>

--- a/extras/rya.geoindexing/pom.xml
+++ b/extras/rya.geoindexing/pom.xml
@@ -1,206 +1,51 @@
 <?xml version='1.0'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
 
-<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor 
-    license agreements. See the NOTICE file distributed with this work for additional 
-    information regarding copyright ownership. The ASF licenses this file to 
-    you under the Apache License, Version 2.0 (the "License"); you may not use 
-    this file except in compliance with the License. You may obtain a copy of 
-    the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
-    by applicable law or agreed to in writing, software distributed under the 
-    License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
-    OF ANY KIND, either express or implied. See the License for the specific 
-    language governing permissions and limitations under the License. -->
+  http://www.apache.org/licenses/LICENSE-2.0
 
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <groupId>org.apache.rya</groupId>
-    <artifactId>rya.extras</artifactId>
-    <version>3.2.12-incubating-SNAPSHOT</version>
-  </parent>
-  <artifactId>rya.geoindexing</artifactId>
-  <packaging>pom</packaging>
-  <name>Apache Rya Geo Indexing Projects</name>
-  <description>This parent has several alternative implementations using different libraries or versions of the same library.  
-  Specifically 
-          Geomesa depends on geotools v5.1 and 
-          GeoWave depends on geotools v6.
-  See the module poms for the actual versions.
-  </description>
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.rya</groupId>
+        <artifactId>rya.extras</artifactId>
+        <version>3.2.12-incubating-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>rya.geoindexing</artifactId>
+    <packaging>pom</packaging>
+
+    <name>Apache Rya Geo Indexing Projects</name>
+    <description>
+        This parent has several alternative implementations using different libraries or versions of the same library.  
+        Specifically 
+            Geomesa depends on geotools v5.1 and 
+            GeoWave depends on geotools v6.
+        See the module poms for the actual versions.
+     </description>
+
      <modules>
         <!-- common for all implementations  -->
-     	 <!-- geomesa for accumulo, uses geotools (not compatible with geowave's dependencies)   -->
-     	 <!-- geo wave for accumulo, uses geotools (not compatible with geomesa's dependencies)  -->
-     	 <!-- mongo native geo, not accumulo  -->
-     	<module>geo.common</module>
-     	<module>geo.geomesa</module>
-     	<module>geo.geowave</module>
-     	<module>geo.mongo</module>
-     </modules>
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
-	<dependencies>
-		<dependency>
-			<groupId>com.vividsolutions</groupId>
-			<artifactId>jts</artifactId>
-			<version>1.13</version>
-		</dependency>
-		<dependency>
-		   <groupId>org.apache.accumulo</groupId>
-            <artifactId>accumulo-minicluster</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.rya</groupId>
-            <artifactId>rya.sail</artifactId>
-            <exclusions>
-                <exclusion>
-                    <artifactId>hsqldb</artifactId>
-                    <groupId>hsqldb</groupId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.rya</groupId>
-            <artifactId>rya.indexing</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.rya</groupId>
-            <artifactId>accumulo.rya</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.rya</groupId>
-            <artifactId>mongodb.rya</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.rya</groupId>
-            <artifactId>rya.prospector</artifactId>
-        </dependency>
-
-        <!-- Free Text Indexing -->
-        <dependency>
-            <groupId>org.apache.lucene</groupId>
-            <artifactId>lucene-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.lucene</groupId>
-            <artifactId>lucene-analyzers</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-        </dependency>
-
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.mockito</groupId>
-			<artifactId>mockito-all</artifactId>
-			<scope>test</scope>
-		</dependency>
-        <dependency>
-            <groupId>org.apache.rya</groupId>
-            <artifactId>accumulo.rya</artifactId>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.rya</groupId>
-            <artifactId>mongodb.rya</artifactId>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
-	<build>
-		<pluginManagement>
-			<plugins>
-				<plugin>
-					<groupId>org.apache.rat</groupId>
-					<artifactId>apache-rat-plugin</artifactId>
-					<configuration>
-						<excludes>
-							<!-- RDF data Files -->
-							<exclude>**/*.ttl</exclude>
-
-							<!-- Services Files -->
-							<exclude>**/resources/META-INF/services/**</exclude>
-						</excludes>
-					</configuration>
-				</plugin>
-			</plugins>
-		</pluginManagement>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-shade-plugin</artifactId>
-				<executions>
-					<execution>
-						<goals>
-							<goal>shade</goal>
-						</goals>
-						<configuration>
-							<shadedArtifactAttached>true</shadedArtifactAttached>
-							<shadedClassifierName>map-reduce</shadedClassifierName>
-							<transformers>
-								<transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-							</transformers>
-							<filters>
-								<filter>
-									<artifact>*:*</artifact>
-									<excludes>
-										<exclude>META-INF/*.SF</exclude>
-										<exclude>META-INF/*.DSA</exclude>
-										<exclude>META-INF/*.RSA</exclude>
-									</excludes>
-								</filter>
-							</filters>
-						</configuration>
-					</execution>
-					<execution>
-						<id>accumulo-server</id>
-						<phase>package</phase>
-						<goals>
-							<goal>shade</goal>
-						</goals>
-						<configuration>
-							<shadedArtifactAttached>true</shadedArtifactAttached>
-							<shadedClassifierName>accumulo-server</shadedClassifierName>
-							<artifactSet>
-								<excludes>
-									<exclude>org.locationtech.geomesa:*</exclude>
-									<exclude>mil.nga.giat:*</exclude>
-									<exclude>scala:*</exclude>
-									<exclude>org.apache.accumulo:*</exclude>
-									<exclude>org.apache.thrift:*</exclude>
-									<exclude>org.apache.hadoop:*</exclude>
-									<exclude>org.apache.zookeeper:*</exclude>
-								</excludes>
-							</artifactSet>
-							<transformers>
-								<transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-							</transformers>
-							<filters>
-								<filter>
-									<artifact>*:*</artifact>
-									<excludes>
-										<exclude>META-INF/*.SF</exclude>
-										<exclude>META-INF/*.DSA</exclude>
-										<exclude>META-INF/*.RSA</exclude>
-									</excludes>
-								</filter>
-							</filters>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
-
+        <!-- geomesa for accumulo, uses geotools (not compatible with geowave's dependencies)   -->
+        <!-- geo wave for accumulo, uses geotools (not compatible with geomesa's dependencies)  -->
+        <!-- mongo native geo, not accumulo  -->
+        <module>geo.common</module>
+        <module>geo.geomesa</module>
+        <module>geo.geowave</module>
+        <module>geo.mongo</module>
+    </modules>
 </project>

--- a/extras/rya.streams/geo/pom.xml
+++ b/extras/rya.streams/geo/pom.xml
@@ -38,12 +38,14 @@ under the License.
         <dependency>
             <groupId>org.apache.rya</groupId>
             <artifactId>rya.pcj.functions.geo</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.rya</groupId>
             <artifactId>rya.geo.common</artifactId>
-            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.rya</groupId>
+            <artifactId>rya.indexing</artifactId>
         </dependency>
 
         <!-- Test dependencies -->

--- a/extras/rya.streams/kafka/pom.xml
+++ b/extras/rya.streams/kafka/pom.xml
@@ -41,12 +41,10 @@ under the License.
                 <dependency>
                     <groupId>org.apache.rya</groupId>
                     <artifactId>rya.pcj.functions.geo</artifactId>
-                    <version>${project.version}</version>
                 </dependency>
                 <dependency>
                     <groupId>org.apache.rya</groupId>
                     <artifactId>rya.geo.common</artifactId>
-                    <version>${project.version}</version>
                 </dependency>
             </dependencies>
         </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -75,13 +75,10 @@ under the License.
         <accumulo.version>1.6.4</accumulo.version> <!-- Newest: 1.7.0 -->
         <hadoop.version>2.5.0</hadoop.version> <!-- Newest: 2.7.1 -->
         
-        <!-- Required for GeoMesa 1.2.* -->
         <zookeeper.version>3.4.6</zookeeper.version>
 
         <pig.version>0.9.2</pig.version> <!-- Newest: 0.15.0 -->
 
-        <geomesa.version>1.3.0-m1</geomesa.version> <!-- Newest: 1.3.0-m1 -->
-        <geowave.version>0.9.3</geowave.version> <!-- Newest: 0.9.3 -->
         <lucene.version>3.6.2</lucene.version> <!-- Newest: 5.3.1 -->
         <joda-time.version>2.1</joda-time.version> <!-- Newest: 2.9.1 -->
 
@@ -145,7 +142,88 @@ under the License.
         <skip.rya.it>true</skip.rya.it>  <!-- modified by  -P enable-it  -->
     </properties>
     
+    <!-- Enable this profile if you want to include Geo functions within Rya. "mvn ... -P geoindexing" -->
     <profiles>
+        <profile>
+            <id>geoindexing</id>
+            <properties>
+                <geomesa.version>1.3.0-m1</geomesa.version> <!-- Newest: 1.3.0-m1 -->
+                <geowave.version>0.9.3</geowave.version> <!-- Newest: 0.9.3 -->
+                <jts.version>1.13</jts.version>
+            </properties>
+            <dependencyManagement>
+                <dependencies>
+                    <!-- Published RYA geo artifacts. -->
+                    <dependency>
+                        <groupId>org.apache.rya</groupId>
+                        <artifactId>rya.geo.common</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.apache.rya</groupId>
+                        <artifactId>rya.geo.geomesa</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.apache.rya</groupId>
+                        <artifactId>rya.geo.geowave</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                    <dependency>
+                       <groupId>org.apache.rya</groupId>
+                        <artifactId>rya.geo.mongo</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                    <dependency>
+                       <groupId>org.apache.rya</groupId>
+                        <artifactId>rya.geoindexing</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.apache.rya</groupId>
+                        <artifactId>rya.pcj.functions.geo</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+
+                    <!-- Geomesa dependencies. -->
+                    <dependency>
+                        <groupId>org.locationtech.geomesa</groupId>
+                        <artifactId>geomesa-accumulo-datastore_2.11</artifactId>
+                        <version>${geomesa.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.locationtech.geomesa</groupId>
+                        <artifactId>geomesa-accumulo-distributed-runtime_2.11</artifactId>
+                        <version>${geomesa.version}</version>
+                    </dependency>
+                    
+                    <!-- Geowave dependencies. -->
+                    <dependency>
+                        <groupId>mil.nga.giat</groupId>
+                        <artifactId>geowave-parent</artifactId>
+                        <version>${geowave.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>mil.nga.giat</groupId>
+                        <artifactId>geowave-datastore-accumulo</artifactId>
+                        <version>${geowave.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>mil.nga.giat</groupId>
+                        <artifactId>geowave-adapter-vector</artifactId>
+                        <version>${geowave.version}</version>
+                    </dependency>
+                    
+                    <!-- Misc dependencies. -->
+                    <dependency>
+                        <groupId>com.vividsolutions</groupId>
+                        <artifactId>jts</artifactId>
+                        <version>1.13</version>
+                    </dependency>
+                </dependencies>
+            </dependencyManagement>
+        </profile>
+    
         <!-- enable this profile "mvn ... -P enable-it" -->
         <profile>
             <id>enable-it</id>
@@ -694,24 +772,6 @@ under the License.
                 <groupId>org.apache.lucene</groupId>
                 <artifactId>lucene-analyzers</artifactId>
                 <version>${lucene.version}</version>
-            </dependency>
-
-            <!-- Geo Indexing -->
-            <dependency>
-                <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-accumulo-datastore_2.11</artifactId>
-                <version>${geomesa.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-accumulo-distributed-runtime_2.11</artifactId>
-                <version>${geomesa.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>mil.nga.giat</groupId>
-                <artifactId>geowave-parent</artifactId>
-                <version>${geowave.version}</version>
             </dependency>
 
             <dependency>

--- a/web/web.rya/pom.xml
+++ b/web/web.rya/pom.xml
@@ -203,7 +203,6 @@ under the License.
                 <dependency>
                     <groupId>org.apache.rya</groupId>
                     <artifactId>rya.geo.geowave</artifactId>
-                    <version>${project.version}</version>
                     <!-- GeoWave brings in org.springframework jars that are not compatible with web.rya versions -->
                     <exclusions>
                         <exclusion>


### PR DESCRIPTION
## Description
There is a top level geoindexing profile in the rya-project parent pom that defines the dependencies that are specific to geoindexing modules as well as which modules we publish.

### Tests
Ran all integration tests with geoindexing turned on and everything passes.

### Links
[Jira](https://issues.apache.org/jira/browse/RYA-410)

### Checklist
- [ ] Code Review
- [ ] Squash Commits
