### PR TITLE
RYA-501 change from Guava Iterators to Java Collections

### DIFF
--- a/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/iter/RyaStatementBindingSetCursorIterator.java
+++ b/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/iter/RyaStatementBindingSetCursorIterator.java
@@ -19,6 +19,7 @@
 package org.apache.rya.mongodb.iter;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -37,7 +38,6 @@ import org.bson.Document;
 import org.openrdf.query.BindingSet;
 
 import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Iterators;
 import com.google.common.collect.Multimap;
 import com.mongodb.DBObject;
 import com.mongodb.client.AggregateIterable;
@@ -92,7 +92,7 @@ public class RyaStatementBindingSetCursorIterator implements CloseableIteration<
     }
 
     private boolean currentBindingSetIteratorIsValid() {
-        return (currentBindingSetIterator != null) && currentBindingSetIterator.hasNext();
+        return currentBindingSetIterator != null && currentBindingSetIterator.hasNext();
     }
 
     private void findNextResult() {
@@ -131,7 +131,7 @@ public class RyaStatementBindingSetCursorIterator implements CloseableIteration<
     }
 
     private static boolean isResult(final RyaType query, final RyaType result) {
-        return (query == null) || query.equals(result);
+        return query == null || query.equals(result);
     }
 
     private void submitBatchQuery() {
@@ -153,7 +153,7 @@ public class RyaStatementBindingSetCursorIterator implements CloseableIteration<
         } else if (match.size() == 1) {
             pipeline.add(new Document("$match", match.get(0)));
         } else {
-            batchQueryResultsIterator = Iterators.emptyIterator();
+            batchQueryResultsIterator = Collections.emptyIterator();
             return;
         }
 
@@ -167,7 +167,7 @@ public class RyaStatementBindingSetCursorIterator implements CloseableIteration<
     }
 
     private boolean currentBatchQueryResultCursorIsValid() {
-        return (batchQueryResultsIterator != null) && batchQueryResultsIterator.hasNext();
+        return batchQueryResultsIterator != null && batchQueryResultsIterator.hasNext();
     }
 
 


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

  http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
## Description
>What Changed?

Google changed the Iterators object emptyIterator() visibility.
This can cause versioning issues with anything depending on
a newer version of guava.

### Tests
>Coverage?


### Links

### Checklist
- [ ] Code Review
- [x] Squash Commits

#### People To Reivew
@pujav65 
@kchilton2 
@ejwhite922 
@jessehatfield 

