### PR TITLE
RYA-427 Fixed connect to mongo failure

### DIFF
--- a/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/EmbeddedMongoSingleton.java
+++ b/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/EmbeddedMongoSingleton.java
@@ -60,7 +60,7 @@ public class EmbeddedMongoSingleton {
     public static IMongodConfig getMongodConfig() {
         return InstanceHolder.SINGLETON.mongodConfig;
     }
-
+    
     private EmbeddedMongoSingleton() {
         // hiding implicit default constructor
     }

--- a/extras/shell/src/test/java/org/apache/rya/shell/MongoRyaShellIT.java
+++ b/extras/shell/src/test/java/org/apache/rya/shell/MongoRyaShellIT.java
@@ -56,6 +56,19 @@ public class MongoRyaShellIT extends RyaShellMongoITBase {
         // Ensure the connection was successful.
         assertTrue(connectResult.isSuccess());
     }
+    
+    @Test
+    public void connectMongo_noConnection() throws IOException {
+        final JLineShellComponent shell = getTestShell();
+        // Attempt to connect to a mongo instance.  The bad hostname should make this fail.
+        final String cmd =
+                RyaConnectionCommands.CONNECT_MONGO_CMD + " " +
+                        "--hostname badhostname " +
+                        "--port " + super.conf.getMongoPort();
+
+        final CommandResult rez = shell.executeCommand(cmd);
+        assertEquals(RuntimeException.class, rez.getException().getClass());
+    }
 
     @Test
     public void printConnectionDetails_notConnected() {


### PR DESCRIPTION
The shell now presents the appropriate error message
if it is unable to connect to a mongodb instance.

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

  http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
## Description
>What Changed?

Added essentially a ping to the mongo server after attempting to create a mongo client, if it times out, the connection failed and an exception is thrown.

### Tests
>Coverage?

Added test to attempt to connect to the server that doesn't exist

### Links
[Jira](https://issues.apache.org/jira/browse/RYA-427)

### Checklist
- [ ] Code Review
- [x] Squash Commits

#### People To Reivew
@meiercaleb @kchilton2 
  