### PR TITLE
RYA-442 Implementing the Start and Stop Query interactors.

### DIFF
--- a/extras/rya.streams/api/src/main/java/org/apache/rya/streams/api/entity/StreamsQuery.java
+++ b/extras/rya.streams/api/src/main/java/org/apache/rya/streams/api/entity/StreamsQuery.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -34,16 +34,19 @@ public class StreamsQuery {
 
     private final UUID queryId;
     private final String sparql;
+    private final boolean isActive;
 
     /**
      * Constructs an instance of {@link StreamsQuery}.
      *
      * @param queryId - Uniquely identifies the query within Rya Streams. (not null)
      * @param sparql - The SPARQL query that defines how statements will be processed. (not null)
+     * @param isActive - {@code true} if Rya Streams should process this query; otherwise {@code false}.
      */
-    public StreamsQuery(final UUID queryId, final String sparql) {
+    public StreamsQuery(final UUID queryId, final String sparql, final boolean isActive) {
         this.queryId = requireNonNull(queryId);
         this.sparql = requireNonNull(sparql);
+        this.isActive = isActive;
     }
 
     /**
@@ -60,9 +63,16 @@ public class StreamsQuery {
         return sparql;
     }
 
+    /**
+     * @return {@code true} if Rya Streams should process this query; otherwise {@code false}.
+     */
+    public boolean isActive() {
+        return isActive;
+    }
+
     @Override
     public int hashCode() {
-        return Objects.hash(queryId, sparql);
+        return Objects.hash(queryId, sparql, isActive);
     }
 
     @Override
@@ -70,7 +80,8 @@ public class StreamsQuery {
         if(o instanceof StreamsQuery) {
             final StreamsQuery other = (StreamsQuery) o;
             return Objects.equals(queryId, other.queryId) &&
-                    Objects.equals(sparql, other.sparql);
+                    Objects.equals(sparql, other.sparql) &&
+                    isActive == other.isActive;
         }
         return false;
     }

--- a/extras/rya.streams/api/src/main/java/org/apache/rya/streams/api/interactor/defaults/DefaultAddQuery.java
+++ b/extras/rya.streams/api/src/main/java/org/apache/rya/streams/api/interactor/defaults/DefaultAddQuery.java
@@ -49,7 +49,7 @@ public class DefaultAddQuery implements AddQuery {
     }
 
     @Override
-    public StreamsQuery addQuery(final String query) throws RyaStreamsException {
+    public StreamsQuery addQuery(final String query, final boolean isActive) throws RyaStreamsException {
         requireNonNull(query);
 
         // Make sure the SPARQL is valid.
@@ -60,6 +60,6 @@ public class DefaultAddQuery implements AddQuery {
         }
 
         // If it is, then store it in the repository.
-        return repository.add(query);
+        return repository.add(query, isActive);
     }
 }

--- a/extras/rya.streams/api/src/main/java/org/apache/rya/streams/api/interactor/defaults/DefaultStartQuery.java
+++ b/extras/rya.streams/api/src/main/java/org/apache/rya/streams/api/interactor/defaults/DefaultStartQuery.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -16,28 +16,39 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.rya.streams.api.interactor;
+package org.apache.rya.streams.api.interactor.defaults;
 
-import org.apache.rya.streams.api.entity.StreamsQuery;
+import static java.util.Objects.requireNonNull;
+
+import java.util.UUID;
+
 import org.apache.rya.streams.api.exception.RyaStreamsException;
+import org.apache.rya.streams.api.interactor.StartQuery;
+import org.apache.rya.streams.api.queries.QueryRepository;
 
 import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
- * Adds a SPARQL Query to be processed by Rya Streams.
+ * Start a query that is managed by Rya Streams.
  */
 @DefaultAnnotation(NonNull.class)
-public interface AddQuery {
+public class DefaultStartQuery implements StartQuery {
+
+    private final QueryRepository repository;
 
     /**
-     * Adds a query to the Rya Streams system.
+     * Constructs an instance of {@link DefaultStartQuery}.
      *
-     * @param query - The SPARQL query that will be added. (not null)
-     * @param isActive - {@code true} if the query needs to be maintained by
-     *   Rya Streams; otherwise {@code false}.
-     * @return The {@link StreamsQuery} used by Rya Streams for this query.
-     * @throws RyaStreamsException The query could not be added to Rya Streams.
+     * @param repository - The {@link QueryRepository} that will be interacted with. (not null)
      */
-    public StreamsQuery addQuery(final String query, boolean isActive) throws RyaStreamsException;
+    public DefaultStartQuery(final QueryRepository repository) {
+        this.repository = requireNonNull(repository);
+    }
+
+    @Override
+    public void start(final UUID queryId) throws RyaStreamsException {
+        requireNonNull(queryId);
+        repository.updateIsActive(queryId, true);
+    }
 }

--- a/extras/rya.streams/api/src/main/java/org/apache/rya/streams/api/interactor/defaults/DefaultStopQuery.java
+++ b/extras/rya.streams/api/src/main/java/org/apache/rya/streams/api/interactor/defaults/DefaultStopQuery.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -16,28 +16,39 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.rya.streams.api.interactor;
+package org.apache.rya.streams.api.interactor.defaults;
 
-import org.apache.rya.streams.api.entity.StreamsQuery;
+import static java.util.Objects.requireNonNull;
+
+import java.util.UUID;
+
 import org.apache.rya.streams.api.exception.RyaStreamsException;
+import org.apache.rya.streams.api.interactor.StopQuery;
+import org.apache.rya.streams.api.queries.QueryRepository;
 
 import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
- * Adds a SPARQL Query to be processed by Rya Streams.
+ * Stop a query that is managed by Rya Streams.
  */
 @DefaultAnnotation(NonNull.class)
-public interface AddQuery {
+public class DefaultStopQuery implements StopQuery {
+
+    private final QueryRepository repository;
 
     /**
-     * Adds a query to the Rya Streams system.
+     * Constructs an instance of {@link DefaultStopQuery}.
      *
-     * @param query - The SPARQL query that will be added. (not null)
-     * @param isActive - {@code true} if the query needs to be maintained by
-     *   Rya Streams; otherwise {@code false}.
-     * @return The {@link StreamsQuery} used by Rya Streams for this query.
-     * @throws RyaStreamsException The query could not be added to Rya Streams.
+     * @param repository - The {@link QueryRepository} that will be interacted with. (not null)
      */
-    public StreamsQuery addQuery(final String query, boolean isActive) throws RyaStreamsException;
+    public DefaultStopQuery(final QueryRepository repository) {
+        this.repository = requireNonNull(repository);
+    }
+
+    @Override
+    public void stop(final UUID queryId) throws RyaStreamsException {
+        requireNonNull(queryId);
+        repository.updateIsActive(queryId, false);
+    }
 }

--- a/extras/rya.streams/api/src/main/java/org/apache/rya/streams/api/queries/InMemoryQueryRepository.java
+++ b/extras/rya.streams/api/src/main/java/org/apache/rya/streams/api/queries/InMemoryQueryRepository.java
@@ -33,16 +33,15 @@ import org.apache.rya.streams.api.queries.QueryChangeLog.QueryChangeLogException
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
-
 import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import info.aduna.iteration.CloseableIteration;
 
 /**
- * An in memory implementation of {@link QueryRepository}. It is lazily initialized the first time one of its
- * functions is invoked.
+ * An in memory implementation of {@link QueryRepository}. It is lazily
+ * initialized the first time one of its functions is invoked and it updates
+ * its view of the {@link QueryChangeLog} any time a method is invoked that
+ * requires the latest view of the queries.
  * </p>
  * Thread safe.
  */
@@ -51,9 +50,21 @@ public class InMemoryQueryRepository implements QueryRepository {
     private static final Logger LOG = LoggerFactory.getLogger(InMemoryQueryRepository.class);
 
     private final ReentrantLock lock = new ReentrantLock();
-    private final Supplier<Map<UUID, StreamsQuery>> queriesCache;
 
+    /**
+     * The change log that is the ground truth for describing what the queries look like.
+     */
     private final QueryChangeLog changeLog;
+
+    /**
+     * Represents the position within the {@link QueryChangeLog} that {@code queriesCache} represents.
+     */
+    private Optional<Long> cachePosition = Optional.empty();
+
+    /**
+     * The most recently cached view of the queries within this repository.
+     */
+    private final Map<UUID, StreamsQuery> queriesCache = new HashMap<>();
 
     /**
      * Constructs an instance of {@link InMemoryQueryRepository}.
@@ -62,28 +73,24 @@ public class InMemoryQueryRepository implements QueryRepository {
      */
     public InMemoryQueryRepository(final QueryChangeLog changeLog) {
         this.changeLog = requireNonNull(changeLog);
-
-        // Lazily initialize the queries cache the first time you try to use it.
-        queriesCache = Suppliers.memoize(() -> initializeCache(changeLog));
     }
 
     @Override
-    public StreamsQuery add(final String query) throws QueryRepositoryException {
+    public StreamsQuery add(final String query, final boolean isActive) throws QueryRepositoryException {
         requireNonNull(query);
 
         lock.lock();
         try {
             // First record the change to the log.
             final UUID queryId = UUID.randomUUID();
-            final QueryChange change = QueryChange.create(queryId, query);
+            final QueryChange change = QueryChange.create(queryId, query, isActive);
             changeLog.write(change);
 
-            // Then update the view of the change log within the repository.
-            final StreamsQuery streamsQuery = new StreamsQuery(queryId, query);
-            queriesCache.get().put(queryId, streamsQuery);
+            // Update the cache to represent what is currently in the log.
+            updateCache();
 
-            // Return the SreamsQuery that represents the just added query.
-            return streamsQuery;
+            // Return the StreamsQuery that represents the just added query.
+            return queriesCache.get(queryId);
 
         } catch (final QueryChangeLogException e) {
             throw new QueryRepositoryException("Could not create a Rya Streams query for the SPARQL string: " + query, e);
@@ -98,7 +105,35 @@ public class InMemoryQueryRepository implements QueryRepository {
 
         lock.lock();
         try {
-            return Optional.ofNullable( queriesCache.get().get(queryId) );
+            // Update the cache to represent what is currently in the log.
+            updateCache();
+
+            return Optional.ofNullable( queriesCache.get(queryId) );
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public void updateIsActive(final UUID queryId, final boolean isActive) throws QueryRepositoryException {
+        requireNonNull(queryId);
+
+        lock.lock();
+        try {
+            // Update the cache to represent what is currently in the log.
+            updateCache();
+
+            // Ensure the query is in the log.
+            if(!queriesCache.containsKey(queryId)) {
+                throw new QueryRepositoryException("No query exists for ID " + queryId + ".");
+            }
+
+            // First record the change to the log.
+            final QueryChange change = QueryChange.update(queryId, isActive);
+            changeLog.write(change);
+
+        } catch (final QueryChangeLogException e) {
+            throw new QueryRepositoryException("Could not update the Rya Streams query for with ID: " + queryId, e);
         } finally {
             lock.unlock();
         }
@@ -114,9 +149,6 @@ public class InMemoryQueryRepository implements QueryRepository {
             final QueryChange change = QueryChange.delete(queryId);
             changeLog.write(change);
 
-            // Then update the view of the change log within the repository.
-            queriesCache.get().remove(queryId);
-
         } catch (final QueryChangeLogException e) {
             throw new QueryRepositoryException("Could not delete a Rya Streams query for the Query ID: " + queryId, e);
         } finally {
@@ -128,8 +160,11 @@ public class InMemoryQueryRepository implements QueryRepository {
     public Set<StreamsQuery> list() throws QueryRepositoryException {
         lock.lock();
         try {
-            // Our internal cache is already up to date, so just return it's values.
-            return queriesCache.get().values()
+            // Update the cache to represent what is currently in the log.
+            updateCache();
+
+            // Our internal cache is already up to date, so just return its values.
+            return queriesCache.values()
                         .stream()
                         .collect(Collectors.toSet());
 
@@ -149,22 +184,19 @@ public class InMemoryQueryRepository implements QueryRepository {
     }
 
     /**
-     * A {@link Map} from query id to the {@link StreamsQuery} that is represented by that id based on what
-     * is already in a {@link QueryChangeLog}.
-     *
-     * @param changeLog - The change log the cache will represent. (not null)
-     * @return The most recent view of the change log.
+     * Updates the {@link #queriesCache} to reflect the latest position within the {@link #changeLog}.
      */
-    private static Map<UUID, StreamsQuery> initializeCache(final QueryChangeLog changeLog) {
+    private void updateCache() {
         requireNonNull(changeLog);
-
-        // The Map that will be initialized and then returned by this supplier.
-        final Map<UUID, StreamsQuery> queriesCache = new HashMap<>();
 
         CloseableIteration<ChangeLogEntry<QueryChange>, QueryChangeLogException> it = null;
         try {
-            // Iterate over everything that is already in the change log.
-            it = changeLog.readFromStart();
+            // Iterate over everything since the last position that was handled within the change log.
+            if(cachePosition.isPresent()) {
+                it = changeLog.readFromPosition(cachePosition.get() + 1);
+            } else {
+                it = changeLog.readFromStart();
+            }
 
             // Apply each change to the cache.
             while(it.hasNext()) {
@@ -174,18 +206,31 @@ public class InMemoryQueryRepository implements QueryRepository {
 
                 switch(change.getChangeType()) {
                     case CREATE:
-                        final StreamsQuery query = new StreamsQuery(queryId, change.getSparql().get());
+                        final StreamsQuery query = new StreamsQuery(
+                                queryId,
+                                change.getSparql().get(),
+                                change.getIsActive().get());
                         queriesCache.put(queryId, query);
+                        break;
+
+                    case UPDATE:
+                        if(queriesCache.containsKey(queryId)) {
+                            final StreamsQuery old = queriesCache.get(queryId);
+                            final StreamsQuery updated = new StreamsQuery(
+                                    old.getQueryId(),
+                                    old.getSparql(),
+                                    change.getIsActive().get());
+                            queriesCache.put(queryId, updated);
+                        }
                         break;
 
                     case DELETE:
                         queriesCache.remove(queryId);
                         break;
                 }
-            }
 
-            // Return the initialized cache.
-            return queriesCache;
+                cachePosition = Optional.of( entry.getPosition() );
+            }
 
         } catch (final QueryChangeLogException e) {
             // Rethrow the exception because the object the supplier tried to create could not be created.

--- a/extras/rya.streams/api/src/main/java/org/apache/rya/streams/api/queries/QueryRepository.java
+++ b/extras/rya.streams/api/src/main/java/org/apache/rya/streams/api/queries/QueryRepository.java
@@ -38,10 +38,23 @@ public interface QueryRepository extends AutoCloseable {
      * Adds a new query to Rya Streams.
      *
      * @param query - The SPARQL query to add. (not null)
+     * @param isActive - {@code true} if the query should be processed after it is added
+     *   otherwise {@code false}.
      * @return The {@link StreamsQuery} used in Rya Streams.
      * @throws QueryRepositoryException Could not add the query.
      */
-    public StreamsQuery add(final String query) throws QueryRepositoryException;
+    public StreamsQuery add(final String query, boolean isActive) throws QueryRepositoryException;
+
+    /**
+     * Updates the isActive state of a {@link StreamsQuery}. Setting this value to {@code true}
+     * means Rya Streams will start processing the query. Setting it to {@code false} will stop
+     * the processing.
+     *
+     * @param queryId - Identifies which query will be updated. (not null)
+     * @param isActive - The new isActive state for the query.
+     * @throws QueryRepositoryException If the query does not exist or something else caused the change to fail.
+     */
+    public void updateIsActive(UUID queryId, boolean isActive) throws QueryRepositoryException;
 
     /**
      * Get an existing query from Rya Streams.

--- a/extras/rya.streams/api/src/test/java/org/apache/rya/streams/api/interactor/defaults/DefaultAddQueryTest.java
+++ b/extras/rya.streams/api/src/test/java/org/apache/rya/streams/api/interactor/defaults/DefaultAddQueryTest.java
@@ -43,10 +43,10 @@ public class DefaultAddQueryTest {
         final AddQuery addQuery = new DefaultAddQuery(repo);
 
         // Add the query.
-        addQuery.addQuery(sparql);
+        addQuery.addQuery(sparql, true);
 
         // Verify the call was forwarded to the repository.
-        verify(repo, times(1)).add(eq(sparql));
+        verify(repo, times(1)).add(eq(sparql), eq(true));
     }
 
     @Test(expected = RyaStreamsException.class)
@@ -59,6 +59,6 @@ public class DefaultAddQueryTest {
         final AddQuery addQuery = new DefaultAddQuery(repo);
 
         // Add the query.
-        addQuery.addQuery(sparql);
+        addQuery.addQuery(sparql, true);
     }
 }

--- a/extras/rya.streams/api/src/test/java/org/apache/rya/streams/api/queries/InMemoryQueryRepositoryTest.java
+++ b/extras/rya.streams/api/src/test/java/org/apache/rya/streams/api/queries/InMemoryQueryRepositoryTest.java
@@ -43,9 +43,9 @@ public class InMemoryQueryRepositoryTest {
         try(final QueryRepository queries = new InMemoryQueryRepository( new InMemoryQueryChangeLog() )) {
             // Add some queries to it.
             final Set<StreamsQuery> expected = new HashSet<>();
-            expected.add( queries.add("query 1") );
-            expected.add( queries.add("query 2") );
-            expected.add( queries.add("query 3") );
+            expected.add( queries.add("query 1", true) );
+            expected.add( queries.add("query 2", false) );
+            expected.add( queries.add("query 3", true) );
 
             // Show they are in the list of all queries.
             final Set<StreamsQuery> stored = queries.list();
@@ -59,9 +59,9 @@ public class InMemoryQueryRepositoryTest {
         try(final QueryRepository queries = new InMemoryQueryRepository( new InMemoryQueryChangeLog() )) {
             // Add some queries to it. The second one we will delete.
             final Set<StreamsQuery> expected = new HashSet<>();
-            expected.add( queries.add("query 1") );
-            final UUID deletedMeId = queries.add("query 2").getQueryId();
-            expected.add( queries.add("query 3") );
+            expected.add( queries.add("query 1", true) );
+            final UUID deletedMeId = queries.add("query 2", false).getQueryId();
+            expected.add( queries.add("query 3", true) );
 
             // Delete the second query.
             queries.delete( deletedMeId );
@@ -73,15 +73,15 @@ public class InMemoryQueryRepositoryTest {
     }
 
     @Test
-    public void initializedWithPopulatedChnageLog() throws Exception {
+    public void initializedWithPopulatedChangeLog() throws Exception {
         // Setup a totally in memory QueryRepository. Hold onto the change log so that we can use it again later.
         final QueryChangeLog changeLog = new InMemoryQueryChangeLog();
         try(final QueryRepository queries = new InMemoryQueryRepository( changeLog )) {
             // Add some queries and deletes to it.
             final Set<StreamsQuery> expected = new HashSet<>();
-            expected.add( queries.add("query 1") );
-            final UUID deletedMeId = queries.add("query 2").getQueryId();
-            expected.add( queries.add("query 3") );
+            expected.add( queries.add("query 1", true) );
+            final UUID deletedMeId = queries.add("query 2", false).getQueryId();
+            expected.add( queries.add("query 3", true) );
             queries.delete( deletedMeId );
 
             // Create a new totally in memory QueryRepository.
@@ -110,7 +110,7 @@ public class InMemoryQueryRepositoryTest {
         // Setup a totally in memory QueryRepository.
         try(final QueryRepository queries = new InMemoryQueryRepository( new InMemoryQueryChangeLog() )) {
             // Add a query to it.
-            final StreamsQuery query = queries.add("query 1");
+            final StreamsQuery query = queries.add("query 1", true);
 
             // Show the fetched query matches the expected ones.
             final Optional<StreamsQuery> fetched = queries.get(query.getQueryId());
@@ -127,6 +127,23 @@ public class InMemoryQueryRepositoryTest {
 
             // Show it could not be found.
             assertFalse(query.isPresent());
+        }
+    }
+
+    @Test
+    public void update() throws Exception {
+        // Setup a totally in memory QueryRepository.
+        try(final QueryRepository queries = new InMemoryQueryRepository( new InMemoryQueryChangeLog() )) {
+            // Add a query to it.
+            final StreamsQuery query = queries.add("query 1", true);
+
+            // Change the isActive state of that query.
+            queries.updateIsActive(query.getQueryId(), false);
+
+            // Show the fetched query matches the expected one.
+            final Optional<StreamsQuery> fetched = queries.get(query.getQueryId());
+            final StreamsQuery expected = new StreamsQuery(query.getQueryId(), query.getSparql(), false);
+            assertEquals(expected, fetched.get());
         }
     }
 }

--- a/extras/rya.streams/client/src/main/java/org/apache/rya/streams/client/command/AddQueryCommand.java
+++ b/extras/rya.streams/client/src/main/java/org/apache/rya/streams/client/command/AddQueryCommand.java
@@ -52,6 +52,9 @@ public class AddQueryCommand implements RyaStreamsCommand {
         @Parameter(names = { "--query", "-q" }, required = true, description = "The SPARQL query to add to Rya Streams.")
         private String query;
 
+        @Parameter(names = {"--isActive", "-a"}, required = false, description = "True if the added query will be started.")
+        private String isActive;
+
         @Override
         public String toString() {
             final StringBuilder parameters = new StringBuilder();
@@ -60,6 +63,7 @@ public class AddQueryCommand implements RyaStreamsCommand {
             if (!Strings.isNullOrEmpty(query)) {
                 parameters.append("\tQuery: " + query + "\n");
             }
+            parameters.append("\tIs Active: " + isActive + "\n");
             return parameters.toString();
         }
     }
@@ -115,7 +119,7 @@ public class AddQueryCommand implements RyaStreamsCommand {
         try(QueryRepository queryRepo = new InMemoryQueryRepository(queryChangeLog)) {
             final AddQuery addQuery = new DefaultAddQuery(queryRepo);
             try {
-                final StreamsQuery query = addQuery.addQuery(params.query);
+                final StreamsQuery query = addQuery.addQuery(params.query, Boolean.parseBoolean(params.isActive));
                 System.out.println("Added query: " + query.getSparql());
             } catch (final RyaStreamsException e) {
                 System.err.println("Unable to parse query: " + params.query);

--- a/extras/rya.streams/client/src/test/java/org/apache/rya/streams/client/command/AddQueryCommandIT.java
+++ b/extras/rya.streams/client/src/test/java/org/apache/rya/streams/client/command/AddQueryCommandIT.java
@@ -80,7 +80,8 @@ public class AddQueryCommandIT {
                 "-r", "" + ryaInstance,
                 "-i", kafka.getKafkaHostname(),
                 "-p", kafka.getKafkaPort(),
-                "-q", query
+                "-q", query,
+                "-a", "true"
         };
 
         // Execute the command.
@@ -101,7 +102,8 @@ public class AddQueryCommandIT {
                 "--ryaInstance", "" + ryaInstance,
                 "--kafkaHostname", kafka.getKafkaHostname(),
                 "--kafkaPort", kafka.getKafkaPort(),
-                "--query", query
+                "--query", query,
+                "--isActive", "true"
         };
 
         // Execute the command.

--- a/extras/rya.streams/client/src/test/java/org/apache/rya/streams/client/command/ListQueryCommandIT.java
+++ b/extras/rya.streams/client/src/test/java/org/apache/rya/streams/client/command/ListQueryCommandIT.java
@@ -71,9 +71,9 @@ public class ListQueryCommandIT {
     @Test
     public void shortParams() throws Exception {
         // Add a few queries to Rya Streams.
-        queryRepo.add("query1");
-        queryRepo.add("query2");
-        queryRepo.add("query3");
+        queryRepo.add("query1", true);
+        queryRepo.add("query2", false);
+        queryRepo.add("query3", true);
 
         // Execute the List Queries command.
         final String[] args = new String[] {
@@ -89,9 +89,9 @@ public class ListQueryCommandIT {
     @Test
     public void longParams() throws Exception {
         // Add a few queries to Rya Streams.
-        queryRepo.add("query1");
-        queryRepo.add("query2");
-        queryRepo.add("query3");
+        queryRepo.add("query1", true);
+        queryRepo.add("query2", false);
+        queryRepo.add("query3", true);
 
         // Execute the List Queries command.
         final String[] args = new String[] {

--- a/extras/rya.streams/client/src/test/java/org/apache/rya/streams/client/command/RunQueryCommandIT.java
+++ b/extras/rya.streams/client/src/test/java/org/apache/rya/streams/client/command/RunQueryCommandIT.java
@@ -114,7 +114,7 @@ public class RunQueryCommandIT {
     @Test
     public void runQuery() throws Exception {
         // Register a query with the Query Repository.
-        final StreamsQuery sQuery = queryRepo.add("SELECT * WHERE { ?person <urn:worksAt> ?business . }");
+        final StreamsQuery sQuery = queryRepo.add("SELECT * WHERE { ?person <urn:worksAt> ?business . }", true);
 
         // Arguments that run the query we just registered with Rya Streams.
         final String[] args = new String[] {

--- a/extras/rya.streams/kafka/src/test/java/org/apache/rya/streams/kafka/interactor/KafkaRunQueryIT.java
+++ b/extras/rya.streams/kafka/src/test/java/org/apache/rya/streams/kafka/interactor/KafkaRunQueryIT.java
@@ -86,7 +86,7 @@ public class KafkaRunQueryIT {
         final QueryRepository queries = new InMemoryQueryRepository( new InMemoryQueryChangeLog() );
 
         // Add the query to the query repository.
-        final StreamsQuery sQuery = queries.add("SELECT * WHERE { ?person <urn:worksAt> ?business . }");
+        final StreamsQuery sQuery = queries.add("SELECT * WHERE { ?person <urn:worksAt> ?business . }", true);
         final UUID queryId = sQuery.getQueryId();
         final String resultsTopic = KafkaTopics.queryResultsTopic(queryId);
 


### PR DESCRIPTION
## Description
Implemented DefaultStartQuery and DefaultStopQuery interactors. The InMemoryQueryRepository was also updated to refresh its cache if the underlying QueryChangeLog has been updated.

### Tests
Updated and added tests.

### Links
https://issues.apache.org/jira/browse/RYA-442
