### PR TITLE
RYA-413 Fixed how MongoDBRyaDAO closed its internal mongoClient. Updated AbstractMongoDBRdfConfigurationBuilder config tags.

### DIFF
--- a/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/AbstractMongoDBRdfConfigurationBuilder.java
+++ b/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/AbstractMongoDBRdfConfigurationBuilder.java
@@ -40,23 +40,23 @@ public abstract class AbstractMongoDBRdfConfigurationBuilder<B extends AbstractM
     private boolean useMock = false;
     private String host = "localhost";
     private String port = DEFAULT_MONGO_PORT;
-    protected static final String DEFAULT_MONGO_PORT = "27017";
+    public static final String DEFAULT_MONGO_PORT = "27017";
     private String mongoCollectionPrefix = "rya_";
     private String mongoDBName = "rya";
     private boolean usePipeline = false;
 
-    protected static final String MONGO_USER = "mongo.user";
-    protected static final String MONGO_PASSWORD = "mongo.password";
-    protected static final String MONGO_DB_NAME = "mongo.db.name";
-    protected static final String MONGO_COLLECTION_PREFIX = "mongo.collection.prefix";
-    protected static final String MONGO_HOST = "mongo.host";
-    protected static final String MONGO_PORT = "mongo.port";
-    protected static final String MONGO_AUTHS = "mongo.auths";
-    protected static final String MONGO_VISIBILITIES = "mongo.visibilities";
-    protected static final String MONGO_RYA_PREFIX = "mongo.rya.prefix";
-    protected static final String USE_INFERENCE = "use.inference";
-    protected static final String USE_DISPLAY_QUERY_PLAN = "use.display.plan";
-    protected static final String USE_MOCK_MONGO = "use.mock";
+    public static final String MONGO_USER = "mongo.user";
+    public static final String MONGO_PASSWORD = "mongo.password";
+    public static final String MONGO_DB_NAME = "mongo.db.name";
+    public static final String MONGO_COLLECTION_PREFIX = "mongo.collection.prefix";
+    public static final String MONGO_HOST = "mongo.host";
+    public static final String MONGO_PORT = "mongo.port";
+    public static final String MONGO_AUTHS = "mongo.auths";
+    public static final String MONGO_VISIBILITIES = "mongo.visibilities";
+    public static final String MONGO_RYA_PREFIX = "mongo.rya.prefix";
+    public static final String USE_INFERENCE = "use.inference";
+    public static final String USE_DISPLAY_QUERY_PLAN = "use.display.plan";
+    public static final String USE_MOCK_MONGO = "use.mock";
 
     /**
      * Sets Mongo user.

--- a/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/MongoDBRyaDAO.java
+++ b/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/MongoDBRyaDAO.java
@@ -152,9 +152,6 @@ public final class MongoDBRyaDAO implements RyaDAO<StatefulMongoDBRdfConfigurati
                 log.error("Error closing indexer: " + indexer.getClass().getSimpleName(), e);
             }
         }
-        if (mongoClient != null) {
-            mongoClient.close();
-        }
 
         IOUtils.closeQuietly(queryEngine);
     }

--- a/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/MongoDBRyaDAOIT.java
+++ b/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/MongoDBRyaDAOIT.java
@@ -154,6 +154,67 @@ public class MongoDBRyaDAOIT extends MongoITBase {
     }
 
     @Test
+    public void testReconstructDao() throws RyaDAOException, IOException {
+        MongoDBRyaDAO dao = new MongoDBRyaDAO();
+        try {
+            dao.setConf(conf);
+            dao.init();
+
+            final RyaStatementBuilder builder = new RyaStatementBuilder();
+            builder.setPredicate(new RyaURI("http://temp.com"));
+            builder.setSubject(new RyaURI("http://subject.com"));
+            builder.setObject(new RyaURI("http://object.com"));
+            builder.setColumnVisibility(new DocumentVisibility("B").flatten());
+
+            final MongoDatabase db = conf.getMongoClient().getDatabase(conf.get(MongoDBRdfConfiguration.MONGO_DB_NAME));
+            final MongoCollection<Document> coll = db.getCollection(conf.getTriplesCollectionName());
+
+            dao.add(builder.build());
+
+            assertEquals(coll.count(), 1);
+
+            final Document dbo = coll.find().first();
+            assertTrue(dbo.containsKey(DOCUMENT_VISIBILITY));
+            assertTrue(dbo.containsKey(TIMESTAMP));
+        }  finally {
+            dao.destroy();
+        }
+
+        // Test reinitializing the same instance
+        try {
+            dao.init();
+        } finally {
+            dao.destroy();
+        }
+
+        // Reconstruct new DAO and try again
+        dao = new MongoDBRyaDAO();
+        try {
+            dao.setConf(conf);
+            dao.init();
+
+            final RyaStatementBuilder builder = new RyaStatementBuilder();
+            builder.setPredicate(new RyaURI("http://temp.com"));
+            builder.setSubject(new RyaURI("http://subject.com"));
+            builder.setObject(new RyaURI("http://object.com"));
+            builder.setColumnVisibility(new DocumentVisibility("B").flatten());
+
+            final MongoDatabase db = conf.getMongoClient().getDatabase(conf.get(MongoDBRdfConfiguration.MONGO_DB_NAME));
+            final MongoCollection<Document> coll = db.getCollection(conf.getTriplesCollectionName());
+
+            dao.add(builder.build());
+
+            assertEquals(coll.count(), 1);
+
+            final Document dbo = coll.find().first();
+            assertTrue(dbo.containsKey(DOCUMENT_VISIBILITY));
+            assertTrue(dbo.containsKey(TIMESTAMP));
+        }  finally {
+            dao.destroy();
+        }
+    }
+
+    @Test
     public void testVisibility() throws RyaDAOException, MongoException, IOException {
         final MongoDBRyaDAO dao = new MongoDBRyaDAO();
         try {

--- a/extras/indexing/src/test/java/org/apache/rya/sail/config/RyaMongoDbSailFactoryTest.java
+++ b/extras/indexing/src/test/java/org/apache/rya/sail/config/RyaMongoDbSailFactoryTest.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.sail.config;
+
+import static org.junit.Assert.assertFalse;
+
+import org.apache.rya.mongodb.MongoITBase;
+import org.junit.Assert;
+import org.junit.Test;
+import org.openrdf.model.Statement;
+import org.openrdf.model.ValueFactory;
+import org.openrdf.repository.sail.SailRepository;
+import org.openrdf.repository.sail.SailRepositoryConnection;
+import org.openrdf.sail.Sail;
+
+/**
+ * Tests {@link RyaSailFactory} with a MongoDB backend.
+ */
+public class RyaMongoDbSailFactoryTest extends MongoITBase {
+    @Test
+    public void testCreateMongoDbSail() throws Exception {
+        Sail sail = null;
+        SailRepository repo = null;
+        SailRepositoryConnection conn = null;
+        try {
+            sail = RyaSailFactory.getInstance(conf);
+            repo = new SailRepository(sail);
+            conn = repo.getConnection();
+        } finally {
+            if (conn != null) {
+                conn.close();
+            }
+            if (repo != null) {
+                repo.shutDown();
+            }
+            if (sail != null) {
+                sail.shutDown();
+            }
+        }
+    }
+
+    @Test
+    public void testAddStatement() throws Exception {
+        Sail sail = null;
+        SailRepository repo = null;
+        SailRepositoryConnection conn = null;
+        try {
+            sail = RyaSailFactory.getInstance(conf);
+            repo = new SailRepository(sail);
+            conn = repo.getConnection();
+
+            final ValueFactory vf = conn.getValueFactory();
+            final Statement s = vf.createStatement(vf.createURI("u:a"), vf.createURI("u:b"), vf.createURI("u:c"));
+
+            assertFalse(conn.hasStatement(s, false));
+
+            conn.add(s);
+
+            Assert.assertTrue(conn.hasStatement(s, false));
+        } finally {
+            if (conn != null) {
+                conn.close();
+            }
+            if (repo != null) {
+                repo.shutDown();
+            }
+            if (sail != null) {
+                sail.shutDown();
+            }
+        }
+    }
+
+    @Test
+    public void testReuseSail() throws Exception {
+        Sail sail = null;
+        SailRepository repo = null;
+        SailRepositoryConnection conn = null;
+        try {
+            sail = RyaSailFactory.getInstance(conf);
+            repo = new SailRepository(sail);
+            conn = repo.getConnection();
+
+            final ValueFactory vf = conn.getValueFactory();
+            final Statement s = vf.createStatement(vf.createURI("u:a"), vf.createURI("u:b"), vf.createURI("u:c"));
+
+            assertFalse(conn.hasStatement(s, false));
+
+            conn.add(s);
+
+            Assert.assertTrue(conn.hasStatement(s, false));
+
+            conn.remove(s);
+
+            Assert.assertFalse(conn.hasStatement(s, false));
+        } finally {
+            if (conn != null) {
+                conn.close();
+            }
+            if (repo != null) {
+                repo.shutDown();
+            }
+            if (sail != null) {
+                sail.shutDown();
+            }
+        }
+
+        // Reuse Sail after shutdown
+        try {
+            sail = RyaSailFactory.getInstance(conf);
+            repo = new SailRepository(sail);
+            conn = repo.getConnection();
+
+            final ValueFactory vf = conn.getValueFactory();
+            final Statement s = vf.createStatement(vf.createURI("u:a"), vf.createURI("u:b"), vf.createURI("u:c"));
+
+            assertFalse(conn.hasStatement(s, false));
+
+            conn.add(s);
+
+            Assert.assertTrue(conn.hasStatement(s, false));
+        } finally {
+            if (conn != null) {
+                conn.close();
+            }
+            if (repo != null) {
+                repo.shutDown();
+            }
+            if (sail != null) {
+                sail.shutDown();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description
If the MongoDBRyaDAO is destroyed, its internal mongoClient is not disposed correctly. This leaves the mongoClient closed which causes problems the next time the MongoDBRyaDAO is created.

The mongoClient is managed by MongoConnectorFactory and needs to be null'ed out to be recreated properly (by calling MongoConnectorFactory.closeMongoClient(); instead of mongoClient.close();)

Some new unit tests were added to test reconstructing the DAO. They failed with the old way of using mongoClient.close() and pass with the new way of using MongoConnectorFactory.closeMongoClient().

Also, all the static final config tags inside AbstractMongoDBRdfConfigurationBuilder were changed from protected to public (like AbstractAccumuloRdfConfigurationBuilder has) so they could be used inside other tests that make use of the tags.

NOTE: This is the same as [PR 253](https://github.com/apache/incubator-rya/pull/253) just recreated off of master after some rebasing issues with other PR.

### Tests
Unit tests

### Links
[Jira](https://issues.apache.org/jira/browse/RYA-413)

### Checklist
- [ ] Code Review
- [ ] Squash Commits

#### People To Review
@meiercaleb
@kchilton2
@jessehatfield
@isper3at
@DLotts
@pujav65
