### PR TITLE
RYA-501 Change guava Iterators to Collections

### DIFF
--- a/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/iter/RyaStatementBindingSetCursorIterator.java
+++ b/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/iter/RyaStatementBindingSetCursorIterator.java
@@ -19,6 +19,7 @@
 package org.apache.rya.mongodb.iter;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -38,7 +39,6 @@ import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.query.BindingSet;
 
 import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Iterators;
 import com.google.common.collect.Multimap;
 import com.mongodb.DBObject;
 import com.mongodb.client.AggregateIterable;
@@ -91,7 +91,7 @@ public class RyaStatementBindingSetCursorIterator implements CloseableIteration<
     }
 
     private boolean currentBindingSetIteratorIsValid() {
-        return (currentBindingSetIterator != null) && currentBindingSetIterator.hasNext();
+        return currentBindingSetIterator != null && currentBindingSetIterator.hasNext();
     }
 
     private void findNextResult() {
@@ -130,7 +130,7 @@ public class RyaStatementBindingSetCursorIterator implements CloseableIteration<
     }
 
     private static boolean isResult(final RyaType query, final RyaType result) {
-        return (query == null) || query.equals(result);
+        return query == null || query.equals(result);
     }
 
     private void submitBatchQuery() {
@@ -152,7 +152,7 @@ public class RyaStatementBindingSetCursorIterator implements CloseableIteration<
         } else if (match.size() == 1) {
             pipeline.add(new Document("$match", match.get(0)));
         } else {
-            batchQueryResultsIterator = Iterators.emptyIterator();
+            batchQueryResultsIterator = Collections.emptyIterator();
             return;
         }
 
@@ -166,7 +166,7 @@ public class RyaStatementBindingSetCursorIterator implements CloseableIteration<
     }
 
     private boolean currentBatchQueryResultCursorIsValid() {
-        return (batchQueryResultsIterator != null) && batchQueryResultsIterator.hasNext();
+        return batchQueryResultsIterator != null && batchQueryResultsIterator.hasNext();
     }
 
 


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

  http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
## Description
>What Changed?

Google changed the Iterators object emptyIterator() visibility.
This can cause versioning issues with anything depending on
a newer version of guava.  Using Java's Collections.emptyIterator() instead.

### Tests
>Coverage?

N/A

### Links
[Jira](https://issues.apache.org/jira/browse/RYA-501)

### Checklist
- [ ] Code Review
- [x] Squash Commits

#### People To Reivew
@ejwhite922 
@kchilton2 
@pujav65 
