### PR TITLE
Fixed tests that are sensitive to DST spring forward.

### DIFF
--- a/common/rya.api/src/test/java/org/apache/rya/api/functions/DateTimeWithinPeriodTest.java
+++ b/common/rya.api/src/test/java/org/apache/rya/api/functions/DateTimeWithinPeriodTest.java
@@ -38,12 +38,13 @@ public class DateTimeWithinPeriodTest {
     private static final ValueFactory vf = new ValueFactoryImpl();
     private static final Literal TRUE = vf.createLiteral(true);
     private static final Literal FALSE = vf.createLiteral(false);
+    private static final ZonedDateTime testThisTimeDate = ZonedDateTime.parse("2018-02-03T14:15:16+07:00");
 
     @Test
     public void testSeconds() throws DatatypeConfigurationException, ValueExprEvaluationException {
         DatatypeFactory dtf = DatatypeFactory.newInstance();
 
-        ZonedDateTime zTime = ZonedDateTime.now();
+        ZonedDateTime zTime = testThisTimeDate;
         String time = zTime.format(DateTimeFormatter.ISO_INSTANT);
 
         ZonedDateTime zTime1 = zTime.minusSeconds(1);
@@ -64,7 +65,7 @@ public class DateTimeWithinPeriodTest {
 
         DatatypeFactory dtf = DatatypeFactory.newInstance();
 
-        ZonedDateTime zTime = ZonedDateTime.now();
+        ZonedDateTime zTime = testThisTimeDate;
         String time = zTime.format(DateTimeFormatter.ISO_INSTANT);
 
         ZonedDateTime zTime1 = zTime.minusMinutes(1);
@@ -85,7 +86,7 @@ public class DateTimeWithinPeriodTest {
     public void testHours() throws DatatypeConfigurationException, ValueExprEvaluationException {
         DatatypeFactory dtf = DatatypeFactory.newInstance();
 
-        ZonedDateTime zTime = ZonedDateTime.now();
+        ZonedDateTime zTime = testThisTimeDate;
         String time = zTime.format(DateTimeFormatter.ISO_INSTANT);
 
         ZonedDateTime zTime1 = zTime.minusHours(1);
@@ -106,7 +107,7 @@ public class DateTimeWithinPeriodTest {
     public void testDays() throws DatatypeConfigurationException, ValueExprEvaluationException {
         DatatypeFactory dtf = DatatypeFactory.newInstance();
 
-        ZonedDateTime zTime = ZonedDateTime.now();
+        ZonedDateTime zTime = testThisTimeDate;
         String time = zTime.format(DateTimeFormatter.ISO_INSTANT);
 
         ZonedDateTime zTime1 = zTime.minusDays(1);
@@ -122,11 +123,12 @@ public class DateTimeWithinPeriodTest {
         assertEquals(TRUE, func.evaluate(vf, now, nowMinusOne, vf.createLiteral(2), OWLTime.DAYS_URI));
     }
 
+    // Note that this test fails if the week under test spans a DST when the USA springs forward.
     @Test
     public void testWeeks() throws DatatypeConfigurationException, ValueExprEvaluationException {
         DatatypeFactory dtf = DatatypeFactory.newInstance();
 
-        ZonedDateTime zTime = ZonedDateTime.now();
+        ZonedDateTime zTime = testThisTimeDate;
         String time = zTime.format(DateTimeFormatter.ISO_INSTANT);
 
         ZonedDateTime zTime1 = zTime.minusWeeks(1);
@@ -151,7 +153,7 @@ public class DateTimeWithinPeriodTest {
     public void testTimeZone() throws DatatypeConfigurationException, ValueExprEvaluationException {
         DatatypeFactory dtf = DatatypeFactory.newInstance();
 
-        ZonedDateTime now = ZonedDateTime.now();
+        ZonedDateTime now = testThisTimeDate;
         String time = now.format(DateTimeFormatter.ISO_INSTANT);
 
         ZonedDateTime zTime1 = now.withZoneSameInstant(ZoneId.of("Europe/London"));
@@ -175,6 +177,5 @@ public class DateTimeWithinPeriodTest {
         assertEquals(FALSE, func.evaluate(vf, nowLocal, nowAsiaTZMinusOne, vf.createLiteral(1), OWLTime.DAYS_URI));
         assertEquals(TRUE, func.evaluate(vf, nowLocal, nowAsiaTZMinusOne, vf.createLiteral(2), OWLTime.DAYS_URI));
     }
-
 
 }

--- a/extras/rya.streams/query-manager/pom.xml
+++ b/extras/rya.streams/query-manager/pom.xml
@@ -22,7 +22,7 @@ under the License.
     <parent>
         <groupId>org.apache.rya</groupId>
         <artifactId>rya.streams.parent</artifactId>
-        <version>3.2.12-incubating-SNAPSHOT</version>
+        <version>3.2.13-incubating-SNAPSHOT</version>
     </parent>
     
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
## Description
Fixed failed assertion here:
org.apache.rya.api.functions.DateTimeWithinPeriodTest.testWeeks(DateTimeWithinPeriodTest.java:145)
Failed because of DST transition.  Test is using the current date and time.  Changed to fixed datetime.

### Tests
No new tests.

### Links
[Jira RYA-476](https://issues.apache.org/jira/browse/RYA-476)

### Checklist
- [ ] Code Review
- [ ] Squash Commits

#### People To Review
anyone