### PR TITLE
RYA-447 Fixed issue building rya.shell under Windows.  Loading data from relative path test failed due to malformed user.home paths.

### DIFF
--- a/extras/shell/src/main/java/org/apache/rya/shell/RyaCommands.java
+++ b/extras/shell/src/main/java/org/apache/rya/shell/RyaCommands.java
@@ -29,6 +29,7 @@ import java.nio.file.Paths;
 import java.text.DecimalFormat;
 import java.util.Objects;
 
+import org.apache.commons.io.FilenameUtils;
 import org.apache.rya.api.client.RyaClient;
 import org.apache.rya.api.client.RyaClientException;
 import org.apache.rya.shell.SharedShellState.ShellState;
@@ -104,7 +105,11 @@ public class RyaCommands implements CommandMarker {
             final long start = System.currentTimeMillis();
 
             // If the provided path is relative, then make it rooted in the user's home.
-            Path rootedFile = Paths.get( file.replaceFirst("^~", System.getProperty("user.home")) );
+            // Make sure the path is formatted with Unix style file
+            // separators('/') before using it as a regex replacement string.
+            // Windows file separators('\') will not work unless escaped.
+            final String userHome = FilenameUtils.separatorsToUnix(System.getProperty("user.home"));
+            final Path rootedFile = Paths.get( file.replaceFirst("^~", userHome) );
 
             RDFFormat rdfFormat = null;
             // If a format was provided, then go with that.


### PR DESCRIPTION
## Description
When building rya.shell under Windows, loading tests fail due to malformed user.home paths.  It appears that Windows file separators ('\\') are causing problems when being used as part of a regex replacement operation since they're not being escaped.

### Tests
Build/Unit Test

### Links
[Jira](https://issues.apache.org/jira/browse/RYA-447)

### Checklist
- [ ] Code Review
- [ ] Squash Commits

#### People To Review
@meiercaleb
@kchilton2
@jessehatfield
@isper3at
@DLotts
@pujav65
