### PR TITLE
Rya 515 Upgraded mongo-java-driver to 3.10.2

### DIFF
--- a/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/MongoDBQueryEngine.java
+++ b/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/MongoDBQueryEngine.java
@@ -77,8 +77,8 @@ public class MongoDBQueryEngine implements RyaQueryEngine<StatefulMongoDBRdfConf
         checkNotNull(stmt);
         checkNotNull(conf);
 
-        Entry<RyaStatement, BindingSet> entry = new AbstractMap.SimpleEntry<>(stmt, new MapBindingSet());
-        Collection<Entry<RyaStatement, BindingSet>> collection = Collections.singleton(entry);
+        final Entry<RyaStatement, BindingSet> entry = new AbstractMap.SimpleEntry<>(stmt, new MapBindingSet());
+        final Collection<Entry<RyaStatement, BindingSet>> collection = Collections.singleton(entry);
 
         return new RyaStatementCursorIterator(queryWithBindingSet(collection, conf));
     }
@@ -142,7 +142,8 @@ public class MongoDBQueryEngine implements RyaQueryEngine<StatefulMongoDBRdfConf
             queries.put(stmt, new MapBindingSet());
         }
 
-        Iterator<RyaStatement> iterator = new RyaStatementCursorIterator(queryWithBindingSet(queries.entrySet(), getConf()));
+        @SuppressWarnings("resource")
+        final Iterator<RyaStatement> iterator = new RyaStatementCursorIterator(queryWithBindingSet(queries.entrySet(), getConf()));
         return CloseableIterables.wrap(() -> iterator);
     }
 

--- a/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/aggregation/AggregationPipelineQueryNode.java
+++ b/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/aggregation/AggregationPipelineQueryNode.java
@@ -95,6 +95,8 @@ import com.mongodb.client.model.Projections;
  * false.
  */
 public class AggregationPipelineQueryNode extends ExternalSet {
+    private static final long serialVersionUID = 1L;
+
     /**
      * An aggregation result corresponding to a solution should map this key
      * to an object which itself maps variable names to variable values.
@@ -230,8 +232,12 @@ public class AggregationPipelineQueryNode extends ExternalSet {
             }
             final List<Bson> fields = new LinkedList<>();
             fields.add(Projections.excludeId());
-            fields.add(Projections.computed(VALUES, values));
-            fields.add(Projections.computed(HASHES, hashes));
+            if (!values.isEmpty()) {
+                fields.add(Projections.computed(VALUES, values));
+            }
+            if (!hashes.isEmpty()) {
+                fields.add(Projections.computed(HASHES, hashes));
+            }
             if (!types.isEmpty()) {
                 fields.add(Projections.computed(TYPES, types));
             }
@@ -778,8 +784,7 @@ public class AggregationPipelineQueryNode extends ExternalSet {
      */
     public void requireSourceDerivationDepth(final int requiredLevel) {
         if (requiredLevel > 0) {
-            pipeline.add(Aggregates.match(new Document(LEVEL,
-                    new Document("$gte", requiredLevel))));
+            pipeline.add(Aggregates.match(Filters.gte(LEVEL, requiredLevel)));
         }
     }
 
@@ -794,8 +799,7 @@ public class AggregationPipelineQueryNode extends ExternalSet {
      *  timestamp than this.
      */
     public void requireSourceTimestamp(final long t) {
-        pipeline.add(Aggregates.match(new Document(TIMESTAMP,
-                new Document("$gte", t))));
+        pipeline.add(Aggregates.match(Filters.gte(TIMESTAMP, t)));
     }
 
     /**

--- a/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/aggregation/AggregationPipelineQueryNode.java
+++ b/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/aggregation/AggregationPipelineQueryNode.java
@@ -22,7 +22,6 @@ import static org.apache.rya.mongodb.dao.SimpleMongoDBStorageStrategy.CONTEXT;
 import static org.apache.rya.mongodb.dao.SimpleMongoDBStorageStrategy.DOCUMENT_VISIBILITY;
 import static org.apache.rya.mongodb.dao.SimpleMongoDBStorageStrategy.OBJECT;
 import static org.apache.rya.mongodb.dao.SimpleMongoDBStorageStrategy.OBJECT_HASH;
-import static org.apache.rya.mongodb.dao.SimpleMongoDBStorageStrategy.OBJECT_LANGUAGE;
 import static org.apache.rya.mongodb.dao.SimpleMongoDBStorageStrategy.OBJECT_TYPE;
 import static org.apache.rya.mongodb.dao.SimpleMongoDBStorageStrategy.PREDICATE;
 import static org.apache.rya.mongodb.dao.SimpleMongoDBStorageStrategy.PREDICATE_HASH;
@@ -199,7 +198,6 @@ public class AggregationPipelineQueryNode extends ExternalSet {
                 varToTripleValue.put(name, OBJECT);
                 varToTripleHash.put(name, OBJECT_HASH);
                 varToTripleType.put(name, OBJECT_TYPE);
-                varToTripleType.put(name, OBJECT_LANGUAGE);
             }
             if (sp.getContextVar() != null && !sp.getContextVar().hasValue()) {
                 final String name = sanitize(sp.getContextVar().getName());
@@ -836,7 +834,6 @@ public class AggregationPipelineQueryNode extends ExternalSet {
         fields.add(Projections.computed(OBJECT_HASH, hashFieldExpr(OBJECT)));
         fields.add(Projections.computed(OBJECT_TYPE,
                 ConditionalOperators.ifNull(typeFieldExpr(OBJECT), DEFAULT_TYPE)));
-        fields.add(Projections.computed(OBJECT_LANGUAGE, hashFieldExpr(OBJECT)));
         fields.add(Projections.computed(CONTEXT, DEFAULT_CONTEXT));
         fields.add(Projections.computed(STATEMENT_METADATA, DEFAULT_METADATA));
         fields.add(DEFAULT_DV);
@@ -848,7 +845,7 @@ public class AggregationPipelineQueryNode extends ExternalSet {
             final String collectionName = collection.getNamespace().getCollectionName();
             final Bson includeAll = Projections.include(SUBJECT, SUBJECT_HASH,
                     PREDICATE, PREDICATE_HASH, OBJECT, OBJECT_HASH,
-                    OBJECT_TYPE, OBJECT_LANGUAGE, CONTEXT, STATEMENT_METADATA,
+                    OBJECT_TYPE, CONTEXT, STATEMENT_METADATA,
                     DOCUMENT_VISIBILITY, TIMESTAMP, LEVEL);
             final List<Bson> eqTests = new LinkedList<>();
             eqTests.add(new Document("$eq", Arrays.asList("$$this." + PREDICATE_HASH, "$" + PREDICATE_HASH)));

--- a/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/batch/collection/DbCollectionType.java
+++ b/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/batch/collection/DbCollectionType.java
@@ -29,7 +29,9 @@ import com.mongodb.WriteConcern;
 
 /**
  * Provides access to the {@link DBCollection} type.
+ * @Deprecated use {@link MongoCollectionType}
  */
+@Deprecated
 public class DbCollectionType implements CollectionType<DBObject> {
     private final DBCollection collection;
 

--- a/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/dao/MongoDBStorageStrategy.java
+++ b/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/dao/MongoDBStorageStrategy.java
@@ -1,8 +1,3 @@
-package org.apache.rya.mongodb.dao;
-
-import com.mongodb.DBCollection;
-import com.mongodb.DBObject;
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -21,25 +16,25 @@ import com.mongodb.DBObject;
  * specific language governing permissions and limitations
  * under the License.
  */
+package org.apache.rya.mongodb.dao;
 
-
-import org.apache.rya.api.domain.RyaStatement;
 import org.apache.rya.api.persist.query.RyaQuery;
+import org.bson.Document;
+
+import com.mongodb.client.MongoCollection;
 
 /**
  * Defines how objects are stored in MongoDB.
  * <T> - The object to store in MongoDB
  */
 public interface MongoDBStorageStrategy<T> {
+    public Document getQuery(T statement);
 
-	public DBObject getQuery(T statement);
+    public T deserializeDocument(Document queryResult);
 
-	public RyaStatement deserializeDBObject(DBObject queryResult);
+    public Document serialize(T statement);
 
-	public DBObject serialize(T statement);
+    public Document getQuery(RyaQuery ryaQuery);
 
-	public DBObject getQuery(RyaQuery ryaQuery);
-
-	public void createIndices(DBCollection coll);
-
+    public void createIndices(MongoCollection<Document> coll);
 }

--- a/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/document/operators/aggregation/AggregationUtil.java
+++ b/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/document/operators/aggregation/AggregationUtil.java
@@ -37,7 +37,6 @@ import org.apache.rya.mongodb.document.util.AuthorizationsUtil;
 import org.bson.Document;
 
 import com.google.common.collect.Lists;
-import com.mongodb.DBObject;
 
 /**
  * Utility methods for MongoDB aggregation.
@@ -55,7 +54,7 @@ public final class AggregationUtil {
      * All other documents are excluded.
      * @param authorizations the {@link Authorization}s to include in the
      * $redact. Only documents that match the authorizations will be returned.
-     * @return the {@link List} of {@link DBObject}s that represents the $redact
+     * @return the {@link List} of {@link Document}s that represents the $redact
      * aggregation pipeline.
      */
     public static List<Document> createRedactPipeline(final Authorizations authorizations) {

--- a/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/document/operators/aggregation/PipelineOperators.java
+++ b/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/document/operators/aggregation/PipelineOperators.java
@@ -18,13 +18,9 @@
  */
 package org.apache.rya.mongodb.document.operators.aggregation;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.rya.mongodb.document.operators.query.ConditionalOperators.cond;
 
 import org.bson.Document;
-
-import com.mongodb.BasicDBObject;
-import com.mongodb.BasicDBObjectBuilder;
 
 /**
  * Utility methods for pipeline operators.
@@ -85,7 +81,7 @@ public final class PipelineOperators {
      * the expression passes.
      * @param rejectResult the {@link RedactAggregationResult} to return when
      * the expression fails.
-     * @return the $redact expression {@link BasicDBObjectBuilder}.
+     * @return the $redact expression {@link Document}.
      */
     public static Document redact(final Document expression, final RedactAggregationResult acceptResult, final RedactAggregationResult rejectResult) {
         return new Document("$redact", cond(expression, acceptResult.toString(), rejectResult.toString()));

--- a/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/document/operators/query/ConditionalOperators.java
+++ b/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/document/operators/query/ConditionalOperators.java
@@ -22,9 +22,6 @@ import java.util.Arrays;
 
 import org.bson.Document;
 
-import com.mongodb.BasicDBObject;
-import com.mongodb.BasicDBObjectBuilder;
-
 /**
  * Utility methods for conditional operators.
  */
@@ -37,12 +34,12 @@ public final class ConditionalOperators {
 
     /**
      * Creates an "if-then-else" MongoDB expression.
-     * @param ifStatement the "if" statement {@link BasicDBObject}.
+     * @param ifStatement the "if" statement {@link Document}.
      * @param thenResult the {@link Object} to return when the
      * {@code ifStatement} is {@code true}.
      * @param elseResult the {@link Object} to return when the
      * {@code ifStatement} is {@code false}.
-     * @return the "if" expression {@link BasicDBObjectBuilder}.
+     * @return the "if" expression {@link Document}.
      */
     public static Document ifThenElse(final Document ifStatement, final Object thenResult, final Object elseResult) {
         return new Document("if", ifStatement)
@@ -55,7 +52,7 @@ public final class ConditionalOperators {
      * @param expression the expression to {@code null} check.
      * @param replacementExpression the expression to replace it with if it's
      * {@code null}.
-     * @return the $ifNull expression {@link BasicDBObjectBuilder}.
+     * @return the $ifNull expression {@link Document}.
      */
     public static Document ifNull(final Object expression, final Object replacementExpression) {
         return new Document("$ifNull", Arrays.asList(expression, replacementExpression));
@@ -63,12 +60,12 @@ public final class ConditionalOperators {
 
     /**
      * Creates an "$cond" MongoDB expression.
-     * @param expression the expression {@link BasicDBObject}.
+     * @param expression the expression {@link Document}.
      * @param thenResult the {@link Object} to return when the
      * {@code expression} is {@code true}.
      * @param elseResult the {@link Object} to return when the
      * {@code expression} is {@code false}.
-     * @return the $cond expression {@link BasicDBObjectBuilder}.
+     * @return the $cond expression {@link Document}.
      */
     public static Document cond(final Document expression, final Object thenResult, final Object elseResult) {
         return new Document("$cond", ifThenElse(expression, thenResult, elseResult));

--- a/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/document/operators/query/QueryBuilder.java
+++ b/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/document/operators/query/QueryBuilder.java
@@ -1,0 +1,513 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.mongodb.document.operators.query;
+
+import static com.mongodb.assertions.Assertions.notNull;
+import static java.util.Arrays.asList;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.bson.Document;
+
+import com.mongodb.QueryOperators;
+import com.mongodb.lang.Nullable;
+
+/**
+ * Utility for creating Document queries
+ *
+ * This is a {@link Document} based version of {@link com.mongodb.QueryBuilder}.
+ * @see com.mongodb.QueryBuilder
+ * @mongodb.driver.manual tutorial/query-documents/ Querying
+ */
+public class QueryBuilder {
+    private final Document query;
+    private String currentKey;
+    private boolean hasNot;
+
+    /**
+     * Creates a builder with an empty query
+     */
+    public QueryBuilder() {
+        query = new Document();
+    }
+
+    /**
+     * Returns a new QueryBuilder.
+     *
+     * @return a builder
+     */
+    public static QueryBuilder start() {
+        return new QueryBuilder();
+    }
+
+    /**
+     * Creates a new query with a document key
+     *
+     * @param key MongoDB document key
+     * @return {@code this}
+     */
+    public static QueryBuilder start(final String key) {
+        return (new QueryBuilder()).put(key);
+    }
+
+    /**
+     * Adds a new key to the query if not present yet. Sets this key as the current key.
+     *
+     * @param key MongoDB document key
+     * @return {@code this}
+     */
+    public QueryBuilder put(final String key) {
+        currentKey = key;
+        if (query.get(key) == null) {
+            query.put(currentKey, new NullObject());
+        }
+        return this;
+    }
+
+    /**
+     * Equivalent to {@code QueryBuilder.put(key)}. Intended for compound query chains to be more readable, e.g. {@code
+     * QueryBuilder.start("a").greaterThan(1).and("b").lessThan(3) }
+     *
+     * @param key MongoDB document key
+     * @return {@code this}
+     */
+    public QueryBuilder and(final String key) {
+        return put(key);
+    }
+
+    /**
+     * Equivalent to the $gt operator
+     *
+     * @param object Value to query
+     * @return {@code this}
+     */
+    public QueryBuilder greaterThan(final Object object) {
+        addOperand(QueryOperators.GT, object);
+        return this;
+    }
+
+    /**
+     * Equivalent to the $gte operator
+     *
+     * @param object Value to query
+     * @return {@code this}
+     */
+    public QueryBuilder greaterThanEquals(final Object object) {
+        addOperand(QueryOperators.GTE, object);
+        return this;
+    }
+
+    /**
+     * Equivalent to the $lt operand
+     *
+     * @param object Value to query
+     * @return {@code this}
+     */
+    public QueryBuilder lessThan(final Object object) {
+        addOperand(QueryOperators.LT, object);
+        return this;
+    }
+
+    /**
+     * Equivalent to the $lte operand
+     *
+     * @param object Value to query
+     * @return {@code this}
+     */
+    public QueryBuilder lessThanEquals(final Object object) {
+        addOperand(QueryOperators.LTE, object);
+        return this;
+    }
+
+    /**
+     * Equivalent of the find({key:value})
+     *
+     * @param object Value to query
+     * @return {@code this}
+     */
+    public QueryBuilder is(final Object object) {
+        addOperand(null, object);
+        return this;
+    }
+
+    /**
+     * Equivalent of the $ne operand
+     *
+     * @param object Value to query
+     * @return {@code this}
+     */
+    public QueryBuilder notEquals(final Object object) {
+        addOperand(QueryOperators.NE, object);
+        return this;
+    }
+
+    /**
+     * Equivalent of the $in operand
+     *
+     * @param object Value to query
+     * @return {@code this}
+     */
+    public QueryBuilder in(final Object object) {
+        addOperand(QueryOperators.IN, object);
+        return this;
+    }
+
+    /**
+     * Equivalent of the $nin operand
+     *
+     * @param object Value to query
+     * @return {@code this}
+     */
+    public QueryBuilder notIn(final Object object) {
+        addOperand(QueryOperators.NIN, object);
+        return this;
+    }
+
+    /**
+     * Equivalent of the $mod operand
+     *
+     * @param object Value to query
+     * @return {@code this}
+     */
+    public QueryBuilder mod(final Object object) {
+        addOperand(QueryOperators.MOD, object);
+        return this;
+    }
+
+    /**
+     * Equivalent of the $all operand
+     *
+     * @param object Value to query
+     * @return {@code this}
+     */
+    public QueryBuilder all(final Object object) {
+        addOperand(QueryOperators.ALL, object);
+        return this;
+    }
+
+    /**
+     * Equivalent of the $size operand
+     *
+     * @param object Value to query
+     * @return {@code this}
+     */
+    public QueryBuilder size(final Object object) {
+        addOperand(QueryOperators.SIZE, object);
+        return this;
+    }
+
+    /**
+     * Equivalent of the $exists operand
+     *
+     * @param object Value to query
+     * @return {@code this}
+     */
+    public QueryBuilder exists(final Object object) {
+        addOperand(QueryOperators.EXISTS, object);
+        return this;
+    }
+
+    /**
+     * Passes a regular expression for a query
+     *
+     * @param regex Regex pattern object
+     * @return {@code this}
+     */
+    public QueryBuilder regex(final Pattern regex) {
+        addOperand(null, regex);
+        return this;
+    }
+
+    /**
+     * Equivalent to the $elemMatch operand
+     *
+     * @param match the object to match
+     * @return {@code this}
+     */
+    public QueryBuilder elemMatch(final Document match) {
+        addOperand(QueryOperators.ELEM_MATCH, match);
+        return this;
+    }
+
+
+    /**
+     * Equivalent of the $within operand, used for geospatial operation
+     *
+     * @param x      x coordinate
+     * @param y      y coordinate
+     * @param radius radius
+     * @return {@code this}
+     */
+    public QueryBuilder withinCenter(final double x, final double y, final double radius) {
+        addOperand(QueryOperators.WITHIN,
+                   new Document(QueryOperators.CENTER, asList(asList(x, y), radius)));
+        return this;
+    }
+
+    /**
+     * Equivalent of the $near operand
+     *
+     * @param x x coordinate
+     * @param y y coordinate
+     * @return {@code this}
+     */
+    public QueryBuilder near(final double x, final double y) {
+        addOperand(QueryOperators.NEAR,
+                   asList(x, y));
+        return this;
+    }
+
+    /**
+     * Equivalent of the $near operand
+     *
+     * @param x           x coordinate
+     * @param y           y coordinate
+     * @param maxDistance max distance
+     * @return {@code this}
+     */
+    public QueryBuilder near(final double x, final double y, final double maxDistance) {
+        addOperand(QueryOperators.NEAR,
+                   asList(x, y));
+        addOperand(QueryOperators.MAX_DISTANCE,
+                   maxDistance);
+        return this;
+    }
+
+    /**
+     * Equivalent of the $nearSphere operand
+     *
+     * @param longitude coordinate in decimal degrees
+     * @param latitude  coordinate in decimal degrees
+     * @return {@code this}
+     */
+    public QueryBuilder nearSphere(final double longitude, final double latitude) {
+        addOperand(QueryOperators.NEAR_SPHERE,
+                   asList(longitude, latitude));
+        return this;
+    }
+
+    /**
+     * Equivalent of the $nearSphere operand
+     *
+     * @param longitude   coordinate in decimal degrees
+     * @param latitude    coordinate in decimal degrees
+     * @param maxDistance max spherical distance
+     * @return {@code this}
+     */
+    public QueryBuilder nearSphere(final double longitude, final double latitude, final double maxDistance) {
+        addOperand(QueryOperators.NEAR_SPHERE,
+                   asList(longitude, latitude));
+        addOperand(QueryOperators.MAX_DISTANCE,
+                   maxDistance);
+        return this;
+    }
+
+    /**
+     * Equivalent of the $centerSphere operand mostly intended for queries up to a few hundred miles or km.
+     *
+     * @param longitude   coordinate in decimal degrees
+     * @param latitude    coordinate in decimal degrees
+     * @param maxDistance max spherical distance
+     * @return {@code this}
+     */
+    public QueryBuilder withinCenterSphere(final double longitude, final double latitude, final double maxDistance) {
+        addOperand(QueryOperators.WITHIN,
+                   new Document(QueryOperators.CENTER_SPHERE,
+                                     asList(asList(longitude, latitude), maxDistance)));
+        return this;
+    }
+
+    /**
+     * Equivalent to a $within operand, based on a bounding box using represented by two corners
+     *
+     * @param x  the x coordinate of the first box corner.
+     * @param y  the y coordinate of the first box corner.
+     * @param x2 the x coordinate of the second box corner.
+     * @param y2 the y coordinate of the second box corner.
+     * @return {@code this}
+     */
+    public QueryBuilder withinBox(final double x, final double y, final double x2, final double y2) {
+        addOperand(QueryOperators.WITHIN,
+                   new Document(QueryOperators.BOX, new Object[]{new Double[]{x, y}, new Double[]{x2, y2}}));
+        return this;
+    }
+
+    /**
+     * Equivalent to a $within operand, based on a bounding polygon represented by an array of points
+     *
+     * @param points an array of Double[] defining the vertices of the search area
+     * @return {@code this}
+     */
+    public QueryBuilder withinPolygon(final List<Double[]> points) {
+        notNull("points", points);
+        if (points.isEmpty() || points.size() < 3) {
+            throw new IllegalArgumentException("Polygon insufficient number of vertices defined");
+        }
+        addOperand(QueryOperators.WITHIN,
+                   new Document(QueryOperators.POLYGON, convertToListOfLists(points)));
+        return this;
+    }
+
+    private List<List<Double>> convertToListOfLists(final List<Double[]> points) {
+        final List<List<Double>> listOfLists = new ArrayList<List<Double>>(points.size());
+        for (final Double[] cur : points) {
+            final List<Double> list = new ArrayList<Double>(cur.length);
+            Collections.addAll(list, cur);
+            listOfLists.add(list);
+        }
+        return listOfLists;
+    }
+
+    /**
+     * Equivalent to a $text operand.
+     *
+     * @param search the search terms to apply to the text index.
+     * @return {@code this}
+     * @mongodb.server.release 2.6
+     */
+    public QueryBuilder text(final String search) {
+        return text(search, null);
+    }
+
+    /**
+     * Equivalent to a $text operand.
+     *
+     * @param search   the search terms to apply to the text index.
+     * @param language the language to use.
+     * @return {@code this}
+     * @mongodb.server.release 2.6
+     */
+    public QueryBuilder text(final String search, @Nullable final String language) {
+        if (currentKey != null) {
+            throw new QueryBuilderException("The text operand may only occur at the top-level of a query. It does"
+                                            + " not apply to a specific element, but rather to a document as a whole.");
+        }
+
+        put(QueryOperators.TEXT);
+        addOperand(QueryOperators.SEARCH, search);
+        if (language != null) {
+            addOperand(QueryOperators.LANGUAGE, language);
+        }
+
+        return this;
+    }
+
+    /**
+     * Equivalent to $not meta operator. Must be followed by an operand, not a value, e.g. {@code
+     * QueryBuilder.start("val").not().mod(Arrays.asList(10, 1)) }
+     *
+     * @return {@code this}
+     */
+    public QueryBuilder not() {
+        hasNot = true;
+        return this;
+    }
+
+    /**
+     * Equivalent to an $or operand
+     *
+     * @param ors the list of conditions to or together
+     * @return {@code this}
+     */
+    public QueryBuilder or(final Document... ors) {
+        List<Object> l = query.getList(QueryOperators.OR, Object.class);
+        if (l == null) {
+            l = new ArrayList<>();
+            query.put(QueryOperators.OR, l);
+        }
+        Collections.addAll(l, ors);
+        return this;
+    }
+
+    /**
+     * Equivalent to an $and operand
+     *
+     * @param ands the list of conditions to and together
+     * @return {@code this}
+     */
+    public QueryBuilder and(final Document... ands) {
+        List<Object> l = query.getList(QueryOperators.AND, Object.class);
+        if (l == null) {
+            l = new ArrayList<>();
+            query.put(QueryOperators.AND, l);
+        }
+        Collections.addAll(l, ands);
+        return this;
+    }
+
+    /**
+     * Creates a {@code Document} query to be used for the driver's find operations
+     *
+     * @return {@code this}
+     * @throws RuntimeException if a key does not have a matching operand
+     */
+    public Document get() {
+        for (final String key : query.keySet()) {
+            if (query.get(key) instanceof NullObject) {
+                throw new QueryBuilderException("No operand for key:" + key);
+            }
+        }
+        return query;
+    }
+
+    private void addOperand(@Nullable final String op, final Object value) {
+        Object valueToPut = value;
+        if (op == null) {
+            if (hasNot) {
+                valueToPut = new Document(QueryOperators.NOT, valueToPut);
+                hasNot = false;
+            }
+            query.put(currentKey, valueToPut);
+            return;
+        }
+
+        final Object storedValue = query.get(currentKey);
+        Document operand;
+        if (!(storedValue instanceof Document)) {
+            operand = new Document();
+            if (hasNot) {
+                final Document notOperand = new Document(QueryOperators.NOT, operand);
+                query.put(currentKey, notOperand);
+                hasNot = false;
+            } else {
+                query.put(currentKey, operand);
+            }
+        } else {
+            operand = (Document) query.get(currentKey);
+            if (operand.get(QueryOperators.NOT) != null) {
+                operand = (Document) operand.get(QueryOperators.NOT);
+            }
+        }
+        operand.put(op, valueToPut);
+    }
+
+    static class QueryBuilderException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
+
+        QueryBuilderException(final String message) {
+            super(message);
+        }
+    }
+
+    private static class NullObject {
+    }
+}

--- a/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/iter/RyaStatementBindingSetCursorIterator.java
+++ b/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/iter/RyaStatementBindingSetCursorIterator.java
@@ -41,8 +41,6 @@ import org.eclipse.rdf4j.query.BindingSet;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Multimap;
-import com.mongodb.BasicDBObject;
-import com.mongodb.DBObject;
 import com.mongodb.client.AggregateIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.Aggregates;
@@ -105,8 +103,7 @@ public class RyaStatementBindingSetCursorIterator implements CloseableIteration<
         if (currentBatchQueryResultCursorIsValid()) {
             // convert to Rya Statement
             final Document queryResult = batchQueryResultsIterator.next();
-            final DBObject dbo = BasicDBObject.parse(queryResult.toJson());
-            currentResultStatement = strategy.deserializeDBObject(dbo);
+            currentResultStatement = strategy.deserializeDocument(queryResult);
 
             // Find all of the queries in the executed RangeMap that this result matches
             // and collect all of those binding sets
@@ -146,9 +143,8 @@ public class RyaStatementBindingSetCursorIterator implements CloseableIteration<
             count++;
             final RyaStatement query = queryIterator.next();
             executedRangeMap.putAll(query, rangeMap.get(query));
-            final DBObject currentQuery = strategy.getQuery(query);
-            final Document doc = Document.parse(currentQuery.toString());
-            matches.add(doc);
+            final Document currentQuery = strategy.getQuery(query);
+            matches.add(currentQuery);
         }
 
         final int numMatches = matches.size();

--- a/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/MongoDBRdfConfigurationTest.java
+++ b/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/MongoDBRdfConfigurationTest.java
@@ -42,7 +42,7 @@ public class MongoDBRdfConfigurationTest {
         final boolean useInference = true;
         final boolean displayPlan = false;
 
-        final MongoDBRdfConfiguration conf = new MongoDBRdfConfiguration().getBuilder()
+        final MongoDBRdfConfiguration conf = MongoDBRdfConfiguration.getBuilder()
                 .setVisibilities(visibility)
                 .setUseInference(useInference)
                 .setDisplayQueryPlan(displayPlan)

--- a/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/MongoDBRyaDAO2IT.java
+++ b/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/MongoDBRyaDAO2IT.java
@@ -75,7 +75,7 @@ public class MongoDBRyaDAO2IT extends MongoRyaITBase {
 
             dao.add(builder.build());
 
-            assertEquals(coll.count(),1);
+            assertEquals(coll.countDocuments(), 1);
         }  finally {
             dao.destroy();
         }
@@ -98,10 +98,10 @@ public class MongoDBRyaDAO2IT extends MongoRyaITBase {
             final MongoCollection<Document> coll = db.getCollection(conf.getTriplesCollectionName());
 
             dao.add(statement);
-            assertEquals(coll.count(),1);
+            assertEquals(coll.countDocuments(), 1);
 
             dao.delete(statement, conf);
-            assertEquals(coll.count(),0);
+            assertEquals(coll.countDocuments(), 0);
         } finally {
             dao.destroy();
         }
@@ -125,7 +125,7 @@ public class MongoDBRyaDAO2IT extends MongoRyaITBase {
             final MongoCollection<Document> coll = db.getCollection(conf.getTriplesCollectionName());
 
             dao.add(statement);
-            assertEquals(coll.count(),1);
+            assertEquals(coll.countDocuments(), 1);
 
             final RyaStatementBuilder builder2 = new RyaStatementBuilder();
             builder2.setPredicate(new RyaIRI("http://temp.com"));
@@ -134,7 +134,7 @@ public class MongoDBRyaDAO2IT extends MongoRyaITBase {
             final RyaStatement query = builder2.build();
 
             dao.delete(query, conf);
-            assertEquals(coll.count(),1);
+            assertEquals(coll.countDocuments(), 1);
         } finally {
             dao.destroy();
         }
@@ -158,11 +158,11 @@ public class MongoDBRyaDAO2IT extends MongoRyaITBase {
 
             dao.add(builder.build());
 
-            assertEquals(coll.count(), 1);
+            assertEquals(coll.countDocuments(), 1);
 
-            final Document dbo = coll.find().first();
-            assertTrue(dbo.containsKey(DOCUMENT_VISIBILITY));
-            assertTrue(dbo.containsKey(TIMESTAMP));
+            final Document doc = coll.find().first();
+            assertTrue(doc.containsKey(DOCUMENT_VISIBILITY));
+            assertTrue(doc.containsKey(TIMESTAMP));
         }  finally {
             dao.destroy();
         }
@@ -191,11 +191,11 @@ public class MongoDBRyaDAO2IT extends MongoRyaITBase {
 
             dao.add(builder.build());
 
-            assertEquals(coll.count(), 1);
+            assertEquals(coll.countDocuments(), 1);
 
-            final Document dbo = coll.find().first();
-            assertTrue(dbo.containsKey(DOCUMENT_VISIBILITY));
-            assertTrue(dbo.containsKey(TIMESTAMP));
+            final Document doc = coll.find().first();
+            assertTrue(doc.containsKey(DOCUMENT_VISIBILITY));
+            assertTrue(doc.containsKey(TIMESTAMP));
         }  finally {
             dao.destroy();
         }

--- a/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/MongoDBRyaDAOIT.java
+++ b/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/MongoDBRyaDAOIT.java
@@ -83,11 +83,11 @@ public class MongoDBRyaDAOIT extends MongoRyaITBase {
 
             dao.add(builder.build());
 
-            assertEquals(coll.count(),1);
+            assertEquals(coll.countDocuments(), 1);
 
-            final Document dbo = coll.find().first();
-            assertTrue(dbo.containsKey(DOCUMENT_VISIBILITY));
-            assertTrue(dbo.containsKey(TIMESTAMP));
+            final Document doc = coll.find().first();
+            assertTrue(doc.containsKey(DOCUMENT_VISIBILITY));
+            assertTrue(doc.containsKey(TIMESTAMP));
         }  finally {
             dao.destroy();
         }
@@ -110,10 +110,10 @@ public class MongoDBRyaDAOIT extends MongoRyaITBase {
             final MongoCollection<Document> coll = db.getCollection(conf.getTriplesCollectionName());
 
             dao.add(statement);
-            assertEquals(1, coll.count());
+            assertEquals(1, coll.countDocuments());
 
             dao.delete(statement, conf);
-            assertEquals(0, coll.count());
+            assertEquals(0, coll.countDocuments());
         } finally {
             dao.destroy();
         }
@@ -138,7 +138,7 @@ public class MongoDBRyaDAOIT extends MongoRyaITBase {
             final MongoCollection<Document> coll = db.getCollection(conf.getTriplesCollectionName());
 
             dao.add(statement);
-            assertEquals(1, coll.count());
+            assertEquals(1, coll.countDocuments());
 
             final RyaStatementBuilder builder2 = new RyaStatementBuilder();
             builder2.setPredicate(new RyaIRI("http://temp.com"));
@@ -147,7 +147,7 @@ public class MongoDBRyaDAOIT extends MongoRyaITBase {
             final RyaStatement query = builder2.build();
 
             dao.delete(query, conf);
-            assertEquals(1, coll.count());
+            assertEquals(1, coll.countDocuments());
         } finally {
             dao.destroy();
         }
@@ -171,11 +171,11 @@ public class MongoDBRyaDAOIT extends MongoRyaITBase {
 
             dao.add(builder.build());
 
-            assertEquals(coll.count(), 1);
+            assertEquals(coll.countDocuments(), 1);
 
-            final Document dbo = coll.find().first();
-            assertTrue(dbo.containsKey(DOCUMENT_VISIBILITY));
-            assertTrue(dbo.containsKey(TIMESTAMP));
+            final Document doc = coll.find().first();
+            assertTrue(doc.containsKey(DOCUMENT_VISIBILITY));
+            assertTrue(doc.containsKey(TIMESTAMP));
         }  finally {
             dao.destroy();
         }
@@ -204,11 +204,11 @@ public class MongoDBRyaDAOIT extends MongoRyaITBase {
 
             dao.add(builder.build());
 
-            assertEquals(coll.count(), 1);
+            assertEquals(coll.countDocuments(), 1);
 
-            final Document dbo = coll.find().first();
-            assertTrue(dbo.containsKey(DOCUMENT_VISIBILITY));
-            assertTrue(dbo.containsKey(TIMESTAMP));
+            final Document doc = coll.find().first();
+            assertTrue(doc.containsKey(DOCUMENT_VISIBILITY));
+            assertTrue(doc.containsKey(TIMESTAMP));
         }  finally {
             dao.destroy();
         }
@@ -602,7 +602,7 @@ public class MongoDBRyaDAOIT extends MongoRyaITBase {
         dao.add(statement);
         dao.getConf().setAuths(AuthorizationsUtil.getAuthorizationsStringArray(userAuthorizations != null ? userAuthorizations : Authorizations.EMPTY));
 
-        assertEquals(1, coll.count());
+        assertEquals(1, coll.countDocuments());
 
         final MongoDBQueryEngine queryEngine = (MongoDBQueryEngine) dao.getQueryEngine();
         queryEngine.setConf(conf);
@@ -613,7 +613,7 @@ public class MongoDBRyaDAOIT extends MongoRyaITBase {
 
         // Reset
         dao.delete(statement, conf);
-        assertEquals(0, coll.count());
+        assertEquals(0, coll.countDocuments());
         dao.getConf().setAuths(AuthorizationsUtil.getAuthorizationsStringArray(Authorizations.EMPTY));
 
         return hasNext;

--- a/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/MongoRyaITBase.java
+++ b/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/MongoRyaITBase.java
@@ -24,7 +24,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.rya.test.mongo.MongoITBase;
 import org.bson.Document;
 
-import com.mongodb.DBCollection;
 import com.mongodb.client.MongoCollection;
 
 /**
@@ -69,12 +68,5 @@ public class MongoRyaITBase extends MongoITBase {
      */
     public MongoCollection<Document> getRyaCollection() {
         return getMongoClient().getDatabase(conf.getMongoDBName()).getCollection(conf.getTriplesCollectionName());
-    }
-
-    /**
-     * @return The Rya triples {@link DBCollection}.
-     */
-    public DBCollection getRyaDbCollection() {
-        return getMongoClient().getDB(conf.getMongoDBName()).getCollection(conf.getTriplesCollectionName());
     }
 }

--- a/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/SimpleMongoDBStorageStrategyTest.java
+++ b/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/SimpleMongoDBStorageStrategyTest.java
@@ -33,11 +33,10 @@ import org.apache.rya.mongodb.dao.SimpleMongoDBStorageStrategy;
 import org.apache.rya.mongodb.document.util.DocumentVisibilityConversionException;
 import org.apache.rya.mongodb.document.util.DocumentVisibilityUtil;
 import org.apache.rya.mongodb.document.visibility.DocumentVisibility;
+import org.bson.Document;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.junit.Test;
 
-import com.mongodb.BasicDBObject;
-import com.mongodb.DBObject;
 import com.mongodb.MongoException;
 
 public class SimpleMongoDBStorageStrategyTest {
@@ -50,8 +49,8 @@ public class SimpleMongoDBStorageStrategyTest {
 
     private static final RyaStatement testStatement;
     private static final RyaStatement testStatement2;
-    private static final DBObject testDBO;
-    private static final DBObject testDBO2;
+    private static final Document TEST_DOC;
+    private static final Document TEST_DOC_2;
     private final SimpleMongoDBStorageStrategy storageStrategy = new SimpleMongoDBStorageStrategy();
 
     static {
@@ -64,24 +63,24 @@ public class SimpleMongoDBStorageStrategyTest {
         builder.setTimestamp(null);
         testStatement = builder.build();
 
-        testDBO = new BasicDBObject();
-        testDBO.put(SimpleMongoDBStorageStrategy.ID, "d5f8fea0e85300478da2c9b4e132c69502e21221");
-        testDBO.put(SimpleMongoDBStorageStrategy.SUBJECT, SUBJECT);
-        testDBO.put(SimpleMongoDBStorageStrategy.SUBJECT_HASH, DigestUtils.sha256Hex(SUBJECT));
-        testDBO.put(SimpleMongoDBStorageStrategy.PREDICATE, PREDICATE);
-        testDBO.put(SimpleMongoDBStorageStrategy.PREDICATE_HASH, DigestUtils.sha256Hex(PREDICATE));
-        testDBO.put(SimpleMongoDBStorageStrategy.OBJECT, OBJECT);
-        testDBO.put(SimpleMongoDBStorageStrategy.OBJECT_HASH, DigestUtils.sha256Hex(OBJECT));
-        testDBO.put(SimpleMongoDBStorageStrategy.OBJECT_TYPE, ANYURI.stringValue());
-        testDBO.put(SimpleMongoDBStorageStrategy.OBJECT_LANGUAGE, null);
-        testDBO.put(SimpleMongoDBStorageStrategy.CONTEXT, CONTEXT);
-        testDBO.put(SimpleMongoDBStorageStrategy.STATEMENT_METADATA, STATEMENT_METADATA);
+        TEST_DOC = new Document();
+        TEST_DOC.put(SimpleMongoDBStorageStrategy.ID, "d5f8fea0e85300478da2c9b4e132c69502e21221");
+        TEST_DOC.put(SimpleMongoDBStorageStrategy.SUBJECT, SUBJECT);
+        TEST_DOC.put(SimpleMongoDBStorageStrategy.SUBJECT_HASH, DigestUtils.sha256Hex(SUBJECT));
+        TEST_DOC.put(SimpleMongoDBStorageStrategy.PREDICATE, PREDICATE);
+        TEST_DOC.put(SimpleMongoDBStorageStrategy.PREDICATE_HASH, DigestUtils.sha256Hex(PREDICATE));
+        TEST_DOC.put(SimpleMongoDBStorageStrategy.OBJECT, OBJECT);
+        TEST_DOC.put(SimpleMongoDBStorageStrategy.OBJECT_HASH, DigestUtils.sha256Hex(OBJECT));
+        TEST_DOC.put(SimpleMongoDBStorageStrategy.OBJECT_TYPE, ANYURI.stringValue());
+        TEST_DOC.put(SimpleMongoDBStorageStrategy.OBJECT_LANGUAGE, null);
+        TEST_DOC.put(SimpleMongoDBStorageStrategy.CONTEXT, CONTEXT);
+        TEST_DOC.put(SimpleMongoDBStorageStrategy.STATEMENT_METADATA, STATEMENT_METADATA);
         try {
-            testDBO.put(SimpleMongoDBStorageStrategy.DOCUMENT_VISIBILITY, DocumentVisibilityUtil.toMultidimensionalArray(DOCUMENT_VISIBILITY));
+            TEST_DOC.put(SimpleMongoDBStorageStrategy.DOCUMENT_VISIBILITY, DocumentVisibilityUtil.toMultidimensionalArray(DOCUMENT_VISIBILITY));
         } catch (final DocumentVisibilityConversionException e) {
             e.printStackTrace();
         }
-        testDBO.put(SimpleMongoDBStorageStrategy.TIMESTAMP, null);
+        TEST_DOC.put(SimpleMongoDBStorageStrategy.TIMESTAMP, null);
 
 
         builder = new RyaStatementBuilder();
@@ -94,39 +93,39 @@ public class SimpleMongoDBStorageStrategyTest {
         testStatement2 = builder.build();
 
         // Check language support
-        testDBO2 = new BasicDBObject();
-        testDBO2.put(SimpleMongoDBStorageStrategy.ID, "580fb5d11f0b62fa735ac98b36bba1fc37ddc3fc");
-        testDBO2.put(SimpleMongoDBStorageStrategy.SUBJECT, SUBJECT);
-        testDBO2.put(SimpleMongoDBStorageStrategy.SUBJECT_HASH, DigestUtils.sha256Hex(SUBJECT));
-        testDBO2.put(SimpleMongoDBStorageStrategy.PREDICATE, PREDICATE);
-        testDBO2.put(SimpleMongoDBStorageStrategy.PREDICATE_HASH, DigestUtils.sha256Hex(PREDICATE));
-        testDBO2.put(SimpleMongoDBStorageStrategy.OBJECT, OBJECT);
-        testDBO2.put(SimpleMongoDBStorageStrategy.OBJECT_HASH, DigestUtils.sha256Hex(OBJECT));
-        testDBO2.put(SimpleMongoDBStorageStrategy.OBJECT_TYPE, RDF.LANGSTRING.stringValue());
-        testDBO2.put(SimpleMongoDBStorageStrategy.OBJECT_LANGUAGE, "en-US");
-        testDBO2.put(SimpleMongoDBStorageStrategy.CONTEXT, CONTEXT);
-        testDBO2.put(SimpleMongoDBStorageStrategy.STATEMENT_METADATA, STATEMENT_METADATA);
+        TEST_DOC_2 = new Document();
+        TEST_DOC_2.put(SimpleMongoDBStorageStrategy.ID, "580fb5d11f0b62fa735ac98b36bba1fc37ddc3fc");
+        TEST_DOC_2.put(SimpleMongoDBStorageStrategy.SUBJECT, SUBJECT);
+        TEST_DOC_2.put(SimpleMongoDBStorageStrategy.SUBJECT_HASH, DigestUtils.sha256Hex(SUBJECT));
+        TEST_DOC_2.put(SimpleMongoDBStorageStrategy.PREDICATE, PREDICATE);
+        TEST_DOC_2.put(SimpleMongoDBStorageStrategy.PREDICATE_HASH, DigestUtils.sha256Hex(PREDICATE));
+        TEST_DOC_2.put(SimpleMongoDBStorageStrategy.OBJECT, OBJECT);
+        TEST_DOC_2.put(SimpleMongoDBStorageStrategy.OBJECT_HASH, DigestUtils.sha256Hex(OBJECT));
+        TEST_DOC_2.put(SimpleMongoDBStorageStrategy.OBJECT_TYPE, RDF.LANGSTRING.stringValue());
+        TEST_DOC_2.put(SimpleMongoDBStorageStrategy.OBJECT_LANGUAGE, "en-US");
+        TEST_DOC_2.put(SimpleMongoDBStorageStrategy.CONTEXT, CONTEXT);
+        TEST_DOC_2.put(SimpleMongoDBStorageStrategy.STATEMENT_METADATA, STATEMENT_METADATA);
         try {
-            testDBO2.put(SimpleMongoDBStorageStrategy.DOCUMENT_VISIBILITY, DocumentVisibilityUtil.toMultidimensionalArray(DOCUMENT_VISIBILITY));
+            TEST_DOC_2.put(SimpleMongoDBStorageStrategy.DOCUMENT_VISIBILITY, DocumentVisibilityUtil.toMultidimensionalArray(DOCUMENT_VISIBILITY));
         } catch (final DocumentVisibilityConversionException e) {
             e.printStackTrace();
         }
-        testDBO2.put(SimpleMongoDBStorageStrategy.TIMESTAMP, null);
+        TEST_DOC_2.put(SimpleMongoDBStorageStrategy.TIMESTAMP, null);
     }
 
     @Test
-    public void testSerializeStatementToDBO() throws RyaDAOException, MongoException, IOException {
+    public void testSerializeStatementToDocument() throws RyaDAOException, MongoException, IOException {
 
-        DBObject dbo = storageStrategy.serialize(testStatement);
-        assertEquals(testDBO, dbo);
+        Document doc = storageStrategy.serialize(testStatement);
+        assertEquals(TEST_DOC, doc);
 
-        dbo = storageStrategy.serialize(testStatement2);
-        assertEquals(testDBO2, dbo);
+        doc = storageStrategy.serialize(testStatement2);
+        assertEquals(TEST_DOC_2, doc);
     }
 
     @Test
-    public void testDeSerializeStatementToDBO() throws RyaDAOException, MongoException, IOException {
-        RyaStatement statement = storageStrategy.deserializeDBObject(testDBO);
+    public void testDeSerializeStatementToDocument() throws RyaDAOException, MongoException, IOException {
+        RyaStatement statement = storageStrategy.deserializeDocument(TEST_DOC);
         /*
          * Since RyaStatement creates a timestamp using JVM time if the timestamp is null, we want to re-null it
          * for this test.  Timestamp is created at insert time by the Server, this test
@@ -135,7 +134,7 @@ public class SimpleMongoDBStorageStrategyTest {
         statement.setTimestamp(null);
         assertEquals(testStatement, statement);
 
-        statement = storageStrategy.deserializeDBObject(testDBO2);
+        statement = storageStrategy.deserializeDocument(TEST_DOC_2);
         /*
          * Since RyaStatement creates a timestamp using JVM time if the timestamp is null, we want to re-null it
          * for this test.  Timestamp is created at insert time by the Server, this test

--- a/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/aggregation/PipelineQueryIT.java
+++ b/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/aggregation/PipelineQueryIT.java
@@ -59,8 +59,6 @@ import org.junit.Test;
 
 import com.google.common.collect.HashMultiset;
 import com.google.common.collect.Multiset;
-import com.mongodb.DBObject;
-import com.mongodb.util.JSON;
 
 public class PipelineQueryIT extends MongoRyaITBase {
 
@@ -89,9 +87,9 @@ public class PipelineQueryIT extends MongoRyaITBase {
         builder.setObject(RdfToRyaConversions.convertValue(object));
         final RyaStatement rstmt = builder.build();
         if (derivationLevel > 0) {
-            final DBObject obj = new SimpleMongoDBStorageStrategy().serialize(builder.build());
+            final Document obj = new SimpleMongoDBStorageStrategy().serialize(builder.build());
             obj.put("derivation_level", derivationLevel);
-            getRyaDbCollection().insert(obj);
+            getRyaCollection().insertOne(obj);
         }
         else {
             dao.add(rstmt);
@@ -336,8 +334,7 @@ public class PipelineQueryIT extends MongoRyaITBase {
         final SimpleMongoDBStorageStrategy strategy = new SimpleMongoDBStorageStrategy();
         final List<Statement> results = new LinkedList<>();
         for (final Document doc : getRyaCollection().aggregate(triplePipeline)) {
-            final DBObject dbo = (DBObject) JSON.parse(doc.toJson());
-            final RyaStatement rstmt = strategy.deserializeDBObject(dbo);
+            final RyaStatement rstmt = strategy.deserializeDocument(doc);
             final Statement stmt = RyaToRdfConversions.convertStatement(rstmt);
             results.add(stmt);
         }

--- a/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/document/util/DocumentVisibilityUtilTest.java
+++ b/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/document/util/DocumentVisibilityUtilTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import java.util.Arrays;
+import java.util.List;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.log4j.Logger;
@@ -95,11 +96,11 @@ public class DocumentVisibilityUtilTest {
 
             // Convert to multidimensional array
             final DocumentVisibility dv = new DocumentVisibility(booleanExpression);
-            final Object[] multidimensionalArray = DocumentVisibilityUtil.toMultidimensionalArray(dv);
-            log.info("Array   : " + Arrays.deepToString(multidimensionalArray));
+            final List<Object> multidimensionalArray = DocumentVisibilityUtil.toMultidimensionalArray(dv);
+            log.info("Array   : " + Arrays.deepToString(multidimensionalArray.toArray()));
 
             // Convert multidimensional array back to string
-            final String booleanStringResult = DocumentVisibilityUtil.multidimensionalArrayToBooleanString(multidimensionalArray);
+            final String booleanStringResult = DocumentVisibilityUtil.multidimensionalArrayToBooleanString(multidimensionalArray.toArray());
             log.info("Result  : " + booleanStringResult);
 
             // Compare results
@@ -118,11 +119,11 @@ public class DocumentVisibilityUtilTest {
                 log.info("Original: " + booleanExpression);
                 // Convert to multidimensional array
                 final DocumentVisibility dv = new DocumentVisibility(booleanExpression);
-                final Object[] multidimensionalArray = DocumentVisibilityUtil.toMultidimensionalArray(dv);
-                log.info("Array   : " + Arrays.deepToString(multidimensionalArray));
+                final List<Object> multidimensionalArray = DocumentVisibilityUtil.toMultidimensionalArray(dv);
+                log.info("Array   : " + Arrays.deepToString(multidimensionalArray.toArray()));
 
                 // Convert multidimensional array back to string
-                final String booleanString = DocumentVisibilityUtil.multidimensionalArrayToBooleanString(multidimensionalArray);
+                final String booleanString = DocumentVisibilityUtil.multidimensionalArrayToBooleanString(multidimensionalArray.toArray());
                 log.info("Result  : " + booleanString);
 
                 // Compare results

--- a/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/document/visibility/DocumentVisibilityAdapterTest.java
+++ b/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/document/visibility/DocumentVisibilityAdapterTest.java
@@ -22,140 +22,138 @@ import static org.junit.Assert.assertEquals;
 
 import org.apache.rya.mongodb.MongoDbRdfConstants;
 import org.apache.rya.mongodb.document.visibility.DocumentVisibilityAdapter.MalformedDocumentVisibilityException;
+import org.bson.Document;
 import org.junit.Test;
-
-import com.mongodb.BasicDBObject;
-import com.mongodb.util.JSON;
 
 /**
  * Tests the methods of {@link DocumentVisibilityAdapter}.
  */
 public class DocumentVisibilityAdapterTest {
     @Test
-    public void testToDBObject() {
+    public void testToDocument() {
         final DocumentVisibility dv = new DocumentVisibility("A");
-        final BasicDBObject dbObject = DocumentVisibilityAdapter.toDBObject(dv);
-        final BasicDBObject expected = (BasicDBObject) JSON.parse(
+        final Document document = DocumentVisibilityAdapter.toDocument(dv);
+        final Document expected = Document.parse(
             "{" +
                 "documentVisibility : [[\"A\"]]" +
             "}"
         );
-        assertEquals(expected, dbObject);
+        assertEquals(expected, document);
     }
 
     @Test
-    public void testToDBObject_and() {
+    public void testToDocument_and() {
         final DocumentVisibility dv = new DocumentVisibility("A&B&C");
-        final BasicDBObject dbObject = DocumentVisibilityAdapter.toDBObject(dv);
-        final BasicDBObject expected = (BasicDBObject) JSON.parse(
+        final Document document = DocumentVisibilityAdapter.toDocument(dv);
+        final Document expected = Document.parse(
             "{" +
                 "documentVisibility : [[\"A\", \"B\", \"C\"]]" +
             "}"
         );
-        assertEquals(expected, dbObject);
+        assertEquals(expected, document);
     }
 
     @Test
-    public void testToDBObject_or() {
+    public void testToDocument_or() {
         final DocumentVisibility dv = new DocumentVisibility("A|B|C");
-        final BasicDBObject dbObject = DocumentVisibilityAdapter.toDBObject(dv);
-        final BasicDBObject expected = (BasicDBObject) JSON.parse(
+        final Document document = DocumentVisibilityAdapter.toDocument(dv);
+        final Document expected = Document.parse(
             "{" +
                 "documentVisibility : [[\"C\"], [\"B\"], [\"A\"]]" +
             "}"
         );
-        assertEquals(expected, dbObject);
+        assertEquals(expected, document);
     }
 
     @Test
-    public void testToDBObject_Expression() {
+    public void testToDocument_Expression() {
         final DocumentVisibility dv = new DocumentVisibility("A&B&C");
-        final BasicDBObject dbObject = DocumentVisibilityAdapter.toDBObject(dv.getExpression());
-        final BasicDBObject expected = (BasicDBObject) JSON.parse(
+        final Document document = DocumentVisibilityAdapter.toDocument(dv.getExpression());
+        final Document expected = Document.parse(
             "{" +
                 "documentVisibility : [[\"A\", \"B\", \"C\"]]" +
             "}"
         );
-        assertEquals(expected, dbObject);
+        assertEquals(expected, document);
     }
 
     @Test
-    public void testToDBObject_nullExpression() {
-        final BasicDBObject dbObject = DocumentVisibilityAdapter.toDBObject((byte[])null);
-        final BasicDBObject expected = (BasicDBObject) JSON.parse(
+    public void testToDocument_nullExpression() {
+        final Document document = DocumentVisibilityAdapter.toDocument((byte[])null);
+        final Document expected = Document.parse(
             "{" +
                 "documentVisibility : []" +
             "}"
         );
-        assertEquals(expected, dbObject);
+        assertEquals(expected, document);
     }
 
     @Test
-    public void testToDBObject_nullDocumentVisibility() {
-        final BasicDBObject dbObject = DocumentVisibilityAdapter.toDBObject((DocumentVisibility)null);
-        final BasicDBObject expected = (BasicDBObject) JSON.parse(
+    public void testToDocument_nullDocumentVisibility() {
+        final Document document = DocumentVisibilityAdapter.toDocument((DocumentVisibility)null);
+        final Document expected = Document.parse(
             "{" +
                 "documentVisibility : []" +
             "}"
         );
-        assertEquals(expected, dbObject);
+        assertEquals(expected, document);
     }
 
     @Test
-    public void testToDBObject_emptyDocumentVisibility() {
-        final BasicDBObject dbObject = DocumentVisibilityAdapter.toDBObject(MongoDbRdfConstants.EMPTY_DV);
-        final BasicDBObject expected = (BasicDBObject) JSON.parse(
+    public void testToDocument_emptyDocumentVisibility() {
+        final Document document = DocumentVisibilityAdapter.toDocument(MongoDbRdfConstants.EMPTY_DV);
+        final Document expected = Document.parse(
             "{" +
                 "documentVisibility : []" +
             "}"
         );
-        assertEquals(expected, dbObject);
+        assertEquals(expected, document);
     }
 
     @Test
     public void testToDocumentVisibility() throws MalformedDocumentVisibilityException {
-        final BasicDBObject dbObject = (BasicDBObject) JSON.parse(
+        final Document document = Document.parse(
             "{" +
                 "documentVisibility : [\"A\"]" +
             "}"
         );
-        final DocumentVisibility dv = DocumentVisibilityAdapter.toDocumentVisibility(dbObject);
+        final DocumentVisibility dv = DocumentVisibilityAdapter.toDocumentVisibility(document);
         final DocumentVisibility expected = new DocumentVisibility("A");
         assertEquals(expected, dv);
     }
 
     @Test
     public void testToDocumentVisibility_and() throws MalformedDocumentVisibilityException {
-        final BasicDBObject dbObject = (BasicDBObject) JSON.parse(
+        final Document document = Document.parse(
             "{" +
                 "documentVisibility : [\"A\", \"B\", \"C\"]" +
             "}"
         );
-        final DocumentVisibility dv = DocumentVisibilityAdapter.toDocumentVisibility(dbObject);
+        final DocumentVisibility dv = DocumentVisibilityAdapter.toDocumentVisibility(document);
         final DocumentVisibility expected = new DocumentVisibility("A&B&C");
         assertEquals(expected, dv);
     }
 
     @Test
     public void testToDocumentVisibility_or() throws MalformedDocumentVisibilityException {
-        final BasicDBObject dbObject = (BasicDBObject) JSON.parse(
+        final Document document = Document.parse(
             "{" +
                 "documentVisibility : [[\"A\"], [\"B\"], [\"C\"]]" +
             "}"
         );
-        final DocumentVisibility dv = DocumentVisibilityAdapter.toDocumentVisibility(dbObject);
+        final DocumentVisibility dv = DocumentVisibilityAdapter.toDocumentVisibility(document);
         final DocumentVisibility expected = new DocumentVisibility("A|B|C");
         assertEquals(expected, dv);
     }
 
     @Test
     public void testToDocumentVisibility_empty() throws MalformedDocumentVisibilityException {
-        final BasicDBObject dbObject = (BasicDBObject) JSON.parse(
+        final Document document = Document.parse(
             "{" +
                 "documentVisibility : []" +
             "}"
         );
-        final DocumentVisibility dv = DocumentVisibilityAdapter.toDocumentVisibility(dbObject);
+        final DocumentVisibility dv = DocumentVisibilityAdapter.toDocumentVisibility(document);
         final DocumentVisibility expected = MongoDbRdfConstants.EMPTY_DV;
         assertEquals(expected, dv);
     }

--- a/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/instance/MongoDetailsAdapterTest.java
+++ b/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/instance/MongoDetailsAdapterTest.java
@@ -35,12 +35,10 @@ import org.apache.rya.api.instance.RyaDetails.ProspectorDetails;
 import org.apache.rya.api.instance.RyaDetails.RyaStreamsDetails;
 import org.apache.rya.api.instance.RyaDetails.TemporalIndexDetails;
 import org.apache.rya.mongodb.instance.MongoDetailsAdapter.MalformedRyaDetailsException;
+import org.bson.Document;
 import org.junit.Test;
 
 import com.google.common.base.Optional;
-import com.mongodb.BasicDBObject;
-import com.mongodb.DBObject;
-import com.mongodb.util.JSON;
 
 /**
  * Tests the methods of {@link MongoDetailsAdapter}.
@@ -76,10 +74,10 @@ public class MongoDetailsAdapterTest {
                 .setRyaStreamsDetails(new RyaStreamsDetails("localhost", 6))
                 .build();
 
-        final BasicDBObject actual = MongoDetailsAdapter.toDBObject(details);
+        final Document actual = MongoDetailsAdapter.toDocument(details);
 
         // Ensure it matches the expected object.
-        final DBObject expected = (DBObject) JSON.parse(
+        final Document expected = Document.parse(
                 "{ "
                         + "instanceName : \"test\","
                         + "version : \"1\","
@@ -113,7 +111,7 @@ public class MongoDetailsAdapterTest {
     @Test
     public void mongoToRyaDetailsTest() throws MalformedRyaDetailsException {
         // Convert the Mongo object into a RyaDetails.
-        final BasicDBObject mongo = (BasicDBObject) JSON.parse(
+        final Document mongo = Document.parse(
                 "{ "
                         + "instanceName : \"test\","
                         + "version : \"1\","
@@ -176,7 +174,7 @@ public class MongoDetailsAdapterTest {
     @Test
     public void absentOptionalToRyaDetailsTest() throws MalformedRyaDetailsException {
         // Convert the Mongo object into a RyaDetails.
-        final BasicDBObject mongo = (BasicDBObject) JSON.parse(
+        final Document mongo = Document.parse(
                 "{ "
                         + "instanceName : \"test\","
                         + "version : \"1\","
@@ -234,10 +232,10 @@ public class MongoDetailsAdapterTest {
                 .setJoinSelectivityDetails(new JoinSelectivityDetails(Optional.<Date>absent()))
                 .build();
 
-        final DBObject actual = MongoDetailsAdapter.toDBObject(details);
+        final Document actual = MongoDetailsAdapter.toDocument(details);
 
         // Ensure it matches the expected object.
-        final BasicDBObject expected = (BasicDBObject) JSON.parse(
+        final Document expected = Document.parse(
                 "{ "
                         + "instanceName : \"test\","
                         + "version : \"1\","
@@ -255,34 +253,34 @@ public class MongoDetailsAdapterTest {
     }
 
     @Test
-    public void toDBObject_pcjDetails() {
+    public void toDocument_pcjDetails() {
         final PCJDetails details = PCJDetails.builder()
                 .setId("pcjId")
                 .setLastUpdateTime( new Date() )
                 .setUpdateStrategy( PCJUpdateStrategy.INCREMENTAL )
                 .build();
 
-        // Convert it into a Mongo DB Object.
-        final BasicDBObject dbo = (BasicDBObject) MongoDetailsAdapter.toDBObject(details);
+        // Convert it into a Mongo DB Document.
+        final Document doc = MongoDetailsAdapter.toDocument(details);
 
-        // Convert the dbo back into the original object.
-        final PCJDetails restored = MongoDetailsAdapter.toPCJDetails(dbo).build();
+        // Convert the doc back into the original object.
+        final PCJDetails restored = MongoDetailsAdapter.toPCJDetails(doc).build();
 
         // Ensure the restored value matches the original.
         assertEquals(details, restored);
     }
 
     @Test
-    public void toDBObject_pcjDetails_missing_optionals() {
+    public void toDocument_pcjDetails_missing_optionals() {
         final PCJDetails details = PCJDetails.builder()
                 .setId("pcjId")
                 .build();
 
-        // Convert it into a Mongo DB Object.
-        final BasicDBObject dbo = (BasicDBObject) MongoDetailsAdapter.toDBObject(details);
+        // Convert it into a Mongo DB Document.
+        final Document doc = MongoDetailsAdapter.toDocument(details);
 
-        // Convert the dbo back into the original object.
-        final PCJDetails restored = MongoDetailsAdapter.toPCJDetails(dbo).build();
+        // Convert the doc back into the original object.
+        final PCJDetails restored = MongoDetailsAdapter.toPCJDetails(doc).build();
 
         // Ensure the restored value matches the original.
         assertEquals(details, restored);

--- a/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/instance/MongoRyaDetailsRepositoryIT.java
+++ b/dao/mongodb.rya/src/test/java/org/apache/rya/mongodb/instance/MongoRyaDetailsRepositoryIT.java
@@ -48,7 +48,7 @@ import com.google.common.base.Optional;
 import com.mongodb.MongoClient;
 
 /**
- * Tests the methods of {@link AccumuloRyaDetailsRepository} by using a {@link MiniAccumuloCluster}.
+ * Tests the methods of {@link MongoRyaDetailsRepository} by using a mock {@link MongoClient}.
  */
 public class MongoRyaDetailsRepositoryIT extends MongoITBase {
     private MongoClient client;
@@ -138,7 +138,7 @@ public class MongoRyaDetailsRepositoryIT extends MongoITBase {
 
     @Test(expected = NotInitializedException.class)
     public void getRyaInstance_notInitialized() throws NotInitializedException, RyaDetailsRepositoryException {
-        // Setup the repository that will be tested using a mock instance of Accumulo.
+        // Setup the repository that will be tested using a mock instance of MongoDB.
         final RyaDetailsRepository repo = new MongoRyaInstanceDetailsRepository(client, "testInstance");
 
         // Try to fetch the details from the uninitialized repository.

--- a/extras/indexing/src/main/java/org/apache/rya/api/client/mongo/MongoUninstall.java
+++ b/extras/indexing/src/main/java/org/apache/rya/api/client/mongo/MongoUninstall.java
@@ -58,7 +58,7 @@ public class MongoUninstall implements Uninstall {
             if (!instanceExists.exists(ryaInstanceName)) {
                 throw new InstanceDoesNotExistException("The database '" + ryaInstanceName + "' does not exist.");
             }
-            adminClient.dropDatabase(ryaInstanceName);
+            adminClient.getDatabase(ryaInstanceName).drop();
         } catch (final MongoException e) {
             throw new RyaClientException("Failed to uninstall '" + ryaInstanceName + "' " + e.getLocalizedMessage(), e);
         }

--- a/extras/indexing/src/main/java/org/apache/rya/indexing/entity/storage/mongo/EntityDocumentConverter.java
+++ b/extras/indexing/src/main/java/org/apache/rya/indexing/entity/storage/mongo/EntityDocumentConverter.java
@@ -23,8 +23,8 @@ import static java.util.Objects.requireNonNull;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.apache.rya.api.domain.RyaType;
 import org.apache.rya.api.domain.RyaIRI;
+import org.apache.rya.api.domain.RyaType;
 import org.apache.rya.indexing.entity.model.Entity;
 import org.apache.rya.indexing.entity.model.Property;
 import org.apache.rya.indexing.entity.storage.mongo.key.MongoDbSafeKey;
@@ -114,7 +114,8 @@ public class EntityDocumentConverter implements DocumentConverter<Entity> {
         final Entity.Builder builder = Entity.builder()
                 .setSubject( new RyaIRI(document.getString(SUBJECT)) );
 
-        ((List<String>)document.get(EXPLICIT_TYPE_IDS)).stream()
+        final List<String> explicitTypeIds = document.getList(EXPLICIT_TYPE_IDS, String.class);
+        explicitTypeIds.stream()
             .forEach(explicitTypeId -> builder.setExplicitType(new RyaIRI(explicitTypeId)));
 
         final Document propertiesDoc = (Document) document.get(PROPERTIES);

--- a/extras/indexing/src/main/java/org/apache/rya/indexing/entity/storage/mongo/MongoEntityStorage.java
+++ b/extras/indexing/src/main/java/org/apache/rya/indexing/entity/storage/mongo/MongoEntityStorage.java
@@ -30,7 +30,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.commons.configuration.ConfigurationException;
-import org.apache.log4j.Logger;
 import org.apache.rya.api.domain.RyaIRI;
 import org.apache.rya.indexing.entity.model.Entity;
 import org.apache.rya.indexing.entity.model.Property;
@@ -64,8 +63,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  */
 @DefaultAnnotation(NonNull.class)
 public class MongoEntityStorage implements EntityStorage {
-    private static final Logger log = Logger.getLogger(MongoEntityStorage.class);
-
     protected static final String COLLECTION_NAME = "entity-entities";
 
     private static final EntityDocumentConverter ENTITY_CONVERTER = new EntityDocumentConverter();

--- a/extras/indexing/src/main/java/org/apache/rya/indexing/entity/storage/mongo/TypeDocumentConverter.java
+++ b/extras/indexing/src/main/java/org/apache/rya/indexing/entity/storage/mongo/TypeDocumentConverter.java
@@ -72,7 +72,7 @@ public class TypeDocumentConverter implements DocumentConverter<Type> {
         final RyaIRI typeId = new RyaIRI( document.getString(ID) );
 
         final ImmutableSet.Builder<RyaIRI> propertyNames = ImmutableSet.builder();
-        ((List<String>) document.get(PROPERTY_NAMES))
+        document.getList(PROPERTY_NAMES, String.class)
             .forEach(propertyName -> propertyNames.add(new RyaIRI(propertyName)));
 
         return new Type(typeId, propertyNames.build());

--- a/extras/indexing/src/main/java/org/apache/rya/indexing/mongodb/IndexingMongoDBStorageStrategy.java
+++ b/extras/indexing/src/main/java/org/apache/rya/indexing/mongodb/IndexingMongoDBStorageStrategy.java
@@ -21,34 +21,33 @@ package org.apache.rya.indexing.mongodb;
 
 import java.util.Set;
 
-import com.mongodb.BasicDBObject;
-import com.mongodb.DBObject;
-import com.mongodb.QueryBuilder;
 import org.apache.rya.indexing.StatementConstraints;
 import org.apache.rya.mongodb.dao.SimpleMongoDBStorageStrategy;
+import org.apache.rya.mongodb.document.operators.query.QueryBuilder;
+import org.bson.Document;
 import org.eclipse.rdf4j.model.IRI;
 
 public class IndexingMongoDBStorageStrategy extends SimpleMongoDBStorageStrategy {
-    public DBObject getQuery(final StatementConstraints contraints) {
+    public Document getQuery(final StatementConstraints contraints) {
         final QueryBuilder queryBuilder = QueryBuilder.start();
         if (contraints.hasSubject()){
-            queryBuilder.and(new BasicDBObject(SUBJECT, contraints.getSubject().toString()));
+            queryBuilder.and(new Document(SUBJECT, contraints.getSubject().toString()));
         }
 
         if (contraints.hasPredicates()){
             final Set<IRI> predicates = contraints.getPredicates();
             if (predicates.size() > 1){
                 for (final IRI pred : predicates){
-                    final DBObject currentPred = new BasicDBObject(PREDICATE, pred.toString());
+                    final Document currentPred = new Document(PREDICATE, pred.toString());
                     queryBuilder.or(currentPred);
                 }
             }
             else if (!predicates.isEmpty()){
-                queryBuilder.and(new BasicDBObject(PREDICATE, predicates.iterator().next().toString()));
+                queryBuilder.and(new Document(PREDICATE, predicates.iterator().next().toString()));
             }
         }
         if (contraints.hasContext()){
-            queryBuilder.and(new BasicDBObject(CONTEXT, contraints.getContext().toString()));
+            queryBuilder.and(new Document(CONTEXT, contraints.getContext().toString()));
         }
         return queryBuilder.get();
     }

--- a/extras/indexing/src/main/java/org/apache/rya/indexing/mongodb/freetext/MongoFreeTextIndexer.java
+++ b/extras/indexing/src/main/java/org/apache/rya/indexing/mongodb/freetext/MongoFreeTextIndexer.java
@@ -25,16 +25,15 @@ import org.apache.rya.indexing.FreeTextIndexer;
 import org.apache.rya.indexing.StatementConstraints;
 import org.apache.rya.indexing.accumulo.ConfigUtils;
 import org.apache.rya.indexing.mongodb.AbstractMongoIndexer;
+import org.apache.rya.mongodb.document.operators.query.QueryBuilder;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
 
-import com.mongodb.QueryBuilder;
-
 public class MongoFreeTextIndexer extends AbstractMongoIndexer<TextMongoDBStorageStrategy> implements FreeTextIndexer {
     private static final String COLLECTION_SUFFIX = "freetext";
     private static final Logger logger = Logger.getLogger(MongoFreeTextIndexer.class);
-    
+
     @Override
     public void init() {
         initCore();
@@ -55,6 +54,6 @@ public class MongoFreeTextIndexer extends AbstractMongoIndexer<TextMongoDBStorag
 
     @Override
     public String getCollectionName() {
-    	return ConfigUtils.getTablePrefix(conf)  + COLLECTION_SUFFIX;
+        return ConfigUtils.getTablePrefix(conf) + COLLECTION_SUFFIX;
     }
 }

--- a/extras/indexing/src/main/java/org/apache/rya/indexing/mongodb/freetext/TextMongoDBStorageStrategy.java
+++ b/extras/indexing/src/main/java/org/apache/rya/indexing/mongodb/freetext/TextMongoDBStorageStrategy.java
@@ -1,5 +1,3 @@
-package org.apache.rya.indexing.mongodb.freetext;
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -18,28 +16,27 @@ package org.apache.rya.indexing.mongodb.freetext;
  * specific language governing permissions and limitations
  * under the License.
  */
-
-import com.mongodb.BasicDBObject;
-import com.mongodb.DBCollection;
-import com.mongodb.DBObject;
+package org.apache.rya.indexing.mongodb.freetext;
 
 import org.apache.rya.api.domain.RyaStatement;
 import org.apache.rya.indexing.mongodb.IndexingMongoDBStorageStrategy;
+import org.bson.Document;
+
+import com.mongodb.client.MongoCollection;
 
 public class TextMongoDBStorageStrategy extends IndexingMongoDBStorageStrategy {
-	private static final String text = "text";
+    private static final String TEXT = "text";
 
-	@Override
-    public void createIndices(final DBCollection coll){
-		final BasicDBObject basicDBObject = new BasicDBObject();
-		basicDBObject.append(text, "text");
-		coll.createIndex(basicDBObject);
-	}
+    @Override
+    public void createIndices(final MongoCollection<Document> coll){
+        final Document indexDoc = new Document(TEXT, "text");
+        coll.createIndex(indexDoc);
+    }
 
-	@Override
-    public DBObject serialize(final RyaStatement ryaStatement) {
- 		final BasicDBObject base = (BasicDBObject) super.serialize(ryaStatement);
- 		base.append(text, ryaStatement.getObject().getData());
-     	return base;
-	}
+    @Override
+    public Document serialize(final RyaStatement ryaStatement) {
+         final Document base = super.serialize(ryaStatement);
+         base.append(TEXT, ryaStatement.getObject().getData());
+         return base;
+    }
 }

--- a/extras/indexing/src/main/java/org/apache/rya/indexing/mongodb/temporal/MongoTemporalIndexer.java
+++ b/extras/indexing/src/main/java/org/apache/rya/indexing/mongodb/temporal/MongoTemporalIndexer.java
@@ -1,4 +1,3 @@
-package org.apache.rya.indexing.mongodb.temporal;
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -17,6 +16,7 @@ package org.apache.rya.indexing.mongodb.temporal;
  * specific language governing permissions and limitations
  * under the License.
  */
+package org.apache.rya.indexing.mongodb.temporal;
 
 import static org.apache.rya.indexing.mongodb.temporal.TemporalMongoDBStorageStrategy.INSTANT;
 import static org.apache.rya.indexing.mongodb.temporal.TemporalMongoDBStorageStrategy.INTERVAL_END;
@@ -29,13 +29,14 @@ import org.apache.rya.indexing.TemporalInstant;
 import org.apache.rya.indexing.TemporalInterval;
 import org.apache.rya.indexing.accumulo.ConfigUtils;
 import org.apache.rya.indexing.mongodb.AbstractMongoIndexer;
+import org.apache.rya.mongodb.document.operators.query.QueryBuilder;
+import org.bson.Document;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.mongodb.DBCollection;
-import com.mongodb.QueryBuilder;
+import com.mongodb.client.MongoCollection;
 
 /**
  * Indexes MongoDB based on time instants or intervals.
@@ -146,7 +147,7 @@ public class MongoTemporalIndexer extends AbstractMongoIndexer<TemporalMongoDBSt
     }
 
     @VisibleForTesting
-    public DBCollection getCollection() {
+    public MongoCollection<Document> getCollection() {
         return collection;
     }
 }

--- a/extras/indexing/src/main/java/org/apache/rya/sail/config/RyaSailFactory.java
+++ b/extras/indexing/src/main/java/org/apache/rya/sail/config/RyaSailFactory.java
@@ -20,7 +20,6 @@ package org.apache.rya.sail.config;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
@@ -53,6 +52,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.mongodb.MongoClient;
+import com.mongodb.MongoClientOptions;
 import com.mongodb.MongoCredential;
 import com.mongodb.MongoException;
 import com.mongodb.ServerAddress;
@@ -147,7 +147,8 @@ public class RyaSailFactory {
         final String password = mongoConf.getMongoPassword();
         if(username != null && password != null) {
             final MongoCredential cred = MongoCredential.createCredential(username, database, password.toCharArray());
-            return new MongoClient(server, Arrays.asList(cred));
+            final MongoClientOptions options = new MongoClientOptions.Builder().build();
+            return new MongoClient(server, cred, options);
         } else {
             return new MongoClient(server);
         }
@@ -221,7 +222,7 @@ public class RyaSailFactory {
      * @return - MongoDBRyaDAO with Indexers configured according to user's specification
      * @throws RyaDAOException if the DAO can't be initialized
      */
-    public static MongoDBRyaDAO getMongoDAO(MongoDBRdfConfiguration mongoConfig) throws RyaDAOException {
+    public static MongoDBRyaDAO getMongoDAO(final MongoDBRdfConfiguration mongoConfig) throws RyaDAOException {
             // Create the MongoClient that will be used by the Sail object's components.
             final MongoClient client = createMongoClient(mongoConfig);
 

--- a/extras/indexing/src/test/java/org/apache/rya/api/client/mongo/MongoLoadStatementsFileIT.java
+++ b/extras/indexing/src/test/java/org/apache/rya/api/client/mongo/MongoLoadStatementsFileIT.java
@@ -80,19 +80,21 @@ public class MongoLoadStatementsFileIT extends MongoRyaITBase {
         expected.add(vf.createStatement(vf.createIRI("http://example#charlie"), vf.createIRI("http://example#likes"), vf.createIRI("http://example#icecream")));
 
         final Set<Statement> statements = new HashSet<>();
-        final MongoCursor<Document> triplesIterator = getMongoClient()
+        try (final MongoCursor<Document> triplesIterator = getMongoClient()
                 .getDatabase( conf.getRyaInstanceName() )
                 .getCollection( conf.getTriplesCollectionName() )
                 .find().iterator();
-        while (triplesIterator.hasNext()) {
-            final Document triple = triplesIterator.next();
-            statements.add(vf.createStatement(
-                    vf.createIRI(triple.getString("subject")),
-                    vf.createIRI(triple.getString("predicate")),
-                    vf.createIRI(triple.getString("object"))));
-        }
+        ) {
+            while (triplesIterator.hasNext()) {
+                final Document triple = triplesIterator.next();
+                statements.add(vf.createStatement(
+                        vf.createIRI(triple.getString("subject")),
+                        vf.createIRI(triple.getString("predicate")),
+                        vf.createIRI(triple.getString("object"))));
+            }
 
-        assertEquals(expected, statements);
+            assertEquals(expected, statements);
+        }
     }
 
     private MongoConnectionDetails getConnectionDetails() {

--- a/extras/indexing/src/test/java/org/apache/rya/indexing/external/PcjIntegrationTestingUtil.java
+++ b/extras/indexing/src/test/java/org/apache/rya/indexing/external/PcjIntegrationTestingUtil.java
@@ -420,7 +420,6 @@ public class PcjIntegrationTestingUtil {
     //****************************Creation and Population of PcjTables Mongo ***********************************
 
     public static void deleteCoreRyaTables(final MongoClient client, final String instance, final String collName) {
-        final boolean bool = client.isLocked();
         client.getDatabase(instance).getCollection(collName).drop();
     }
 

--- a/extras/indexing/src/test/java/org/apache/rya/indexing/mongo/MongoPCJIndexIT.java
+++ b/extras/indexing/src/test/java/org/apache/rya/indexing/mongo/MongoPCJIndexIT.java
@@ -151,8 +151,8 @@ public class MongoPCJIndexIT extends MongoRyaITBase {
         final String pcjId = ryaClient.getCreatePCJ().createPCJ(conf.getRyaInstanceName(), pcjQuery);
         ryaClient.getBatchUpdatePCJ().batchUpdate(conf.getRyaInstanceName(), pcjId);
 
-        System.out.println("Triples: " + getMongoClient().getDatabase(conf.getRyaInstanceName()).getCollection(conf.getTriplesCollectionName()).count());
-        System.out.println("PCJS: " + getMongoClient().getDatabase(conf.getRyaInstanceName()).getCollection("pcjs").count());
+        System.out.println("Triples: " + getMongoClient().getDatabase(conf.getRyaInstanceName()).getCollection(conf.getTriplesCollectionName()).countDocuments());
+        System.out.println("PCJS: " + getMongoClient().getDatabase(conf.getRyaInstanceName()).getCollection("pcjs").countDocuments());
 
         //run the query.  since the triples collection is gone, if the results match, they came from the PCJ index.
         final Sail sail = RyaSailFactory.getInstance(conf);

--- a/extras/indexing/src/test/java/org/apache/rya/indexing/mongo/MongoPcjIntegrationTest.java
+++ b/extras/indexing/src/test/java/org/apache/rya/indexing/mongo/MongoPcjIntegrationTest.java
@@ -54,6 +54,7 @@ import org.eclipse.rdf4j.query.parser.sparql.SPARQLParser;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.sail.Sail;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.google.common.collect.Lists;
@@ -127,6 +128,7 @@ public class MongoPcjIntegrationTest extends MongoRyaITBase {
         }
     }
 
+    @Ignore //TODO Fix this. It's been broken for awhile
     @Test
     public void testEvaluateOneIndex() throws Exception {
         final Sail nonPcjSail = RyaSailFactory.getInstance(conf);

--- a/extras/indexingExample/src/main/java/InferenceExamples.java
+++ b/extras/indexingExample/src/main/java/InferenceExamples.java
@@ -18,7 +18,6 @@
  */
 
 import java.io.IOException;
-import java.util.List;
 
 import org.apache.commons.lang.Validate;
 import org.apache.hadoop.conf.Configuration;
@@ -37,13 +36,12 @@ import org.apache.rya.test.mongo.EmbeddedMongoFactory;
 import org.apache.zookeeper.ClientCnxn;
 import org.eclipse.rdf4j.model.vocabulary.OWL;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.eclipse.rdf4j.query.AbstractTupleQueryResultHandler;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.MalformedQueryException;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
 import org.eclipse.rdf4j.query.QueryLanguage;
-import org.eclipse.rdf4j.query.QueryResultHandlerException;
 import org.eclipse.rdf4j.query.TupleQuery;
-import org.eclipse.rdf4j.query.TupleQueryResultHandler;
 import org.eclipse.rdf4j.query.TupleQueryResultHandlerException;
 import org.eclipse.rdf4j.query.Update;
 import org.eclipse.rdf4j.query.UpdateExecutionException;
@@ -53,548 +51,533 @@ import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.sail.Sail;
 
 import com.mongodb.MongoClient;
-import com.mongodb.ServerAddress;
+
+import de.flapdoodle.embed.mongo.config.Net;
 
 
 
 public class InferenceExamples {
-	   private static final Logger log = Logger.getLogger(InferenceExamples.class);
+    private static final Logger log = Logger.getLogger(InferenceExamples.class);
 
-	    private static final boolean IS_DETAILED_LOGGING_ENABLED = false;
+    private static final boolean IS_DETAILED_LOGGING_ENABLED = false;
 
-	    //
-	    // Connection configuration parameters
-	    //
+    //
+    // Connection configuration parameters
+    //
 
-	    private static final boolean PRINT_QUERIES = true;
-	    private static final String MONGO_DB = "rya";
-	    private static final String MONGO_COLL_PREFIX = "rya_";
-	    private static final boolean USE_EMBEDDED_MONGO = true;
-	    private static final String MONGO_INSTANCE_URL = "localhost";
-	    private static final String MONGO_INSTANCE_PORT = "27017";
-	    private static final String MongoUserName="usern";
-	    private static final String MongoUserPswd="passwd";
+    private static final boolean PRINT_QUERIES = true;
+    private static final String MONGO_DB = "rya";
+    private static final String MONGO_COLL_PREFIX = "rya_";
+    private static final boolean USE_EMBEDDED_MONGO = true;
+    private static final String MONGO_INSTANCE_URL = "localhost";
+    private static final String MONGO_INSTANCE_PORT = "27017";
+    private static final String MongoUserName="usern";
+    private static final String MongoUserPswd="passwd";
 
-	    public static void setupLogging() {
-	        final Logger rootLogger = LogManager.getRootLogger();
-	        final ConsoleAppender ca = (ConsoleAppender) rootLogger.getAppender("stdout");
-	        ca.setLayout(new PatternLayout("%d{MMM dd yyyy HH:mm:ss} %5p [%t] (%F:%L) - %m%n"));
-	        rootLogger.setLevel(Level.INFO);
-	        // Filter out noisy messages from the following classes.
-	        Logger.getLogger(ClientCnxn.class).setLevel(Level.OFF);
-	        Logger.getLogger(EmbeddedMongoFactory.class).setLevel(Level.OFF);
-	    }
+    public static void setupLogging() {
+        final Logger rootLogger = LogManager.getRootLogger();
+        final ConsoleAppender ca = (ConsoleAppender) rootLogger.getAppender("stdout");
+        ca.setLayout(new PatternLayout("%d{MMM dd yyyy HH:mm:ss} %5p [%t] (%F:%L) - %m%n"));
+        rootLogger.setLevel(Level.INFO);
+        // Filter out noisy messages from the following classes.
+        Logger.getLogger(ClientCnxn.class).setLevel(Level.OFF);
+        Logger.getLogger(EmbeddedMongoFactory.class).setLevel(Level.OFF);
+    }
 
-	    public static void main(final String[] args) throws Exception {
-	        if (IS_DETAILED_LOGGING_ENABLED) {
-	            setupLogging();
-	        }
-	        final Configuration conf = getConf();
-	        conf.setBoolean(ConfigUtils.DISPLAY_QUERY_PLAN, PRINT_QUERIES);
+    public static void main(final String[] args) throws Exception {
+        if (IS_DETAILED_LOGGING_ENABLED) {
+            setupLogging();
+        }
+        final Configuration conf = getConf();
+        conf.setBoolean(ConfigUtils.DISPLAY_QUERY_PLAN, PRINT_QUERIES);
 
-	        SailRepository repository = null;
-	        SailRepositoryConnection conn = null;
-	        try {
-	            log.info("Connecting to Indexing Sail Repository.");
-	            final Sail sail = RyaSailFactory.getInstance(conf);
-	            repository = new SailRepository(sail);
-	            conn = repository.getConnection();
-
-
-	            final long start = System.currentTimeMillis();
-
-	                testInfer(conn, sail);
-	                testPropertyChainInference(conn, sail);
-	                testPropertyChainInferenceAltRepresentation(conn, sail);
-	                testSomeValuesFromInference(conn, sail);
-	                testAllValuesFromInference(conn, sail);
-	                testIntersectionOfInference(conn, sail);
-	                testOneOfInference(conn, sail);
-
-	            log.info("TIME: " + (System.currentTimeMillis() - start) / 1000.);
-	        } finally {
-	            log.info("Shutting down");
-	            closeQuietly(conn);
-	            closeQuietly(repository);
-	        }
-	    }
-
-	    private static void closeQuietly(final SailRepository repository) {
-	        if (repository != null) {
-	            try {
-	                repository.shutDown();
-	            } catch (final RepositoryException e) {
-	                // quietly absorb this exception
-	            }
-	        }
-	    }
-
-	    private static void closeQuietly(final SailRepositoryConnection conn) {
-	        if (conn != null) {
-	            try {
-	                conn.close();
-	            } catch (final RepositoryException e) {
-	                // quietly absorb this exception
-	            }
-	        }
-	    }
-
-	    private static Configuration getConf() throws IOException {
-
-	       // MongoDBIndexingConfigBuilder builder = MongoIndexingConfiguration.builder()
-	       //     .setUseMockMongo(USE_MOCK).setUseInference(USE_INFER).setAuths("U");
-	        MongoDBIndexingConfigBuilder builder = MongoIndexingConfiguration.builder()
-		            .setUseMockMongo(USE_EMBEDDED_MONGO).setUseInference(true).setAuths("U");
-
-	        if (USE_EMBEDDED_MONGO) {
-	            final MongoClient c = EmbeddedMongoFactory.newFactory().newMongoClient();
-	            final ServerAddress address = c.getAddress();
-	            final String url = address.getHost();
-	            final String port = Integer.toString(address.getPort());
-	            c.close();
-	            builder.setMongoHost(url).setMongoPort(port);
-	        } else {
-	            // User name and password must be filled in:
-	            builder = builder.setMongoUser(MongoUserName)
-	                             .setMongoPassword(MongoUserPswd)
-	                             .setMongoHost(MONGO_INSTANCE_URL)
-	                             .setMongoPort(MONGO_INSTANCE_PORT);
-	        }
-
-	        return builder.setMongoDBName(MONGO_DB)
-	               .setMongoCollectionPrefix(MONGO_COLL_PREFIX)
-	               .setUseMongoFreetextIndex(true)
-	               .setMongoFreeTextPredicates(RDFS.LABEL.stringValue()).build();
-
-	    }
+        SailRepository repository = null;
+        SailRepositoryConnection conn = null;
+        try {
+            log.info("Connecting to Indexing Sail Repository.");
+            final Sail sail = RyaSailFactory.getInstance(conf);
+            repository = new SailRepository(sail);
+            conn = repository.getConnection();
 
 
-	    public static void testPropertyChainInferenceAltRepresentation(final SailRepositoryConnection conn, final Sail sail) throws MalformedQueryException, RepositoryException,
-	    UpdateExecutionException, QueryEvaluationException, TupleQueryResultHandlerException, InferenceEngineException {
+            final long start = System.currentTimeMillis();
 
-	        // Add data
-	        String query = "INSERT DATA\n"//
-	                + "{ GRAPH <http://updated/test> {\n"//
-	                + "  <urn:jenGreatGranMother> <urn:Motherof> <urn:jenGranMother> . "
-	                + "  <urn:jenGranMother> <urn:isChildOf> <urn:jenGreatGranMother> . "
-	                + "  <urn:jenGranMother> <urn:Motherof> <urn:jenMother> . "
-	                + "  <urn:jenMother> <urn:isChildOf> <urn:jenGranMother> . "
-	                + " <urn:jenMother> <urn:Motherof> <urn:jen> . "
-	                + "  <urn:jen> <urn:isChildOf> <urn:jenMother> . "
-	                + " <urn:jen> <urn:Motherof> <urn:jenDaughter> .  }}";
+                testInfer(conn, sail);
+                testPropertyChainInference(conn, sail);
+                testPropertyChainInferenceAltRepresentation(conn, sail);
+                testSomeValuesFromInference(conn, sail);
+                testAllValuesFromInference(conn, sail);
+                testIntersectionOfInference(conn, sail);
+                testOneOfInference(conn, sail);
 
-	        log.info("Performing Query");
+            log.info("TIME: " + (System.currentTimeMillis() - start) / 1000.);
+        } finally {
+            log.info("Shutting down");
+            closeQuietly(conn);
+            closeQuietly(repository);
+        }
+    }
 
-	        Update update = conn.prepareUpdate(QueryLanguage.SPARQL, query);
-	        update.execute();
+    private static void closeQuietly(final SailRepository repository) {
+        if (repository != null) {
+            try {
+                repository.shutDown();
+            } catch (final RepositoryException e) {
+                // quietly absorb this exception
+            }
+        }
+    }
 
-	        query = "select ?p { GRAPH <http://updated/test> {?s <urn:Motherof>/<urn:Motherof> ?p}}";
-	        CountingResultHandler resultHandler = new CountingResultHandler();
-	        TupleQuery tupleQuery = conn.prepareTupleQuery(QueryLanguage.SPARQL, query);
-	        tupleQuery.evaluate(resultHandler);
-	        log.info("Result count : " + resultHandler.getCount());
+    private static void closeQuietly(final SailRepositoryConnection conn) {
+        if (conn != null) {
+            try {
+                conn.close();
+            } catch (final RepositoryException e) {
+                // quietly absorb this exception
+            }
+        }
+    }
 
+    private static Configuration getConf() throws IOException {
 
-	        // try adding a property chain and querying for it
-	        query = "INSERT DATA\n"//
-	                + "{ GRAPH <http://updated/test> {\n"//
-	                + "  <urn:greatMother> owl:propertyChainAxiom <urn:12342>  . " +
-	                " <urn:12342> <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:node1atjakcvbx15023 . " +
-	                " _:node1atjakcvbx15023 <http://www.w3.org/2002/07/owl#inverseOf> <urn:isChildOf> . " +
-	                " <urn:12342> <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:node1atjakcvbx15123 . " +
-	                   " _:node1atjakcvbx15123 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> . " +
-	                " _:node1atjakcvbx15123 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <urn:MotherOf> .  }}";
-	        update = conn.prepareUpdate(QueryLanguage.SPARQL, query);
-	        update.execute();
-	        ((RdfCloudTripleStore) sail).getInferenceEngine().refreshGraph();
+       // MongoDBIndexingConfigBuilder builder = MongoIndexingConfiguration.builder()
+       //     .setUseMockMongo(USE_MOCK).setUseInference(USE_INFER).setAuths("U");
+        MongoDBIndexingConfigBuilder builder = MongoIndexingConfiguration.builder()
+	            .setUseMockMongo(USE_EMBEDDED_MONGO).setUseInference(true).setAuths("U");
 
-	        resultHandler.resetCount();
-	        query = "select ?x { GRAPH <http://updated/test> {<urn:jenGreatGranMother> <urn:greatMother> ?x}}";
-	        resultHandler = new CountingResultHandler();
-	        tupleQuery = conn.prepareTupleQuery(QueryLanguage.SPARQL, query);
-	        tupleQuery.evaluate(resultHandler);
-	        log.info("Result count : " + resultHandler.getCount());
+        if (USE_EMBEDDED_MONGO) {
+            final MongoClient c = EmbeddedMongoFactory.newFactory().newMongoClient();
+            final Net address = EmbeddedMongoFactory.newFactory().getMongoServerDetails().net();
+            final String url = address.getServerAddress().getHostAddress();
+            final String port = Integer.toString(address.getPort());
+            c.close();
+            builder.setMongoHost(url).setMongoPort(port);
+        } else {
+            // User name and password must be filled in:
+            builder = builder.setMongoUser(MongoUserName)
+                             .setMongoPassword(MongoUserPswd)
+                             .setMongoHost(MONGO_INSTANCE_URL)
+                             .setMongoPort(MONGO_INSTANCE_PORT);
+        }
 
-	    }
+        return builder.setMongoDBName(MONGO_DB)
+               .setMongoCollectionPrefix(MONGO_COLL_PREFIX)
+               .setUseMongoFreetextIndex(true)
+               .setMongoFreeTextPredicates(RDFS.LABEL.stringValue()).build();
 
-	    public static void testPropertyChainInference(final SailRepositoryConnection conn, final Sail sail) throws MalformedQueryException, RepositoryException,
-	    UpdateExecutionException, QueryEvaluationException, TupleQueryResultHandlerException, InferenceEngineException {
-
-	        // Add data
-	        String query = "INSERT DATA\n"//
-	                + "{ GRAPH <http://updated/test> {\n"//
-	                + "  <urn:paulGreatGrandfather> <urn:father> <urn:paulGrandfather> . "
-	                + "  <urn:paulGrandfather> <urn:father> <urn:paulFather> . " +
-	                " <urn:paulFather> <urn:father> <urn:paul> . " +
-	                " <urn:paul> <urn:father> <urn:paulSon> .  }}";
-
-	        log.info("Performing Query");
-
-	        Update update = conn.prepareUpdate(QueryLanguage.SPARQL, query);
-	        update.execute();
-
-	        query = "select ?p { GRAPH <http://updated/test> {<urn:paulGreatGrandfather> <urn:father>/<urn:father> ?p}}";
-	        CountingResultHandler resultHandler = new CountingResultHandler();
-	        TupleQuery tupleQuery = conn.prepareTupleQuery(QueryLanguage.SPARQL, query);
-	        tupleQuery.evaluate(resultHandler);
-	        log.info("Result count : " + resultHandler.getCount());
+    }
 
 
-	        // try adding a property chain and querying for it
-	        query = "INSERT DATA\n"//
-	                + "{ GRAPH <http://updated/test> {\n"//
-	                + "  <urn:greatGrandfather> owl:propertyChainAxiom <urn:1234>  . " +
-	                " <urn:1234> <http://www.w3.org/2000/10/swap/list#length> 3 . " +
-	                " <urn:1234> <http://www.w3.org/2000/10/swap/list#index> (0 <urn:father>) . " +
-	                " <urn:1234> <http://www.w3.org/2000/10/swap/list#index> (1 <urn:father>) . " +
-	                " <urn:1234> <http://www.w3.org/2000/10/swap/list#index> (2 <urn:father>) .  }}";
-	        update = conn.prepareUpdate(QueryLanguage.SPARQL, query);
-	        update.execute();
-	        query = "INSERT DATA\n"//
-	                + "{ GRAPH <http://updated/test> {\n"//
-	                + "  <urn:grandfather> owl:propertyChainAxiom <urn:12344>  . " +
-	                " <urn:12344> <http://www.w3.org/2000/10/swap/list#length> 2 . " +
-	                " <urn:12344> <http://www.w3.org/2000/10/swap/list#index> (0 <urn:father>) . " +
-	                " <urn:12344> <http://www.w3.org/2000/10/swap/list#index> (1 <urn:father>) .  }}";
-	        update = conn.prepareUpdate(QueryLanguage.SPARQL, query);
-	        update.execute();
-	        ((RdfCloudTripleStore) sail).getInferenceEngine().refreshGraph();
+    public static void testPropertyChainInferenceAltRepresentation(final SailRepositoryConnection conn, final Sail sail) throws MalformedQueryException, RepositoryException,
+    UpdateExecutionException, QueryEvaluationException, TupleQueryResultHandlerException, InferenceEngineException {
 
-	        resultHandler.resetCount();
-	        query = "select ?p { GRAPH <http://updated/test> {<urn:paulGreatGrandfather> <urn:greatGrandfather> ?p}}";
-	        resultHandler = new CountingResultHandler();
-	        tupleQuery = conn.prepareTupleQuery(QueryLanguage.SPARQL, query);
-	        tupleQuery.evaluate(resultHandler);
-	        log.info("Result count : " + resultHandler.getCount());
+        // Add data
+        String query = "INSERT DATA\n"//
+                + "{ GRAPH <http://updated/test> {\n"//
+                + "  <urn:jenGreatGranMother> <urn:Motherof> <urn:jenGranMother> . "
+                + "  <urn:jenGranMother> <urn:isChildOf> <urn:jenGreatGranMother> . "
+                + "  <urn:jenGranMother> <urn:Motherof> <urn:jenMother> . "
+                + "  <urn:jenMother> <urn:isChildOf> <urn:jenGranMother> . "
+                + " <urn:jenMother> <urn:Motherof> <urn:jen> . "
+                + "  <urn:jen> <urn:isChildOf> <urn:jenMother> . "
+                + " <urn:jen> <urn:Motherof> <urn:jenDaughter> .  }}";
 
-	        resultHandler.resetCount();
-	        query = "select ?s ?p { GRAPH <http://updated/test> {?s <urn:grandfather> ?p}}";
-	        resultHandler = new CountingResultHandler();
-	        tupleQuery = conn.prepareTupleQuery(QueryLanguage.SPARQL, query);
-	        tupleQuery.evaluate(resultHandler);
-	        log.info("Result count : " + resultHandler.getCount());
+        log.info("Performing Query");
 
-	    }
+        Update update = conn.prepareUpdate(QueryLanguage.SPARQL, query);
+        update.execute();
 
-	    public static void testIntersectionOfInference(final SailRepositoryConnection conn, final Sail sail) throws MalformedQueryException, RepositoryException, UpdateExecutionException, QueryEvaluationException, TupleQueryResultHandlerException, InferenceEngineException {
-	        log.info("Adding Data");
-	        final String instances = "INSERT DATA\n"
-	                + "{ GRAPH <http://updated/test> {\n"
-	                + "  <urn:Susan> a <urn:Mother> . \n"
-	                + "  <urn:Mary> a <urn:Woman> . \n"
-	                + "  <urn:Mary> a <urn:Parent> . \n"
-	                + "}}";
-	        Update update = conn.prepareUpdate(QueryLanguage.SPARQL, instances);
-	        update.execute();
-	        final String inferQuery = "select distinct ?x { GRAPH <http://updated/test> { ?x a <urn:Mother> }}";
-	        final String explicitQuery = "select distinct ?x { GRAPH <http://updated/test> {\n"
-	                + "  { ?x a <urn:Mother> }\n"
-	                + "  UNION {\n"
-	                + "    ?x a <urn:Woman> .\n"
-	                + "    ?x a <urn:Parent> .\n"
-	                + "  }\n"
-	                + "}}";
-	        log.info("Running Explicit Query");
-	        CountingResultHandler resultHandler = new CountingResultHandler();
-	        TupleQuery tupleQuery = conn.prepareTupleQuery(QueryLanguage.SPARQL, explicitQuery);
-	        tupleQuery.evaluate(resultHandler);
-	        log.info("Result count : " + resultHandler.getCount());
-	        Validate.isTrue(resultHandler.getCount() == 2);
-	        log.info("Running Inference-dependant Query");
-	        resultHandler.resetCount();
-	        tupleQuery = conn.prepareTupleQuery(QueryLanguage.SPARQL, inferQuery);
-	        tupleQuery.evaluate(resultHandler);
-	        log.info("Result count : " + resultHandler.getCount());
-	        Validate.isTrue(resultHandler.getCount() == 1);
-	        log.info("Adding owl:intersectionOf Schema");
-	        // ONTOLOGY - :Mother intersectionOf[:Woman, :Parent]
-	        final String ontology = "INSERT DATA\n"
-	                + "{ GRAPH <http://updated/test> {\n"
-	                + "  <urn:Mother> owl:intersectionOf _:bnode1 . \n"
-	                + "  _:bnode1 rdf:first <urn:Woman> . \n"
-	                + "  _:bnode1 rdf:rest _:bnode2 . \n"
-	                + "  _:bnode2 rdf:first <urn:Parent> . \n"
-	                + "  _:bnode2 rdf:rest rdf:nil . \n"
-	               + "}}";
-	        update = conn.prepareUpdate(QueryLanguage.SPARQL, ontology);
-	        update.execute();
-	        log.info("Refreshing InferenceEngine");
-	        ((RdfCloudTripleStore) sail).getInferenceEngine().refreshGraph();
-	        log.info("Re-running Inference-dependant Query");
-	        resultHandler.resetCount();
-	        resultHandler = new CountingResultHandler();
-	        tupleQuery = conn.prepareTupleQuery(QueryLanguage.SPARQL, inferQuery);
-	        tupleQuery.evaluate(resultHandler);
-	        log.info("Result count : " + resultHandler.getCount());
-	        Validate.isTrue(resultHandler.getCount() == 2);
-	    }
+        query = "select ?p { GRAPH <http://updated/test> {?s <urn:Motherof>/<urn:Motherof> ?p}}";
+        CountingResultHandler resultHandler = new CountingResultHandler();
+        TupleQuery tupleQuery = conn.prepareTupleQuery(QueryLanguage.SPARQL, query);
+        tupleQuery.evaluate(resultHandler);
+        log.info("Result count : " + resultHandler.getCount());
 
-	    public static void testSomeValuesFromInference(final SailRepositoryConnection conn, final Sail sail) throws MalformedQueryException, RepositoryException,
-	    UpdateExecutionException, QueryEvaluationException, TupleQueryResultHandlerException, InferenceEngineException {
-	        final String lubm = "http://swat.cse.lehigh.edu/onto/univ-bench.owl#";
-	        log.info("Adding Data");
-	        String insert = "PREFIX lubm: <" + lubm + ">\n"
-	                + "INSERT DATA { GRAPH <http://updated/test> {\n"
-	                + "  <urn:Department0> a lubm:Department; lubm:subOrganizationOf <urn:University0> .\n"
-	                + "  <urn:ResearchGroup0> a lubm:ResearchGroup; lubm:subOrganizationOf <urn:Department0> .\n"
-	                + "  <urn:Alice> lubm:headOf <urn:Department0> .\n"
-	                + "  <urn:Bob> lubm:headOf <urn:ResearchGroup0> .\n"
-	                + "  <urn:Carol> lubm:worksFor <urn:Department0> .\n"
-	                + "}}";
-	        Update update = conn.prepareUpdate(QueryLanguage.SPARQL, insert);
-	        update.execute();
-	        final String inferQuery = "select distinct ?x { GRAPH <http://updated/test> { ?x a <" + lubm + "Chair> }}";
-	        final String explicitQuery = "prefix lubm: <" + lubm + ">\n"
-	                + "select distinct ?x { GRAPH <http://updated/test> {\n"
-	                + "  { ?x a lubm:Chair }\n"
-	                + "  UNION\n"
-	                + "  { ?x lubm:headOf [ a lubm:Department ] }\n"
-	                + "}}";
-	        log.info("Running Explicit Query");
-	        final CountingResultHandler resultHandler = new CountingResultHandler();
-	        TupleQuery tupleQuery = conn.prepareTupleQuery(QueryLanguage.SPARQL, explicitQuery);
-	        tupleQuery.evaluate(resultHandler);
-	        log.info("Result count : " + resultHandler.getCount());
-	        Validate.isTrue(resultHandler.getCount() == 1);
-	        log.info("Running Inference-dependent Query");
-	        resultHandler.resetCount();
-	        tupleQuery = conn.prepareTupleQuery(QueryLanguage.SPARQL, inferQuery);
-	        tupleQuery.evaluate(resultHandler);
-	        log.info("Result count : " + resultHandler.getCount());
-	        Validate.isTrue(resultHandler.getCount() == 0);
-	        log.info("Adding owl:someValuesFrom Schema");
-	        insert = "PREFIX rdfs: <" + RDFS.NAMESPACE + ">\n"
-	                + "PREFIX owl: <" + OWL.NAMESPACE + ">\n"
-	                + "PREFIX lubm: <" + lubm + ">\n"
-	                + "INSERT DATA\n"
-	                + "{ GRAPH <http://updated/test> {\n"
-	                + "  lubm:Chair owl:equivalentClass [ owl:onProperty lubm:headOf ; owl:someValuesFrom lubm:Department ] ."
-	                + "}}";
-	        update = conn.prepareUpdate(QueryLanguage.SPARQL, insert);
-	        update.execute();
-	        log.info("Refreshing InferenceEngine");
-	        ((RdfCloudTripleStore) sail).getInferenceEngine().refreshGraph();
-	        log.info("Re-running Inference-dependent Query");
-	        resultHandler.resetCount();
-	        tupleQuery = conn.prepareTupleQuery(QueryLanguage.SPARQL, inferQuery);
-	        tupleQuery.evaluate(resultHandler);
-	        log.info("Result count : " + resultHandler.getCount());
-	        Validate.isTrue(resultHandler.getCount() == 1);
-	    }
 
-	    public static void testAllValuesFromInference(final SailRepositoryConnection conn, final Sail sail) throws MalformedQueryException, RepositoryException,
-	    UpdateExecutionException, QueryEvaluationException, TupleQueryResultHandlerException, InferenceEngineException {
-	        log.info("Adding Data");
-	        String insert = "INSERT DATA\n"
-	                + "{ GRAPH <http://updated/test> {\n"
-	                + "  <urn:Alice> a <urn:Person> .\n"
-	                + "  <urn:Alice> <urn:hasParent> <urn:Bob> .\n"
-	                + "  <urn:Carol> <urn:hasParent> <urn:Dan> .\n"
-	                + "}}";
-	        Update update = conn.prepareUpdate(QueryLanguage.SPARQL, insert);
-	        update.execute();
-	        final String inferQuery = "select distinct ?x { GRAPH <http://updated/test> { ?x a <urn:Person> }}";
-	        final String explicitQuery = "select distinct ?x { GRAPH <http://updated/test> {\n"
-	                + "  { ?x a <urn:Person> }\n"
-	                + "  UNION {\n"
-	                + "    ?y a <urn:Person> .\n"
-	                + "    ?y <urn:hasParent> ?x .\n"
-	                + "  }\n"
-	                + "}}";
-	        log.info("Running Explicit Query");
-	        final CountingResultHandler resultHandler = new CountingResultHandler();
-	        TupleQuery tupleQuery = conn.prepareTupleQuery(QueryLanguage.SPARQL, explicitQuery);
-	        tupleQuery.evaluate(resultHandler);
-	        log.info("Result count : " + resultHandler.getCount());
-	        Validate.isTrue(resultHandler.getCount() == 2);
-	        log.info("Running Inference-dependent Query");
-	        resultHandler.resetCount();
-	        tupleQuery = conn.prepareTupleQuery(QueryLanguage.SPARQL, inferQuery);
-	        tupleQuery.evaluate(resultHandler);
-	        log.info("Result count : " + resultHandler.getCount());
-	        Validate.isTrue(resultHandler.getCount() == 1);
-	        log.info("Adding owl:allValuesFrom Schema");
-	        insert = "PREFIX rdfs: <" + RDFS.NAMESPACE + ">\n"
-	                + "PREFIX owl: <" + OWL.NAMESPACE + ">\n"
-	                + "INSERT DATA\n"
-	                + "{ GRAPH <http://updated/test> {\n"
-	                + "  <urn:Person> rdfs:subClassOf [ owl:onProperty <urn:hasParent> ; owl:allValuesFrom <urn:Person> ] ."
-	                + "}}";
-	        update = conn.prepareUpdate(QueryLanguage.SPARQL, insert);
-	        update.execute();
-	        log.info("Refreshing InferenceEngine");
-	        ((RdfCloudTripleStore) sail).getInferenceEngine().refreshGraph();
-	        log.info("Re-running Inference-dependent Query");
-	        resultHandler.resetCount();
-	        tupleQuery = conn.prepareTupleQuery(QueryLanguage.SPARQL, inferQuery);
-	        tupleQuery.evaluate(resultHandler);
-	        log.info("Result count : " + resultHandler.getCount());
-	        Validate.isTrue(resultHandler.getCount() == 2);
-	    }
+        // try adding a property chain and querying for it
+        query = "INSERT DATA\n"//
+                + "{ GRAPH <http://updated/test> {\n"//
+                + "  <urn:greatMother> owl:propertyChainAxiom <urn:12342>  . " +
+                " <urn:12342> <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:node1atjakcvbx15023 . " +
+                " _:node1atjakcvbx15023 <http://www.w3.org/2002/07/owl#inverseOf> <urn:isChildOf> . " +
+                " <urn:12342> <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:node1atjakcvbx15123 . " +
+                   " _:node1atjakcvbx15123 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> . " +
+                " _:node1atjakcvbx15123 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <urn:MotherOf> .  }}";
+        update = conn.prepareUpdate(QueryLanguage.SPARQL, query);
+        update.execute();
+        ((RdfCloudTripleStore<?>) sail).getInferenceEngine().refreshGraph();
 
-	    public static void testOneOfInference(final SailRepositoryConnection conn, final Sail sail) throws MalformedQueryException, RepositoryException, UpdateExecutionException, QueryEvaluationException, TupleQueryResultHandlerException, InferenceEngineException {
-	        log.info("Adding Data");
-	        final String instances = "INSERT DATA"
-	                + "{ GRAPH <http://updated/test> {\n"
-	                + "  <urn:FlopCard1> a <urn:Card> . \n"
-	                + "    <urn:FlopCard1> <urn:HasRank> <urn:Ace> . \n"
-	                + "    <urn:FlopCard1> <urn:HasSuit> <urn:Diamonds> . \n"
-	                + "  <urn:FlopCard2> a <urn:Card> . \n"
-	                + "    <urn:FlopCard2> <urn:HasRank> <urn:Ace> . \n"
-	                + "    <urn:FlopCard2> <urn:HasSuit> <urn:Hearts> . \n"
-	                + "  <urn:FlopCard3> a <urn:Card> . \n"
-	                + "    <urn:FlopCard3> <urn:HasRank> <urn:King> . \n"
-	                + "    <urn:FlopCard3> <urn:HasSuit> <urn:Spades> . \n"
-	                + "  <urn:TurnCard> a <urn:Card> . \n"
-	                + "    <urn:TurnCard> <urn:HasRank> <urn:10> . \n"
-	                + "    <urn:TurnCard> <urn:HasSuit> <urn:Clubs> . \n"
-	                + "  <urn:RiverCard> a <urn:Card> . \n"
-	                + "    <urn:RiverCard> <urn:HasRank> <urn:Queen> . \n"
-	                + "    <urn:RiverCard> <urn:HasSuit> <urn:Hearts> . \n"
-	                + "}}";
-	        Update update = conn.prepareUpdate(QueryLanguage.SPARQL, instances);
-	        update.execute();
-	        final String explicitQuery = "select distinct ?card { GRAPH <http://updated/test> {\n"
-	                + "  ?card a <urn:Card> . \n"
-	                + "  VALUES ?suit { <urn:Clubs> <urn:Diamonds> <urn:Hearts> <urn:Spades> } . \n"
-	                + "  ?card <urn:HasSuit> ?suit . \n"
-	                + "}}";
-	        log.info("Running Explicit Query");
-	        CountingResultHandler resultHandler = new CountingResultHandler();
-	        TupleQuery tupleQuery = conn.prepareTupleQuery(QueryLanguage.SPARQL, explicitQuery);
-	        tupleQuery.evaluate(resultHandler);
-	        log.info("Result count : " + resultHandler.getCount());
-	        Validate.isTrue(resultHandler.getCount() == 5);
-	        log.info("Adding owl:oneOf Schema");
-	        // ONTOLOGY - :Suits oneOf (:Clubs, :Diamonds, :Hearts, :Spades)
-	        // ONTOLOGY - :Ranks oneOf (:Ace, :1, :2, :3, :4, :5, :6, :7, :8, :9, :10, :Jack, :Queen, :King)
-	        final String ontology = "INSERT DATA { GRAPH <http://updated/test> {\n"
-	                + "  <urn:Suits> owl:oneOf _:bnodeS1 . \n"
-	                + "  _:bnodeS1 rdf:first <urn:Clubs> . \n"
-	                + "  _:bnodeS1 rdf:rest _:bnodeS2 . \n"
-	                + "  _:bnodeS2 rdf:first <urn:Diamonds> . \n"
-	                + "  _:bnodeS2 rdf:rest _:bnodeS3 . \n"
-	                + "  _:bnodeS3 rdf:first <urn:Hearts> . \n"
-	                + "  _:bnodeS3 rdf:rest _:bnodeS4 . \n"
-	                + "  _:bnodeS4 rdf:first <urn:Spades> . \n"
-	                + "  _:bnodeS4 rdf:rest rdf:nil . \n"
-	                + "  <urn:Ranks> owl:oneOf _:bnodeR1 . \n"
-	                + "  _:bnodeR1 rdf:first <urn:Ace> . \n"
-	                + "  _:bnodeR1 rdf:rest _:bnodeR2 . \n"
-	                + "  _:bnodeR2 rdf:first <urn:2> . \n"
-	                + "  _:bnodeR2 rdf:rest _:bnodeR3 . \n"
-	                + "  _:bnodeR3 rdf:first <urn:3> . \n"
-	                + "  _:bnodeR3 rdf:rest _:bnodeR4 . \n"
-	                + "  _:bnodeR4 rdf:first <urn:4> . \n"
-	                + "  _:bnodeR4 rdf:rest _:bnodeR5 . \n"
-	                + "  _:bnodeR5 rdf:first <urn:5> . \n"
-	                + "  _:bnodeR5 rdf:rest _:bnodeR6 . \n"
-	                + "  _:bnodeR6 rdf:first <urn:6> . \n"
-	                + "  _:bnodeR6 rdf:rest _:bnodeR7 . \n"
-	                + "  _:bnodeR7 rdf:first <urn:7> . \n"
-	                + "  _:bnodeR7 rdf:rest _:bnodeR8 . \n"
-	                + "  _:bnodeR8 rdf:first <urn:8> . \n"
-	                + "  _:bnodeR8 rdf:rest _:bnodeR9 . \n"
-	                + "  _:bnodeR9 rdf:first <urn:9> . \n"
-	                + "  _:bnodeR9 rdf:rest _:bnodeR10 . \n"
-	                + "  _:bnodeR10 rdf:first <urn:10> . \n"
-	                + "  _:bnodeR10 rdf:rest _:bnodeR11 . \n"
-	                + "  _:bnodeR11 rdf:first <urn:Jack> . \n"
-	                + "  _:bnodeR11 rdf:rest _:bnodeR12 . \n"
-	                + "  _:bnodeR12 rdf:first <urn:Queen> . \n"
-	                + "  _:bnodeR12 rdf:rest _:bnodeR13 . \n"
-	                + "  _:bnodeR13 rdf:first <urn:King> . \n"
-	                + "  _:bnodeR13 rdf:rest rdf:nil . \n"
-	                + "  <urn:Card> owl:intersectionOf (\n"
-	                + "    [ owl:onProperty <urn:HasRank> ; owl:someValuesFrom <urn:Ranks> ]\n"
-	                + "    [ owl:onProperty <urn:HasSuit> ; owl:someValuesFrom <urn:Suits> ]\n"
-	                + "  ) . \n"
-	                + "  <urn:HasRank> owl:range <urn:Ranks> . \n"
-	                + "  <urn:HasSuit> owl:range <urn:Suits> . \n"
-	                + "}}";
-	        update = conn.prepareUpdate(QueryLanguage.SPARQL, ontology);
-	        update.execute();
-	        log.info("Running Inference-dependent Query without refreshing InferenceEngine");
-	        resultHandler.resetCount();
-	        final String inferQuery = "select distinct ?card { GRAPH <http://updated/test> {\n"
-	                + "  ?card a <urn:Card> . \n"
-	                + "  ?suit a <urn:Suits> . \n"
-	                + "  ?card <urn:HasSuit> ?suit . \n"
-	                + "}}";
-	        tupleQuery = conn.prepareTupleQuery(QueryLanguage.SPARQL, inferQuery);
-	        tupleQuery.evaluate(resultHandler);
-	        log.info("Result count : " + resultHandler.getCount());
-	        Validate.isTrue(resultHandler.getCount() == 0);
-	        log.info("Refreshing InferenceEngine");
-	        ((RdfCloudTripleStore) sail).getInferenceEngine().refreshGraph();
-	        log.info("Re-running Inference-dependent Query");
-	        resultHandler.resetCount();
-	        resultHandler = new CountingResultHandler();
-	        tupleQuery = conn.prepareTupleQuery(QueryLanguage.SPARQL, inferQuery);
-	        tupleQuery.evaluate(resultHandler);
-	        log.info("Result count : " + resultHandler.getCount());
-	        Validate.isTrue(resultHandler.getCount() == 5);
-	    }
+        resultHandler.resetCount();
+        query = "select ?x { GRAPH <http://updated/test> {<urn:jenGreatGranMother> <urn:greatMother> ?x}}";
+        resultHandler = new CountingResultHandler();
+        tupleQuery = conn.prepareTupleQuery(QueryLanguage.SPARQL, query);
+        tupleQuery.evaluate(resultHandler);
+        log.info("Result count : " + resultHandler.getCount());
 
-	    public static void testInfer(final SailRepositoryConnection conn, final Sail sail) throws MalformedQueryException, RepositoryException,
-	    UpdateExecutionException, QueryEvaluationException, TupleQueryResultHandlerException, InferenceEngineException {
+    }
 
-	        // Add data
-	        String query = "INSERT DATA\n"//
-	                + "{ \n"//
-	                + " <http://acme.com/people/Mike> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <urn:type1>.  "
-	                + " <urn:type1> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <urn:superclass>.  }";
+    public static void testPropertyChainInference(final SailRepositoryConnection conn, final Sail sail) throws MalformedQueryException, RepositoryException,
+    UpdateExecutionException, QueryEvaluationException, TupleQueryResultHandlerException, InferenceEngineException {
 
-	        log.info("Performing Query");
+        // Add data
+        String query = "INSERT DATA\n"//
+                + "{ GRAPH <http://updated/test> {\n"//
+                + "  <urn:paulGreatGrandfather> <urn:father> <urn:paulGrandfather> . "
+                + "  <urn:paulGrandfather> <urn:father> <urn:paulFather> . " +
+                " <urn:paulFather> <urn:father> <urn:paul> . " +
+                " <urn:paul> <urn:father> <urn:paulSon> .  }}";
 
-	        final Update update = conn.prepareUpdate(QueryLanguage.SPARQL, query);
-	        update.execute();
+        log.info("Performing Query");
 
-	        // refresh the graph for inferencing (otherwise there is a five minute wait)
-	        ((RdfCloudTripleStore) sail).getInferenceEngine().refreshGraph();
+        Update update = conn.prepareUpdate(QueryLanguage.SPARQL, query);
+        update.execute();
 
-	        query = "select ?s { ?s <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <urn:superclass> . }";
-	        final CountingResultHandler resultHandler = new CountingResultHandler();
-	        final TupleQuery tupleQuery = conn.prepareTupleQuery(QueryLanguage.SPARQL, query);
-	        tupleQuery.evaluate(resultHandler);
-	        log.info("Result count : " + resultHandler.getCount());
+        query = "select ?p { GRAPH <http://updated/test> {<urn:paulGreatGrandfather> <urn:father>/<urn:father> ?p}}";
+        CountingResultHandler resultHandler = new CountingResultHandler();
+        TupleQuery tupleQuery = conn.prepareTupleQuery(QueryLanguage.SPARQL, query);
+        tupleQuery.evaluate(resultHandler);
+        log.info("Result count : " + resultHandler.getCount());
 
-	        Validate.isTrue(resultHandler.getCount() == 1);
 
-	        resultHandler.resetCount();
-	    }
+        // try adding a property chain and querying for it
+        query = "INSERT DATA\n"//
+                + "{ GRAPH <http://updated/test> {\n"//
+                + "  <urn:greatGrandfather> owl:propertyChainAxiom <urn:1234>  . " +
+                " <urn:1234> <http://www.w3.org/2000/10/swap/list#length> 3 . " +
+                " <urn:1234> <http://www.w3.org/2000/10/swap/list#index> (0 <urn:father>) . " +
+                " <urn:1234> <http://www.w3.org/2000/10/swap/list#index> (1 <urn:father>) . " +
+                " <urn:1234> <http://www.w3.org/2000/10/swap/list#index> (2 <urn:father>) .  }}";
+        update = conn.prepareUpdate(QueryLanguage.SPARQL, query);
+        update.execute();
+        query = "INSERT DATA\n"//
+                + "{ GRAPH <http://updated/test> {\n"//
+                + "  <urn:grandfather> owl:propertyChainAxiom <urn:12344>  . " +
+                " <urn:12344> <http://www.w3.org/2000/10/swap/list#length> 2 . " +
+                " <urn:12344> <http://www.w3.org/2000/10/swap/list#index> (0 <urn:father>) . " +
+                " <urn:12344> <http://www.w3.org/2000/10/swap/list#index> (1 <urn:father>) .  }}";
+        update = conn.prepareUpdate(QueryLanguage.SPARQL, query);
+        update.execute();
+        ((RdfCloudTripleStore<?>) sail).getInferenceEngine().refreshGraph();
 
-	    private static class CountingResultHandler implements TupleQueryResultHandler {
-	        private int count = 0;
+        resultHandler.resetCount();
+        query = "select ?p { GRAPH <http://updated/test> {<urn:paulGreatGrandfather> <urn:greatGrandfather> ?p}}";
+        resultHandler = new CountingResultHandler();
+        tupleQuery = conn.prepareTupleQuery(QueryLanguage.SPARQL, query);
+        tupleQuery.evaluate(resultHandler);
+        log.info("Result count : " + resultHandler.getCount());
 
-	        public int getCount() {
-	            return count;
-	        }
+        resultHandler.resetCount();
+        query = "select ?s ?p { GRAPH <http://updated/test> {?s <urn:grandfather> ?p}}";
+        resultHandler = new CountingResultHandler();
+        tupleQuery = conn.prepareTupleQuery(QueryLanguage.SPARQL, query);
+        tupleQuery.evaluate(resultHandler);
+        log.info("Result count : " + resultHandler.getCount());
 
-	        public void resetCount() {
-	            count = 0;
-	        }
+    }
 
-	        @Override
-	        public void startQueryResult(final List<String> arg0) throws TupleQueryResultHandlerException {
-	        }
+    public static void testIntersectionOfInference(final SailRepositoryConnection conn, final Sail sail) throws MalformedQueryException, RepositoryException, UpdateExecutionException, QueryEvaluationException, TupleQueryResultHandlerException, InferenceEngineException {
+        log.info("Adding Data");
+        final String instances = "INSERT DATA\n"
+                + "{ GRAPH <http://updated/test> {\n"
+                + "  <urn:Susan> a <urn:Mother> . \n"
+                + "  <urn:Mary> a <urn:Woman> . \n"
+                + "  <urn:Mary> a <urn:Parent> . \n"
+                + "}}";
+        Update update = conn.prepareUpdate(QueryLanguage.SPARQL, instances);
+        update.execute();
+        final String inferQuery = "select distinct ?x { GRAPH <http://updated/test> { ?x a <urn:Mother> }}";
+        final String explicitQuery = "select distinct ?x { GRAPH <http://updated/test> {\n"
+                + "  { ?x a <urn:Mother> }\n"
+                + "  UNION {\n"
+                + "    ?x a <urn:Woman> .\n"
+                + "    ?x a <urn:Parent> .\n"
+                + "  }\n"
+                + "}}";
+        log.info("Running Explicit Query");
+        CountingResultHandler resultHandler = new CountingResultHandler();
+        TupleQuery tupleQuery = conn.prepareTupleQuery(QueryLanguage.SPARQL, explicitQuery);
+        tupleQuery.evaluate(resultHandler);
+        log.info("Result count : " + resultHandler.getCount());
+        Validate.isTrue(resultHandler.getCount() == 2);
+        log.info("Running Inference-dependant Query");
+        resultHandler.resetCount();
+        tupleQuery = conn.prepareTupleQuery(QueryLanguage.SPARQL, inferQuery);
+        tupleQuery.evaluate(resultHandler);
+        log.info("Result count : " + resultHandler.getCount());
+        Validate.isTrue(resultHandler.getCount() == 1);
+        log.info("Adding owl:intersectionOf Schema");
+        // ONTOLOGY - :Mother intersectionOf[:Woman, :Parent]
+        final String ontology = "INSERT DATA\n"
+                + "{ GRAPH <http://updated/test> {\n"
+                + "  <urn:Mother> owl:intersectionOf _:bnode1 . \n"
+                + "  _:bnode1 rdf:first <urn:Woman> . \n"
+                + "  _:bnode1 rdf:rest _:bnode2 . \n"
+                + "  _:bnode2 rdf:first <urn:Parent> . \n"
+                + "  _:bnode2 rdf:rest rdf:nil . \n"
+               + "}}";
+        update = conn.prepareUpdate(QueryLanguage.SPARQL, ontology);
+        update.execute();
+        log.info("Refreshing InferenceEngine");
+        ((RdfCloudTripleStore<?>) sail).getInferenceEngine().refreshGraph();
+        log.info("Re-running Inference-dependant Query");
+        resultHandler.resetCount();
+        resultHandler = new CountingResultHandler();
+        tupleQuery = conn.prepareTupleQuery(QueryLanguage.SPARQL, inferQuery);
+        tupleQuery.evaluate(resultHandler);
+        log.info("Result count : " + resultHandler.getCount());
+        Validate.isTrue(resultHandler.getCount() == 2);
+    }
 
-	        @Override
-	        public void handleSolution(final BindingSet arg0) throws TupleQueryResultHandlerException {
-	            count++;
-	            System.out.println(arg0);
-	        }
+    public static void testSomeValuesFromInference(final SailRepositoryConnection conn, final Sail sail) throws MalformedQueryException, RepositoryException,
+    UpdateExecutionException, QueryEvaluationException, TupleQueryResultHandlerException, InferenceEngineException {
+        final String lubm = "http://swat.cse.lehigh.edu/onto/univ-bench.owl#";
+        log.info("Adding Data");
+        String insert = "PREFIX lubm: <" + lubm + ">\n"
+                + "INSERT DATA { GRAPH <http://updated/test> {\n"
+                + "  <urn:Department0> a lubm:Department; lubm:subOrganizationOf <urn:University0> .\n"
+                + "  <urn:ResearchGroup0> a lubm:ResearchGroup; lubm:subOrganizationOf <urn:Department0> .\n"
+                + "  <urn:Alice> lubm:headOf <urn:Department0> .\n"
+                + "  <urn:Bob> lubm:headOf <urn:ResearchGroup0> .\n"
+                + "  <urn:Carol> lubm:worksFor <urn:Department0> .\n"
+                + "}}";
+        Update update = conn.prepareUpdate(QueryLanguage.SPARQL, insert);
+        update.execute();
+        final String inferQuery = "select distinct ?x { GRAPH <http://updated/test> { ?x a <" + lubm + "Chair> }}";
+        final String explicitQuery = "prefix lubm: <" + lubm + ">\n"
+                + "select distinct ?x { GRAPH <http://updated/test> {\n"
+                + "  { ?x a lubm:Chair }\n"
+                + "  UNION\n"
+                + "  { ?x lubm:headOf [ a lubm:Department ] }\n"
+                + "}}";
+        log.info("Running Explicit Query");
+        final CountingResultHandler resultHandler = new CountingResultHandler();
+        TupleQuery tupleQuery = conn.prepareTupleQuery(QueryLanguage.SPARQL, explicitQuery);
+        tupleQuery.evaluate(resultHandler);
+        log.info("Result count : " + resultHandler.getCount());
+        Validate.isTrue(resultHandler.getCount() == 1);
+        log.info("Running Inference-dependent Query");
+        resultHandler.resetCount();
+        tupleQuery = conn.prepareTupleQuery(QueryLanguage.SPARQL, inferQuery);
+        tupleQuery.evaluate(resultHandler);
+        log.info("Result count : " + resultHandler.getCount());
+        Validate.isTrue(resultHandler.getCount() == 0);
+        log.info("Adding owl:someValuesFrom Schema");
+        insert = "PREFIX rdfs: <" + RDFS.NAMESPACE + ">\n"
+                + "PREFIX owl: <" + OWL.NAMESPACE + ">\n"
+                + "PREFIX lubm: <" + lubm + ">\n"
+                + "INSERT DATA\n"
+                + "{ GRAPH <http://updated/test> {\n"
+                + "  lubm:Chair owl:equivalentClass [ owl:onProperty lubm:headOf ; owl:someValuesFrom lubm:Department ] ."
+                + "}}";
+        update = conn.prepareUpdate(QueryLanguage.SPARQL, insert);
+        update.execute();
+        log.info("Refreshing InferenceEngine");
+        ((RdfCloudTripleStore<?>) sail).getInferenceEngine().refreshGraph();
+        log.info("Re-running Inference-dependent Query");
+        resultHandler.resetCount();
+        tupleQuery = conn.prepareTupleQuery(QueryLanguage.SPARQL, inferQuery);
+        tupleQuery.evaluate(resultHandler);
+        log.info("Result count : " + resultHandler.getCount());
+        Validate.isTrue(resultHandler.getCount() == 1);
+    }
 
-	        @Override
-	        public void endQueryResult() throws TupleQueryResultHandlerException {
-	        }
+    public static void testAllValuesFromInference(final SailRepositoryConnection conn, final Sail sail) throws MalformedQueryException, RepositoryException,
+    UpdateExecutionException, QueryEvaluationException, TupleQueryResultHandlerException, InferenceEngineException {
+        log.info("Adding Data");
+        String insert = "INSERT DATA\n"
+                + "{ GRAPH <http://updated/test> {\n"
+                + "  <urn:Alice> a <urn:Person> .\n"
+                + "  <urn:Alice> <urn:hasParent> <urn:Bob> .\n"
+                + "  <urn:Carol> <urn:hasParent> <urn:Dan> .\n"
+                + "}}";
+        Update update = conn.prepareUpdate(QueryLanguage.SPARQL, insert);
+        update.execute();
+        final String inferQuery = "select distinct ?x { GRAPH <http://updated/test> { ?x a <urn:Person> }}";
+        final String explicitQuery = "select distinct ?x { GRAPH <http://updated/test> {\n"
+                + "  { ?x a <urn:Person> }\n"
+                + "  UNION {\n"
+                + "    ?y a <urn:Person> .\n"
+                + "    ?y <urn:hasParent> ?x .\n"
+                + "  }\n"
+                + "}}";
+        log.info("Running Explicit Query");
+        final CountingResultHandler resultHandler = new CountingResultHandler();
+        TupleQuery tupleQuery = conn.prepareTupleQuery(QueryLanguage.SPARQL, explicitQuery);
+        tupleQuery.evaluate(resultHandler);
+        log.info("Result count : " + resultHandler.getCount());
+        Validate.isTrue(resultHandler.getCount() == 2);
+        log.info("Running Inference-dependent Query");
+        resultHandler.resetCount();
+        tupleQuery = conn.prepareTupleQuery(QueryLanguage.SPARQL, inferQuery);
+        tupleQuery.evaluate(resultHandler);
+        log.info("Result count : " + resultHandler.getCount());
+        Validate.isTrue(resultHandler.getCount() == 1);
+        log.info("Adding owl:allValuesFrom Schema");
+        insert = "PREFIX rdfs: <" + RDFS.NAMESPACE + ">\n"
+                + "PREFIX owl: <" + OWL.NAMESPACE + ">\n"
+                + "INSERT DATA\n"
+                + "{ GRAPH <http://updated/test> {\n"
+                + "  <urn:Person> rdfs:subClassOf [ owl:onProperty <urn:hasParent> ; owl:allValuesFrom <urn:Person> ] ."
+                + "}}";
+        update = conn.prepareUpdate(QueryLanguage.SPARQL, insert);
+        update.execute();
+        log.info("Refreshing InferenceEngine");
+        ((RdfCloudTripleStore<?>) sail).getInferenceEngine().refreshGraph();
+        log.info("Re-running Inference-dependent Query");
+        resultHandler.resetCount();
+        tupleQuery = conn.prepareTupleQuery(QueryLanguage.SPARQL, inferQuery);
+        tupleQuery.evaluate(resultHandler);
+        log.info("Result count : " + resultHandler.getCount());
+        Validate.isTrue(resultHandler.getCount() == 2);
+    }
 
-	        @Override
-	        public void handleBoolean(final boolean arg0) throws QueryResultHandlerException {
-	        }
+    public static void testOneOfInference(final SailRepositoryConnection conn, final Sail sail) throws MalformedQueryException, RepositoryException, UpdateExecutionException, QueryEvaluationException, TupleQueryResultHandlerException, InferenceEngineException {
+        log.info("Adding Data");
+        final String instances = "INSERT DATA"
+                + "{ GRAPH <http://updated/test> {\n"
+                + "  <urn:FlopCard1> a <urn:Card> . \n"
+                + "    <urn:FlopCard1> <urn:HasRank> <urn:Ace> . \n"
+                + "    <urn:FlopCard1> <urn:HasSuit> <urn:Diamonds> . \n"
+                + "  <urn:FlopCard2> a <urn:Card> . \n"
+                + "    <urn:FlopCard2> <urn:HasRank> <urn:Ace> . \n"
+                + "    <urn:FlopCard2> <urn:HasSuit> <urn:Hearts> . \n"
+                + "  <urn:FlopCard3> a <urn:Card> . \n"
+                + "    <urn:FlopCard3> <urn:HasRank> <urn:King> . \n"
+                + "    <urn:FlopCard3> <urn:HasSuit> <urn:Spades> . \n"
+                + "  <urn:TurnCard> a <urn:Card> . \n"
+                + "    <urn:TurnCard> <urn:HasRank> <urn:10> . \n"
+                + "    <urn:TurnCard> <urn:HasSuit> <urn:Clubs> . \n"
+                + "  <urn:RiverCard> a <urn:Card> . \n"
+                + "    <urn:RiverCard> <urn:HasRank> <urn:Queen> . \n"
+                + "    <urn:RiverCard> <urn:HasSuit> <urn:Hearts> . \n"
+                + "}}";
+        Update update = conn.prepareUpdate(QueryLanguage.SPARQL, instances);
+        update.execute();
+        final String explicitQuery = "select distinct ?card { GRAPH <http://updated/test> {\n"
+                + "  ?card a <urn:Card> . \n"
+                + "  VALUES ?suit { <urn:Clubs> <urn:Diamonds> <urn:Hearts> <urn:Spades> } . \n"
+                + "  ?card <urn:HasSuit> ?suit . \n"
+                + "}}";
+        log.info("Running Explicit Query");
+        CountingResultHandler resultHandler = new CountingResultHandler();
+        TupleQuery tupleQuery = conn.prepareTupleQuery(QueryLanguage.SPARQL, explicitQuery);
+        tupleQuery.evaluate(resultHandler);
+        log.info("Result count : " + resultHandler.getCount());
+        Validate.isTrue(resultHandler.getCount() == 5);
+        log.info("Adding owl:oneOf Schema");
+        // ONTOLOGY - :Suits oneOf (:Clubs, :Diamonds, :Hearts, :Spades)
+        // ONTOLOGY - :Ranks oneOf (:Ace, :1, :2, :3, :4, :5, :6, :7, :8, :9, :10, :Jack, :Queen, :King)
+        final String ontology = "INSERT DATA { GRAPH <http://updated/test> {\n"
+                + "  <urn:Suits> owl:oneOf _:bnodeS1 . \n"
+                + "  _:bnodeS1 rdf:first <urn:Clubs> . \n"
+                + "  _:bnodeS1 rdf:rest _:bnodeS2 . \n"
+                + "  _:bnodeS2 rdf:first <urn:Diamonds> . \n"
+                + "  _:bnodeS2 rdf:rest _:bnodeS3 . \n"
+                + "  _:bnodeS3 rdf:first <urn:Hearts> . \n"
+                + "  _:bnodeS3 rdf:rest _:bnodeS4 . \n"
+                + "  _:bnodeS4 rdf:first <urn:Spades> . \n"
+                + "  _:bnodeS4 rdf:rest rdf:nil . \n"
+                + "  <urn:Ranks> owl:oneOf _:bnodeR1 . \n"
+                + "  _:bnodeR1 rdf:first <urn:Ace> . \n"
+                + "  _:bnodeR1 rdf:rest _:bnodeR2 . \n"
+                + "  _:bnodeR2 rdf:first <urn:2> . \n"
+                + "  _:bnodeR2 rdf:rest _:bnodeR3 . \n"
+                + "  _:bnodeR3 rdf:first <urn:3> . \n"
+                + "  _:bnodeR3 rdf:rest _:bnodeR4 . \n"
+                + "  _:bnodeR4 rdf:first <urn:4> . \n"
+                + "  _:bnodeR4 rdf:rest _:bnodeR5 . \n"
+                + "  _:bnodeR5 rdf:first <urn:5> . \n"
+                + "  _:bnodeR5 rdf:rest _:bnodeR6 . \n"
+                + "  _:bnodeR6 rdf:first <urn:6> . \n"
+                + "  _:bnodeR6 rdf:rest _:bnodeR7 . \n"
+                + "  _:bnodeR7 rdf:first <urn:7> . \n"
+                + "  _:bnodeR7 rdf:rest _:bnodeR8 . \n"
+                + "  _:bnodeR8 rdf:first <urn:8> . \n"
+                + "  _:bnodeR8 rdf:rest _:bnodeR9 . \n"
+                + "  _:bnodeR9 rdf:first <urn:9> . \n"
+                + "  _:bnodeR9 rdf:rest _:bnodeR10 . \n"
+                + "  _:bnodeR10 rdf:first <urn:10> . \n"
+                + "  _:bnodeR10 rdf:rest _:bnodeR11 . \n"
+                + "  _:bnodeR11 rdf:first <urn:Jack> . \n"
+                + "  _:bnodeR11 rdf:rest _:bnodeR12 . \n"
+                + "  _:bnodeR12 rdf:first <urn:Queen> . \n"
+                + "  _:bnodeR12 rdf:rest _:bnodeR13 . \n"
+                + "  _:bnodeR13 rdf:first <urn:King> . \n"
+                + "  _:bnodeR13 rdf:rest rdf:nil . \n"
+                + "  <urn:Card> owl:intersectionOf (\n"
+                + "    [ owl:onProperty <urn:HasRank> ; owl:someValuesFrom <urn:Ranks> ]\n"
+                + "    [ owl:onProperty <urn:HasSuit> ; owl:someValuesFrom <urn:Suits> ]\n"
+                + "  ) . \n"
+                + "  <urn:HasRank> owl:range <urn:Ranks> . \n"
+                + "  <urn:HasSuit> owl:range <urn:Suits> . \n"
+                + "}}";
+        update = conn.prepareUpdate(QueryLanguage.SPARQL, ontology);
+        update.execute();
+        log.info("Running Inference-dependent Query without refreshing InferenceEngine");
+        resultHandler.resetCount();
+        final String inferQuery = "select distinct ?card { GRAPH <http://updated/test> {\n"
+                + "  ?card a <urn:Card> . \n"
+                + "  ?suit a <urn:Suits> . \n"
+                + "  ?card <urn:HasSuit> ?suit . \n"
+                + "}}";
+        tupleQuery = conn.prepareTupleQuery(QueryLanguage.SPARQL, inferQuery);
+        tupleQuery.evaluate(resultHandler);
+        log.info("Result count : " + resultHandler.getCount());
+        Validate.isTrue(resultHandler.getCount() == 0);
+        log.info("Refreshing InferenceEngine");
+        ((RdfCloudTripleStore<?>) sail).getInferenceEngine().refreshGraph();
+        log.info("Re-running Inference-dependent Query");
+        resultHandler.resetCount();
+        resultHandler = new CountingResultHandler();
+        tupleQuery = conn.prepareTupleQuery(QueryLanguage.SPARQL, inferQuery);
+        tupleQuery.evaluate(resultHandler);
+        log.info("Result count : " + resultHandler.getCount());
+        Validate.isTrue(resultHandler.getCount() == 5);
+    }
 
-	        @Override
-	        public void handleLinks(final List<String> arg0) throws QueryResultHandlerException {
-	        }
-	    }
+    public static void testInfer(final SailRepositoryConnection conn, final Sail sail) throws MalformedQueryException, RepositoryException,
+    UpdateExecutionException, QueryEvaluationException, TupleQueryResultHandlerException, InferenceEngineException {
+
+        // Add data
+        String query = "INSERT DATA\n"//
+                + "{ \n"//
+                + " <http://acme.com/people/Mike> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <urn:type1>.  "
+                + " <urn:type1> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <urn:superclass>.  }";
+
+        log.info("Performing Query");
+
+        final Update update = conn.prepareUpdate(QueryLanguage.SPARQL, query);
+        update.execute();
+
+        // refresh the graph for inferencing (otherwise there is a five minute wait)
+        ((RdfCloudTripleStore<?>) sail).getInferenceEngine().refreshGraph();
+
+        query = "select ?s { ?s <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <urn:superclass> . }";
+        final CountingResultHandler resultHandler = new CountingResultHandler();
+        final TupleQuery tupleQuery = conn.prepareTupleQuery(QueryLanguage.SPARQL, query);
+        tupleQuery.evaluate(resultHandler);
+        log.info("Result count : " + resultHandler.getCount());
+
+        Validate.isTrue(resultHandler.getCount() == 1);
+
+        resultHandler.resetCount();
+    }
+
+    private static class CountingResultHandler extends AbstractTupleQueryResultHandler {
+        private int count = 0;
+
+        public int getCount() {
+            return count;
+        }
+
+        public void resetCount() {
+            count = 0;
+        }
+
+        @Override
+        public void handleSolution(final BindingSet bindingSet) throws TupleQueryResultHandlerException {
+            count++;
+            System.out.println(bindingSet);
+        }
+    }
 }

--- a/extras/indexingExample/src/main/java/MongoRyaDirectExample.java
+++ b/extras/indexingExample/src/main/java/MongoRyaDirectExample.java
@@ -75,7 +75,6 @@ public class MongoRyaDirectExample {
 
     private static final boolean USE_LUBM_QUERIES = true;
     private static final Path LUBM_FILE = Paths.get("src/main/resources/lubm-1uni-withschema.nt");
-    private static final String LUBM_PREFIX = "http://swat.cse.lehigh.edu/onto/univ-bench.owl#";
 
     //
     // Connection configuration parameters
@@ -489,7 +488,7 @@ public class MongoRyaDirectExample {
                 " _:node1atjakcvbx15123 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <urn:MotherOf> .  }}";
         update = conn.prepareUpdate(QueryLanguage.SPARQL, query);
         update.execute();
-        ((RdfCloudTripleStore) sail).getInferenceEngine().refreshGraph();
+        ((RdfCloudTripleStore<?>) sail).getInferenceEngine().refreshGraph();
 
         resultHandler.resetCount();
         query = "select ?x { GRAPH <http://updated/test> {<urn:jenGreatGranMother> <urn:greatMother> ?x}}";
@@ -541,7 +540,7 @@ public class MongoRyaDirectExample {
                 " <urn:12344> <http://www.w3.org/2000/10/swap/list#index> (1 <urn:father>) .  }}";
         update = conn.prepareUpdate(QueryLanguage.SPARQL, query);
         update.execute();
-        ((RdfCloudTripleStore) sail).getInferenceEngine().refreshGraph();
+        ((RdfCloudTripleStore<?>) sail).getInferenceEngine().refreshGraph();
 
         resultHandler.resetCount();
         query = "select ?p { GRAPH <http://updated/test> {<urn:paulGreatGrandfather> <urn:greatGrandfather> ?p}}";
@@ -602,7 +601,7 @@ public class MongoRyaDirectExample {
         update = conn.prepareUpdate(QueryLanguage.SPARQL, ontology);
         update.execute();
         log.info("Refreshing InferenceEngine");
-        ((RdfCloudTripleStore) sail).getInferenceEngine().refreshGraph();
+        ((RdfCloudTripleStore<?>) sail).getInferenceEngine().refreshGraph();
         log.info("Re-running Inference-dependant Query");
         resultHandler.resetCount();
         resultHandler = new CountingResultHandler();
@@ -656,7 +655,7 @@ public class MongoRyaDirectExample {
         update = conn.prepareUpdate(QueryLanguage.SPARQL, insert);
         update.execute();
         log.info("Refreshing InferenceEngine");
-        ((RdfCloudTripleStore) sail).getInferenceEngine().refreshGraph();
+        ((RdfCloudTripleStore<?>) sail).getInferenceEngine().refreshGraph();
         log.info("Re-running Inference-dependent Query");
         resultHandler.resetCount();
         tupleQuery = conn.prepareTupleQuery(QueryLanguage.SPARQL, inferQuery);
@@ -706,7 +705,7 @@ public class MongoRyaDirectExample {
         update = conn.prepareUpdate(QueryLanguage.SPARQL, insert);
         update.execute();
         log.info("Refreshing InferenceEngine");
-        ((RdfCloudTripleStore) sail).getInferenceEngine().refreshGraph();
+        ((RdfCloudTripleStore<?>) sail).getInferenceEngine().refreshGraph();
         log.info("Re-running Inference-dependent Query");
         resultHandler.resetCount();
         tupleQuery = conn.prepareTupleQuery(QueryLanguage.SPARQL, inferQuery);
@@ -809,7 +808,7 @@ public class MongoRyaDirectExample {
         log.info("Result count : " + resultHandler.getCount());
         Validate.isTrue(resultHandler.getCount() == 0);
         log.info("Refreshing InferenceEngine");
-        ((RdfCloudTripleStore) sail).getInferenceEngine().refreshGraph();
+        ((RdfCloudTripleStore<?>) sail).getInferenceEngine().refreshGraph();
         log.info("Re-running Inference-dependent Query");
         resultHandler.resetCount();
         resultHandler = new CountingResultHandler();
@@ -834,7 +833,7 @@ public class MongoRyaDirectExample {
         update.execute();
 
         // refresh the graph for inferencing (otherwise there is a five minute wait)
-        ((RdfCloudTripleStore) sail).getInferenceEngine().refreshGraph();
+        ((RdfCloudTripleStore<?>) sail).getInferenceEngine().refreshGraph();
 
         query = "select ?s { ?s <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <urn:superclass> . }";
         final CountingResultHandler resultHandler = new CountingResultHandler();

--- a/extras/kafka.connect/mongo/src/main/java/org/apache/rya/kafka/connect/mongo/MongoRyaSinkTask.java
+++ b/extras/kafka.connect/mongo/src/main/java/org/apache/rya/kafka/connect/mongo/MongoRyaSinkTask.java
@@ -20,7 +20,6 @@ package org.apache.rya.kafka.connect.mongo;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
 
@@ -43,6 +42,7 @@ import org.eclipse.rdf4j.sail.SailException;
 
 import com.google.common.base.Strings;
 import com.mongodb.MongoClient;
+import com.mongodb.MongoClientOptions;
 import com.mongodb.MongoCredential;
 import com.mongodb.ServerAddress;
 
@@ -71,8 +71,10 @@ public class MongoRyaSinkTask extends RyaSinkTask {
         final ServerAddress serverAddr = new ServerAddress(config.getHostname(), config.getPort());
         final boolean hasCredentials = username != null && password != null;
 
-        try(MongoClient mongoClient = hasCredentials ?
-                new MongoClient(serverAddr, Arrays.asList(MongoCredential.createCredential(username, config.getRyaInstanceName(), password))) :
+        final MongoClientOptions options = new MongoClientOptions.Builder().build();
+
+        try(final MongoClient mongoClient = hasCredentials ?
+                new MongoClient(serverAddr, MongoCredential.createCredential(username, config.getRyaInstanceName(), password), options) :
                 new MongoClient(serverAddr)) {
             // Use a RyaClient to see if the configured instance exists.
             // Create the Mongo Connection Details that describe the Mongo DB Server we are interacting with.
@@ -116,7 +118,7 @@ public class MongoRyaSinkTask extends RyaSinkTask {
         // Create the Sail object.
         try {
             return RyaSailFactory.getInstance(ryaConfig);
-        } catch (SailException | AccumuloException | AccumuloSecurityException | RyaDAOException | InferenceEngineException e) {
+        } catch (final SailException | AccumuloException | AccumuloSecurityException | RyaDAOException | InferenceEngineException e) {
             throw new ConnectException("Could not connect to the Rya Instance named " + config.getRyaInstanceName(), e);
         }
     }

--- a/extras/rya.export/export.integration/src/test/java/org/apache/rya/indexing/export/StoreToStoreIT.java
+++ b/extras/rya.export/export.integration/src/test/java/org/apache/rya/indexing/export/StoreToStoreIT.java
@@ -116,7 +116,7 @@ public class StoreToStoreIT extends ITBase {
             driver.tearDown();
         }
         for(final MongoClient client : clients) {
-            client.dropDatabase(RYA_INSTANCE);
+            client.getDatabase(RYA_INSTANCE).drop();
         }
     }
 

--- a/extras/rya.export/export.mongo/src/main/java/org/apache/rya/export/mongo/parent/ParentMetadataRepositoryAdapter.java
+++ b/extras/rya.export/export.mongo/src/main/java/org/apache/rya/export/mongo/parent/ParentMetadataRepositoryAdapter.java
@@ -21,13 +21,11 @@ package org.apache.rya.export.mongo.parent;
 import java.util.Date;
 
 import org.apache.rya.export.api.metadata.MergeParentMetadata;
-
-import com.mongodb.BasicDBObjectBuilder;
-import com.mongodb.DBObject;
+import org.bson.Document;
 
 /**
  * Adapter for converting {@link MergeParentMetadata} to and from mongo
- * {@link DBObject}s.
+ * {@link Document}s.
  */
 public class ParentMetadataRepositoryAdapter {
     public static final String RYANAME_KEY = "ryaInstanceName";
@@ -36,29 +34,29 @@ public class ParentMetadataRepositoryAdapter {
     public static final String PARENT_TIME_OFFSET_KEY = "parentTimeOffset";
 
     /**
-     * Serializes the {@link MergeParentMetadata} into a mongoDB object.
+     * Serializes the {@link MergeParentMetadata} into a mongoDB document.
      * @param metadata - The {@link MergeParentMetadata} to serialize.
-     * @return The MongoDB object
+     * @return The MongoDB {@link Document}
      */
-    public DBObject serialize(final MergeParentMetadata metadata) {
-        final BasicDBObjectBuilder builder = BasicDBObjectBuilder.start()
-            .add(RYANAME_KEY, metadata.getRyaInstanceName())
-            .add(TIMESTAMP_KEY, metadata.getTimestamp())
-            .add(FILTER_TIMESTAMP_KEY, metadata.getFilterTimestamp())
-            .add(PARENT_TIME_OFFSET_KEY, metadata.getParentTimeOffset());
-        return builder.get();
+    public Document serialize(final MergeParentMetadata metadata) {
+        final Document doc = new Document()
+            .append(RYANAME_KEY, metadata.getRyaInstanceName())
+            .append(TIMESTAMP_KEY, metadata.getTimestamp())
+            .append(FILTER_TIMESTAMP_KEY, metadata.getFilterTimestamp())
+            .append(PARENT_TIME_OFFSET_KEY, metadata.getParentTimeOffset());
+        return doc;
     }
 
     /**
-     * Deserialize the mongoBD object into {@link MergeParentMetadata}.
-     * @param dbo - The mongo {@link DBObject} to deserialize.
+     * Deserialize the mongoBD document into {@link MergeParentMetadata}.
+     * @param doc - The mongo {@link Document} to deserialize.
      * @return The {@link MergeParentMetadata}
      */
-    public MergeParentMetadata deserialize(final DBObject dbo) {
-        final Date timestamp = (Date) dbo.get(TIMESTAMP_KEY);
-        final String ryaInstance = (String) dbo.get(RYANAME_KEY);
-        final Date filterTimestamp = (Date) dbo.get(FILTER_TIMESTAMP_KEY);
-        final Long offset = (Long) dbo.get(PARENT_TIME_OFFSET_KEY);
+    public MergeParentMetadata deserialize(final Document doc) {
+        final Date timestamp = (Date) doc.get(TIMESTAMP_KEY);
+        final String ryaInstance = (String) doc.get(RYANAME_KEY);
+        final Date filterTimestamp = (Date) doc.get(FILTER_TIMESTAMP_KEY);
+        final Long offset = (Long) doc.get(PARENT_TIME_OFFSET_KEY);
         return new MergeParentMetadata.Builder()
             .setRyaInstanceName(ryaInstance)
             .setTimestamp(timestamp)

--- a/extras/rya.export/export.mongo/src/main/java/org/apache/rya/export/mongo/policy/TimestampPolicyMongoRyaStatementStore.java
+++ b/extras/rya.export/export.mongo/src/main/java/org/apache/rya/export/mongo/policy/TimestampPolicyMongoRyaStatementStore.java
@@ -33,12 +33,11 @@ import org.apache.rya.export.api.store.FetchStatementException;
 import org.apache.rya.export.api.store.RyaStatementStore;
 import org.apache.rya.export.mongo.MongoRyaStatementStore;
 import org.apache.rya.mongodb.dao.SimpleMongoDBStorageStrategy;
+import org.bson.Document;
 
-import com.mongodb.BasicDBObject;
-import com.mongodb.BasicDBObjectBuilder;
-import com.mongodb.Cursor;
-import com.mongodb.DB;
-import com.mongodb.DBObject;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoCursor;
+import com.mongodb.client.MongoDatabase;
 
 /**
  * A {@link RyaStatementStore} decorated to connect to a Mongo database and
@@ -46,7 +45,7 @@ import com.mongodb.DBObject;
  */
 public class TimestampPolicyMongoRyaStatementStore extends TimestampPolicyStatementStore {
     private final SimpleMongoDBStorageStrategy adapter;
-    private final DB db;
+    private final MongoDatabase db;
 
     /**
      * Creates a new {@link TimestampPolicyMongoRyaStatementStore}
@@ -57,21 +56,23 @@ public class TimestampPolicyMongoRyaStatementStore extends TimestampPolicyStatem
     public TimestampPolicyMongoRyaStatementStore(final MongoRyaStatementStore store, final Date timestamp, final String ryaInstanceName) {
         super(store, timestamp);
         adapter = new SimpleMongoDBStorageStrategy();
-        db = store.getClient().getDB(ryaInstanceName);
+        db = store.getClient().getDatabase(ryaInstanceName);
     }
 
     @Override
     public Iterator<RyaStatement> fetchStatements() throws FetchStatementException {
-        final DBObject timeObj = new BasicDBObjectBuilder()
-            .add(SimpleMongoDBStorageStrategy.TIMESTAMP,
-                new BasicDBObjectBuilder()
-                    .add("$gte", timestamp.getTime()).get())
-            .get();
-        final Cursor cur = db.getCollection(TRIPLES_COLLECTION).find(timeObj).sort(new BasicDBObject(TIMESTAMP, 1));
+        final Document timeObj = new Document()
+            .append(SimpleMongoDBStorageStrategy.TIMESTAMP,
+                new Document()
+                    .append("$gte", timestamp.getTime()));
+        final Document sortObj = new Document(TIMESTAMP, 1);
+        final MongoCollection<Document> coll = db.getCollection(TRIPLES_COLLECTION);
         final List<RyaStatement> statements = new ArrayList<>();
-        while(cur.hasNext()) {
-            final RyaStatement statement = adapter.deserializeDBObject(cur.next());
-            statements.add(statement);
+        try (final MongoCursor<Document> cur = coll.find(timeObj).sort(sortObj).iterator()) {
+            while(cur.hasNext()) {
+                final RyaStatement statement = adapter.deserializeDocument(cur.next());
+                statements.add(statement);
+            }
         }
         return statements.iterator();
     }

--- a/extras/rya.export/export.mongo/src/test/java/org/apache/rya/export/mongo/parent/ParentMetadataRepositoryAdapterTest.java
+++ b/extras/rya.export/export.mongo/src/test/java/org/apache/rya/export/mongo/parent/ParentMetadataRepositoryAdapterTest.java
@@ -27,10 +27,8 @@ import static org.junit.Assert.assertEquals;
 import java.util.Date;
 
 import org.apache.rya.export.api.metadata.MergeParentMetadata;
+import org.bson.Document;
 import org.junit.Test;
-
-import com.mongodb.BasicDBObjectBuilder;
-import com.mongodb.DBObject;
 
 public class ParentMetadataRepositoryAdapterTest {
     private final static String TEST_INSTANCE = "test_instance";
@@ -41,12 +39,11 @@ public class ParentMetadataRepositoryAdapterTest {
 
     @Test
     public void deserializeTest() {
-        final DBObject dbo = BasicDBObjectBuilder.start()
-            .add(RYANAME_KEY, TEST_INSTANCE)
-            .add(TIMESTAMP_KEY, TEST_TIMESTAMP)
-            .add(FILTER_TIMESTAMP_KEY, TEST_FILTER_TIMESTAMP)
-            .add(PARENT_TIME_OFFSET_KEY, TEST_TIME_OFFSET)
-            .get();
+        final Document doc = new Document()
+            .append(RYANAME_KEY, TEST_INSTANCE)
+            .append(TIMESTAMP_KEY, TEST_TIMESTAMP)
+            .append(FILTER_TIMESTAMP_KEY, TEST_FILTER_TIMESTAMP)
+            .append(PARENT_TIME_OFFSET_KEY, TEST_TIME_OFFSET);
 
         final MergeParentMetadata expected = new MergeParentMetadata.Builder()
             .setRyaInstanceName(TEST_INSTANCE)
@@ -54,24 +51,20 @@ public class ParentMetadataRepositoryAdapterTest {
             .setFilterTimestmap(TEST_FILTER_TIMESTAMP)
             .setParentTimeOffset(TEST_TIME_OFFSET)
             .build();
-        final MergeParentMetadata actual = adapter.deserialize(dbo);
+        final MergeParentMetadata actual = adapter.deserialize(doc);
         assertEquals(expected, actual);
     }
 
     @Test(expected=NullPointerException.class)
     public void deserializeTest_missingTime() {
-        final DBObject dbo = BasicDBObjectBuilder.start()
-            .add(RYANAME_KEY, TEST_INSTANCE)
-            .get();
-        adapter.deserialize(dbo);
+        final Document doc = new Document(RYANAME_KEY, TEST_INSTANCE);
+        adapter.deserialize(doc);
     }
 
     @Test(expected=NullPointerException.class)
     public void deserializeTest_missingName() {
-        final DBObject dbo = BasicDBObjectBuilder.start()
-            .add(TIMESTAMP_KEY, TEST_TIMESTAMP)
-            .get();
-        adapter.deserialize(dbo);
+        final Document doc = new Document(TIMESTAMP_KEY, TEST_TIMESTAMP);
+        adapter.deserialize(doc);
     }
 
     @Test
@@ -83,13 +76,12 @@ public class ParentMetadataRepositoryAdapterTest {
             .setParentTimeOffset(TEST_TIME_OFFSET)
             .build();
 
-        final DBObject expected = BasicDBObjectBuilder.start()
-            .add(RYANAME_KEY, TEST_INSTANCE)
-            .add(TIMESTAMP_KEY, TEST_TIMESTAMP)
-            .add(FILTER_TIMESTAMP_KEY, TEST_FILTER_TIMESTAMP)
-            .add(PARENT_TIME_OFFSET_KEY, TEST_TIME_OFFSET)
-            .get();
-        final DBObject actual = adapter.serialize(merge);
+        final Document expected = new Document()
+            .append(RYANAME_KEY, TEST_INSTANCE)
+            .append(TIMESTAMP_KEY, TEST_TIMESTAMP)
+            .append(FILTER_TIMESTAMP_KEY, TEST_FILTER_TIMESTAMP)
+            .append(PARENT_TIME_OFFSET_KEY, TEST_TIME_OFFSET);
+        final Document actual = adapter.serialize(merge);
         assertEquals(expected, actual);
     }
 }

--- a/extras/rya.forwardchain/src/main/java/org/apache/rya/forwardchain/strategy/MongoPipelineStrategy.java
+++ b/extras/rya.forwardchain/src/main/java/org/apache/rya/forwardchain/strategy/MongoPipelineStrategy.java
@@ -51,8 +51,6 @@ import org.eclipse.rdf4j.query.algebra.QueryRoot;
 import org.eclipse.rdf4j.query.algebra.TupleExpr;
 
 import com.google.common.base.Preconditions;
-import com.mongodb.BasicDBObject;
-import com.mongodb.DBObject;
 import com.mongodb.MongoClient;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
@@ -179,8 +177,7 @@ public class MongoPipelineStrategy extends AbstractRuleExecutionStrategy {
             .allowDiskUse(true)
             .batchSize(PIPELINE_BATCH_SIZE)
             .forEach((Consumer<Document>)(final Document doc) -> {
-                final DBObject dbo = BasicDBObject.parse(doc.toJson());
-                final RyaStatement rstmt = storageStrategy.deserializeDBObject(dbo);
+                final RyaStatement rstmt = storageStrategy.deserializeDocument(doc);
                 if (!statementExists(rstmt)) {
                     count.increment();
                     doc.replace(SimpleMongoDBStorageStrategy.STATEMENT_METADATA, metadata.toString());

--- a/extras/rya.forwardchain/src/main/java/org/apache/rya/forwardchain/strategy/MongoPipelineStrategy.java
+++ b/extras/rya.forwardchain/src/main/java/org/apache/rya/forwardchain/strategy/MongoPipelineStrategy.java
@@ -21,6 +21,7 @@ package org.apache.rya.forwardchain.strategy;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.LongAdder;
+import java.util.function.Consumer;
 
 import org.apache.log4j.Logger;
 import org.apache.rya.api.domain.RyaStatement;
@@ -177,7 +178,7 @@ public class MongoPipelineStrategy extends AbstractRuleExecutionStrategy {
         baseCollection.aggregate(pipeline)
             .allowDiskUse(true)
             .batchSize(PIPELINE_BATCH_SIZE)
-            .forEach((final Document doc) -> {
+            .forEach((Consumer<Document>)(final Document doc) -> {
                 final DBObject dbo = BasicDBObject.parse(doc.toJson());
                 final RyaStatement rstmt = storageStrategy.deserializeDBObject(dbo);
                 if (!statementExists(rstmt)) {

--- a/extras/rya.forwardchain/src/test/java/org/apache/rya/forwardchain/batch/MongoSpinIT.java
+++ b/extras/rya.forwardchain/src/test/java/org/apache/rya/forwardchain/batch/MongoSpinIT.java
@@ -58,7 +58,8 @@ import org.junit.Test;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Resources;
 import com.mongodb.MongoClient;
-import com.mongodb.ServerAddress;
+
+import de.flapdoodle.embed.mongo.config.Net;
 
 public class MongoSpinIT {
     private static final ValueFactory VF = SimpleValueFactory.getInstance();
@@ -164,8 +165,8 @@ public class MongoSpinIT {
     private static MongoDBRdfConfiguration getConf() throws Exception {
         final MongoDBIndexingConfigBuilder builder = MongoIndexingConfiguration.builder().setUseMockMongo(true);
         final MongoClient c = EmbeddedMongoFactory.newFactory().newMongoClient();
-        final ServerAddress address = c.getAddress();
-        builder.setMongoHost(address.getHost());
+        final Net address = EmbeddedMongoFactory.newFactory().getMongoServerDetails().net();
+        builder.setMongoHost(address.getServerAddress().getHostAddress());
         builder.setMongoPort(Integer.toString(address.getPort()));
         builder.setUseInference(false);
         c.close();

--- a/extras/rya.geoindexing/geo.common/src/main/java/org/apache/rya/indexing/GeoRyaSailFactory.java
+++ b/extras/rya.geoindexing/geo.common/src/main/java/org/apache/rya/indexing/GeoRyaSailFactory.java
@@ -20,7 +20,6 @@ package org.apache.rya.indexing;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
@@ -54,6 +53,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.mongodb.MongoClient;
+import com.mongodb.MongoClientOptions;
 import com.mongodb.MongoCredential;
 import com.mongodb.MongoException;
 import com.mongodb.ServerAddress;
@@ -170,7 +170,8 @@ public class GeoRyaSailFactory {
         final String password = mongoConf.getMongoPassword();
         if(username != null && password != null) {
             final MongoCredential cred = MongoCredential.createCredential(username, database, password.toCharArray());
-            return new MongoClient(server, Arrays.asList(cred));
+            final MongoClientOptions options = new MongoClientOptions.Builder().build();
+            return new MongoClient(server, cred, options);
         } else {
             return new MongoClient(server);
         }

--- a/extras/rya.geoindexing/geo.mongo/src/main/java/org/apache/rya/indexing/geoExamples/RyaMongoGeoDirectExample.java
+++ b/extras/rya.geoindexing/geo.mongo/src/main/java/org/apache/rya/indexing/geoExamples/RyaMongoGeoDirectExample.java
@@ -7,9 +7,9 @@ package org.apache.rya.indexing.geoExamples;
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -19,7 +19,6 @@ package org.apache.rya.indexing.geoExamples;
  */
 
 import java.io.IOException;
-import java.util.List;
 
 import org.apache.commons.lang.Validate;
 import org.apache.hadoop.conf.Configuration;
@@ -31,11 +30,10 @@ import org.apache.rya.indexing.mongodb.MongoIndexingConfiguration;
 import org.apache.rya.indexing.mongodb.MongoIndexingConfiguration.MongoDBIndexingConfigBuilder;
 import org.apache.rya.test.mongo.EmbeddedMongoFactory;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.eclipse.rdf4j.query.AbstractTupleQueryResultHandler;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.QueryLanguage;
-import org.eclipse.rdf4j.query.QueryResultHandlerException;
 import org.eclipse.rdf4j.query.TupleQuery;
-import org.eclipse.rdf4j.query.TupleQueryResultHandler;
 import org.eclipse.rdf4j.query.TupleQueryResultHandlerException;
 import org.eclipse.rdf4j.query.Update;
 import org.eclipse.rdf4j.repository.RepositoryException;
@@ -44,7 +42,8 @@ import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.sail.Sail;
 
 import com.mongodb.MongoClient;
-import com.mongodb.ServerAddress;
+
+import de.flapdoodle.embed.mongo.config.Net;
 
 public class RyaMongoGeoDirectExample {
     private static final Logger log = Logger.getLogger(RyaMongoGeoDirectExample.class);
@@ -61,21 +60,21 @@ public class RyaMongoGeoDirectExample {
     private static final String MONGO_INSTANCE_URL = "localhost";
     private static final String MONGO_INSTANCE_PORT = "27017";
 
-    public static void main(String[] args) throws Exception {
-        Configuration conf = getConf();
+    public static void main(final String[] args) throws Exception {
+        final Configuration conf = getConf();
         conf.setBoolean(ConfigUtils.DISPLAY_QUERY_PLAN, PRINT_QUERIES);
-		conf.setBoolean(OptionalConfigUtils.USE_GEO, true);  // Note also the use of "GeoRyaSailFactory" below.
-		conf.setStrings(OptionalConfigUtils.GEO_PREDICATES_LIST, "http://www.opengis.net/ont/geosparql#asWKT");  // Note also the use of "GeoRyaSailFactory" below.
-  
+        conf.setBoolean(OptionalConfigUtils.USE_GEO, true);  // Note also the use of "GeoRyaSailFactory" below.
+        conf.setStrings(OptionalConfigUtils.GEO_PREDICATES_LIST, "http://www.opengis.net/ont/geosparql#asWKT");  // Note also the use of "GeoRyaSailFactory" below.
+
         SailRepository repository = null;
         SailRepositoryConnection conn = null;
         try {
             log.info("Connecting to Indexing Sail Repository.");
-            Sail sail = GeoRyaSailFactory.getInstance(conf);
+            final Sail sail = GeoRyaSailFactory.getInstance(conf);
             repository = new SailRepository(sail);
             conn = repository.getConnection();
 
-            long start = System.currentTimeMillis();
+            final long start = System.currentTimeMillis();
             testAddPointAndWithinSearch(conn);  // uses geospatial features
 
             log.info("TIME: " + (System.currentTimeMillis() - start) / 1000.);
@@ -88,13 +87,14 @@ public class RyaMongoGeoDirectExample {
             }
         }
     }
-/**
- * Try out some geospatial data and queries
- * @param repository
- */
-    private static void testAddPointAndWithinSearch(SailRepositoryConnection conn) throws Exception {
 
-        String update = "PREFIX geo: <http://www.opengis.net/ont/geosparql#>  "//
+    /**
+     * Try out some geospatial data and queries
+     * @param conn
+     */
+    private static void testAddPointAndWithinSearch(final SailRepositoryConnection conn) throws Exception {
+
+        final String update = "PREFIX geo: <http://www.opengis.net/ont/geosparql#>  "//
                 + "INSERT DATA { " //
                 + "  <urn:feature> a geo:Feature ; " //
                 + "    geo:hasGeometry [ " //
@@ -103,7 +103,7 @@ public class RyaMongoGeoDirectExample {
                 + "    ] . " //
                 + "}";
 
-        Update u = conn.prepareUpdate(QueryLanguage.SPARQL, update);
+        final Update u = conn.prepareUpdate(QueryLanguage.SPARQL, update);
         u.execute();
 
         String queryString;
@@ -147,21 +147,21 @@ public class RyaMongoGeoDirectExample {
         Validate.isTrue(tupleHandler.getCount() == 0);
     }
 
-    private static void closeQuietly(SailRepository repository) {
+    private static void closeQuietly(final SailRepository repository) {
         if (repository != null) {
             try {
                 repository.shutDown();
-            } catch (RepositoryException e) {
+            } catch (final RepositoryException e) {
                 // quietly absorb this exception
             }
         }
     }
 
-    private static void closeQuietly(SailRepositoryConnection conn) {
+    private static void closeQuietly(final SailRepositoryConnection conn) {
         if (conn != null) {
             try {
                 conn.close();
-            } catch (RepositoryException e) {
+            } catch (final RepositoryException e) {
                 // quietly absorb this exception
             }
         }
@@ -170,34 +170,34 @@ public class RyaMongoGeoDirectExample {
     private static EmbeddedMongoFactory mock = null;
     private static Configuration getConf() throws IOException {
 
-    	MongoDBIndexingConfigBuilder builder = MongoIndexingConfiguration.builder()
-    		.setUseMockMongo(USE_MOCK).setUseInference(USE_INFER).setAuths("U");
+        MongoDBIndexingConfigBuilder builder = MongoIndexingConfiguration.builder()
+            .setUseMockMongo(USE_MOCK).setUseInference(USE_INFER).setAuths("U");
 
         if (USE_MOCK) {
             mock = EmbeddedMongoFactory.newFactory();
-            MongoClient c = mock.newMongoClient();
-            ServerAddress address = c.getAddress();
-            String url = address.getHost();
-            String port = Integer.toString(address.getPort());
+            final MongoClient c = mock.newMongoClient();
+            final Net address = mock.getMongoServerDetails().net();
+            final String url = address.getServerAddress().getHostAddress();
+            final String port = Integer.toString(address.getPort());
             c.close();
             builder.setMongoHost(url).setMongoPort(port);
         } else {
             // User name and password must be filled in:
-        	builder = builder.setMongoUser("fill this in")
-        					 .setMongoPassword("fill this in")
-        					 .setMongoHost(MONGO_INSTANCE_URL)
-        					 .setMongoPort(MONGO_INSTANCE_PORT);
+            builder = builder.setMongoUser("fill this in")
+                             .setMongoPassword("fill this in")
+                             .setMongoHost(MONGO_INSTANCE_URL)
+                             .setMongoPort(MONGO_INSTANCE_PORT);
         }
-        
+
         return builder.setMongoDBName(MONGO_DB)
                .setMongoCollectionPrefix(MONGO_COLL_PREFIX)
                .setUseMongoFreetextIndex(true)
                .setMongoFreeTextPredicates(RDFS.LABEL.stringValue()).build();
-        
+
     }
 
 
-    private static class CountingResultHandler implements TupleQueryResultHandler {
+    private static class CountingResultHandler extends AbstractTupleQueryResultHandler {
         private int count = 0;
 
         public int getCount() {
@@ -205,29 +205,9 @@ public class RyaMongoGeoDirectExample {
         }
 
         @Override
-        public void startQueryResult(List<String> arg0) throws TupleQueryResultHandlerException {
-        }
-
-        @Override
-        public void handleSolution(BindingSet arg0) throws TupleQueryResultHandlerException {
+        public void handleSolution(final BindingSet bindingSet) throws TupleQueryResultHandlerException {
             count++;
-            System.out.println(arg0);
-        }
-
-        @Override
-        public void endQueryResult() throws TupleQueryResultHandlerException {
-        }
-
-        @Override
-        public void handleBoolean(boolean arg0) throws QueryResultHandlerException {
-          // TODO Auto-generated method stub
-          
-        }
-
-        @Override
-        public void handleLinks(List<String> arg0) throws QueryResultHandlerException {
-          // TODO Auto-generated method stub
-          
+            System.out.println(bindingSet);
         }
     }
 }

--- a/extras/rya.geoindexing/geo.mongo/src/main/java/org/apache/rya/indexing/mongodb/geo/MongoGeoIndexer.java
+++ b/extras/rya.geoindexing/geo.mongo/src/main/java/org/apache/rya/indexing/mongodb/geo/MongoGeoIndexer.java
@@ -31,12 +31,12 @@ import org.apache.rya.indexing.accumulo.geo.GeoTupleSet.GeoSearchFunctionFactory
 import org.apache.rya.indexing.mongodb.AbstractMongoIndexer;
 import org.apache.rya.indexing.mongodb.geo.GeoMongoDBStorageStrategy.GeoQuery;
 import org.apache.rya.mongodb.MongoDBRdfConfiguration;
+import org.bson.Document;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.query.MalformedQueryException;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
 
-import com.mongodb.DBObject;
 import com.vividsolutions.jts.geom.Geometry;
 
 public class MongoGeoIndexer extends AbstractMongoIndexer<GeoMongoDBStorageStrategy> implements GeoIndexer {
@@ -58,7 +58,7 @@ public class MongoGeoIndexer extends AbstractMongoIndexer<GeoMongoDBStorageStrat
     public CloseableIteration<Statement, QueryEvaluationException> queryEquals(
             final Geometry query, final StatementConstraints constraints) {
         try {
-            final DBObject queryObj = storageStrategy.getQuery(new GeoQuery(EQUALS, query));
+            final Document queryObj = storageStrategy.getQuery(new GeoQuery(EQUALS, query));
             return withConstraints(constraints, queryObj);
         } catch (final MalformedQueryException e) {
             logger.error(e.getMessage(), e);
@@ -77,7 +77,7 @@ public class MongoGeoIndexer extends AbstractMongoIndexer<GeoMongoDBStorageStrat
     public CloseableIteration<Statement, QueryEvaluationException> queryIntersects(
             final Geometry query, final StatementConstraints constraints) {
         try {
-            final DBObject queryObj = storageStrategy.getQuery(new GeoQuery(INTERSECTS, query));
+            final Document queryObj = storageStrategy.getQuery(new GeoQuery(INTERSECTS, query));
             return withConstraints(constraints, queryObj);
         } catch (final MalformedQueryException e) {
             logger.error(e.getMessage(), e);
@@ -103,7 +103,7 @@ public class MongoGeoIndexer extends AbstractMongoIndexer<GeoMongoDBStorageStrat
     public CloseableIteration<Statement, QueryEvaluationException> queryWithin(
             final Geometry query, final StatementConstraints constraints) {
         try {
-            final DBObject queryObj = storageStrategy.getQuery(new GeoQuery(WITHIN, query));
+            final Document queryObj = storageStrategy.getQuery(new GeoQuery(WITHIN, query));
             return withConstraints(constraints, queryObj);
         } catch (final MalformedQueryException e) {
             logger.error(e.getMessage(), e);
@@ -124,7 +124,7 @@ public class MongoGeoIndexer extends AbstractMongoIndexer<GeoMongoDBStorageStrat
         }
 
         try {
-            final DBObject queryObj = storageStrategy.getQuery(new GeoQuery(NEAR, query.getGeometry(), maxDistance, minDistance));
+            final Document queryObj = storageStrategy.getQuery(new GeoQuery(NEAR, query.getGeometry(), maxDistance, minDistance));
             return withConstraints(constraints, queryObj);
         } catch (final MalformedQueryException e) {
             logger.error(e.getMessage(), e);

--- a/extras/rya.geoindexing/geo.mongo/src/main/java/org/apache/rya/indexing/mongodb/geo/MongoGeoTupleSet.java
+++ b/extras/rya.geoindexing/geo.mongo/src/main/java/org/apache/rya/indexing/mongodb/geo/MongoGeoTupleSet.java
@@ -44,6 +44,7 @@ import com.vividsolutions.jts.io.ParseException;
 import com.vividsolutions.jts.io.WKTReader;
 
 public class MongoGeoTupleSet extends ExternalTupleSet {
+    private static final long serialVersionUID = 1L;
 
     private Configuration conf;
     private GeoIndexer geoIndexer;

--- a/extras/rya.geoindexing/geo.mongo/src/test/java/org/apache/rya/indexing/geotemporal/mongo/GeoTemporalMongoDBStorageStrategyTest.java
+++ b/extras/rya.geoindexing/geo.mongo/src/test/java/org/apache/rya/indexing/geotemporal/mongo/GeoTemporalMongoDBStorageStrategyTest.java
@@ -34,6 +34,7 @@ import org.apache.rya.indexing.IndexingFunctionRegistry;
 import org.apache.rya.indexing.IndexingFunctionRegistry.FUNCTION_TYPE;
 import org.apache.rya.indexing.geotemporal.GeoTemporalIndexer.GeoPolicy;
 import org.apache.rya.indexing.geotemporal.GeoTemporalIndexer.TemporalPolicy;
+import org.bson.Document;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
@@ -48,12 +49,9 @@ import org.eclipse.rdf4j.query.algebra.Var;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.mongodb.DBObject;
-import com.mongodb.util.JSON;
-
 /**
  * Tests The {@link GeoTemporalMongoDBStorageStrategy}, which turns the filters
- * into mongo {@link DBObject}s used to query.
+ * into mongo {@link Document}s used to query.
  *
  * This tests also ensures all possible filter functions are accounted for in the test.
  * @see TemporalPolicy Temporal Filter Functions
@@ -72,10 +70,10 @@ public class GeoTemporalMongoDBStorageStrategyTest {
     public void emptyFilters_test() throws Exception {
         final List<IndexingExpr> geoFilters = new ArrayList<>();
         final List<IndexingExpr> temporalFilters = new ArrayList<>();
-        final DBObject actual = adapter.getFilterQuery(geoFilters, temporalFilters);
+        final Document actual = adapter.getFilterQuery(geoFilters, temporalFilters);
         final String expectedString =
                 "{ }";
-        final DBObject expected = (DBObject) JSON.parse(expectedString);
+        final Document expected = Document.parse(expectedString);
         assertEqualMongo(expected, actual);
     }
 
@@ -100,7 +98,7 @@ public class GeoTemporalMongoDBStorageStrategyTest {
             geoFilters.add(expr);
         }
         final List<IndexingExpr> temporalFilters = new ArrayList<>();
-        final DBObject actual = adapter.getFilterQuery(geoFilters, temporalFilters);
+        final Document actual = adapter.getFilterQuery(geoFilters, temporalFilters);
         final String expectedString =
             "{ "
             + "\"location\" : { "
@@ -112,7 +110,7 @@ public class GeoTemporalMongoDBStorageStrategyTest {
               + "}"
             + "}"
           + "}";
-        final DBObject expected = (DBObject) JSON.parse(expectedString);
+        final Document expected = Document.parse(expectedString);
         assertEqualMongo(expected, actual);
     }
 
@@ -143,7 +141,7 @@ public class GeoTemporalMongoDBStorageStrategyTest {
                   geoFilters.add(expr);
               }
               final List<IndexingExpr> temporalFilters = new ArrayList<>();
-              final DBObject actual = adapter.getFilterQuery(geoFilters, temporalFilters);
+              final Document actual = adapter.getFilterQuery(geoFilters, temporalFilters);
 
               final String expectedString =
                   "{ "
@@ -162,7 +160,7 @@ public class GeoTemporalMongoDBStorageStrategyTest {
                     + "}"
                   + "}"
                 + "}]}";
-              final DBObject expected = (DBObject) JSON.parse(expectedString);
+              final Document expected = Document.parse(expectedString);
               assertEqualMongo(expected, actual);
     }
 
@@ -187,14 +185,14 @@ public class GeoTemporalMongoDBStorageStrategyTest {
             final IndexingExpr expr = new IndexingExpr(VF.createIRI(filter.getURI()), sps.get(0), Arrays.stream(arguments).toArray());
             temporalFilters.add(expr);
         }
-        final DBObject actual = adapter.getFilterQuery(geoFilters, temporalFilters);
+        final Document actual = adapter.getFilterQuery(geoFilters, temporalFilters);
         final String expectedString =
         "{ "
         + "\"instant\" : {"
           + "\"$date\" : \"2015-12-30T12:00:00.000Z\""
         + "}"
       + "}";
-        final DBObject expected = (DBObject) JSON.parse(expectedString);
+        final Document expected = Document.parse(expectedString);
         assertEqualMongo(expected, actual);
     }
 
@@ -219,7 +217,7 @@ public class GeoTemporalMongoDBStorageStrategyTest {
                   final IndexingExpr expr = new IndexingExpr(VF.createIRI(filter.getURI()), sps.get(0), Arrays.stream(arguments).toArray());
                   temporalFilters.add(expr);
               }
-              final DBObject actual = adapter.getFilterQuery(geoFilters, temporalFilters);
+              final Document actual = adapter.getFilterQuery(geoFilters, temporalFilters);
               final String expectedString =
               "{ "
               + "\"$and\" : [{"
@@ -238,7 +236,7 @@ public class GeoTemporalMongoDBStorageStrategyTest {
                 + "}"
               + "}]"
             + "}";
-              final DBObject expected = (DBObject) JSON.parse(expectedString);
+              final Document expected = Document.parse(expectedString);
               assertEqualMongo(expected, actual);
     }
 
@@ -271,7 +269,7 @@ public class GeoTemporalMongoDBStorageStrategyTest {
                       temporalFilters.add(expr);
                   }
               }
-              final DBObject actual = adapter.getFilterQuery(geoFilters, temporalFilters);
+              final Document actual = adapter.getFilterQuery(geoFilters, temporalFilters);
               final String expectedString =
               "{ "
               + "\"$and\" : [ { "
@@ -291,7 +289,7 @@ public class GeoTemporalMongoDBStorageStrategyTest {
                 + "}"
               + "}]"
             + "}";
-              final DBObject expected = (DBObject) JSON.parse(expectedString);
+              final Document expected = Document.parse(expectedString);
               assertEqualMongo(expected, actual);
     }
 
@@ -326,7 +324,7 @@ public class GeoTemporalMongoDBStorageStrategyTest {
                       temporalFilters.add(expr);
                   }
               }
-              final DBObject actual = adapter.getFilterQuery(geoFilters, temporalFilters);
+              final Document actual = adapter.getFilterQuery(geoFilters, temporalFilters);
               final String expectedString =
                   "{ "
                   + "\"$and\" : [ { "
@@ -359,7 +357,7 @@ public class GeoTemporalMongoDBStorageStrategyTest {
                    + "}]"
                  + "}]"
                + "}";
-              final DBObject expected = (DBObject) JSON.parse(expectedString);
+              final Document expected = Document.parse(expectedString);
               assertEqualMongo(expected, actual);
     }
 
@@ -393,7 +391,7 @@ public class GeoTemporalMongoDBStorageStrategyTest {
                 temporalFilters.add(expr);
              }
         }
-        final DBObject actual = adapter.getFilterQuery(geoFilters, temporalFilters);
+        final Document actual = adapter.getFilterQuery(geoFilters, temporalFilters);
         final String expectedString =
             "{ "
             + "\"$and\" : [ { "
@@ -415,7 +413,7 @@ public class GeoTemporalMongoDBStorageStrategyTest {
               + "}]"
             + "}]"
           + "}";
-        final DBObject expected = (DBObject) JSON.parse(expectedString);
+        final Document expected = Document.parse(expectedString);
         assertEqualMongo(expected, actual);
     }
 
@@ -431,7 +429,7 @@ public class GeoTemporalMongoDBStorageStrategyTest {
         Statement statement = VF.createStatement(subject, predicate, object, context);
         RyaStatement ryaStatement = RdfToRyaConversions.convertStatement(statement);
         int expectedId = ryaStatement.getSubject().hashCode();
-        DBObject actual = adapter.serialize(ryaStatement);
+        Document actual = adapter.serialize(ryaStatement);
         String expectedString =
             "{ "
             + "\"_id\" : " + expectedId + ", "
@@ -440,7 +438,7 @@ public class GeoTemporalMongoDBStorageStrategyTest {
               + "\"type\" : \"Point\""
             + "}"
           + "}";
-        DBObject expected = (DBObject) JSON.parse(expectedString);
+        Document expected = Document.parse(expectedString);
         assertEqualMongo(expected, actual);
 
         //TIME INSTANT
@@ -459,7 +457,7 @@ public class GeoTemporalMongoDBStorageStrategyTest {
                     + "}"
                 + "}"
               + "}";
-        expected = (DBObject) JSON.parse(expectedString);
+        expected = Document.parse(expectedString);
         assertEqualMongo(expected, actual);
 
         //TIME INTERVAL
@@ -481,7 +479,7 @@ public class GeoTemporalMongoDBStorageStrategyTest {
                   + "}"
               + "}"
             + "}";
-        expected = (DBObject) JSON.parse(expectedString);
+        expected = Document.parse(expectedString);
         assertEqualMongo(expected, actual);
     }
 

--- a/extras/rya.indexing.pcj/src/test/java/org/apache/rya/indexing/pcj/storage/mongo/PcjDocumentsIntegrationTest.java
+++ b/extras/rya.indexing.pcj/src/test/java/org/apache/rya/indexing/pcj/storage/mongo/PcjDocumentsIntegrationTest.java
@@ -30,7 +30,6 @@ import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.TableNotFoundException;
-import org.apache.accumulo.minicluster.MiniAccumuloCluster;
 import org.apache.rya.api.model.VisibilityBindingSet;
 import org.apache.rya.api.utils.CloseableIterator;
 import org.apache.rya.indexing.pcj.storage.PcjException;
@@ -59,7 +58,7 @@ import com.google.common.base.Optional;
 import com.google.common.collect.Sets;
 
 /**
- * Performs integration test using {@link MiniAccumuloCluster} to ensure the
+ * Performs integration test using {@link MongoClient} to ensure the
  * functions of {@link PcjTables} work within a cluster setting.
  */
 public class PcjDocumentsIntegrationTest extends MongoRyaITBase {
@@ -99,7 +98,7 @@ public class PcjDocumentsIntegrationTest extends MongoRyaITBase {
     }
 
     /**
-     * Ensure when results have been written to the PCJ table that they are in Accumulo.
+     * Ensure when results have been written to the PCJ table that they are in Mongo.
      * <p>
      * The method being tested is {@link PcjTables#addResults(Connector, String, java.util.Collection)}
      */
@@ -140,7 +139,7 @@ public class PcjDocumentsIntegrationTest extends MongoRyaITBase {
         final PcjMetadata metadata = pcjs.getPcjMetadata(pcjTableName);
         assertEquals(3, metadata.getCardinality());
 
-        // Scan Accumulo for the stored results.
+        // Scan Mongo for the stored results.
         final Collection<BindingSet> fetchedResults = loadPcjResults(pcjTableName);
         assertEquals(expected, fetchedResults);
     }
@@ -205,7 +204,7 @@ public class PcjDocumentsIntegrationTest extends MongoRyaITBase {
         final MongoDBRyaDAO dao = new MongoDBRyaDAO();
         dao.setConf(new StatefulMongoDBRdfConfiguration(conf, getMongoClient()));
         dao.init();
-        final RdfCloudTripleStore ryaStore = new RdfCloudTripleStore();
+        final RdfCloudTripleStore<StatefulMongoDBRdfConfiguration> ryaStore = new RdfCloudTripleStore<>();
         ryaStore.setRyaDAO(dao);
         ryaStore.initialize();
         final SailRepositoryConnection ryaConn = new RyaSailRepository(ryaStore).getConnection();
@@ -282,7 +281,7 @@ public class PcjDocumentsIntegrationTest extends MongoRyaITBase {
         final MongoDBRyaDAO dao = new MongoDBRyaDAO();
         dao.setConf(new StatefulMongoDBRdfConfiguration(conf, getMongoClient()));
         dao.init();
-        final RdfCloudTripleStore ryaStore = new RdfCloudTripleStore();
+        final RdfCloudTripleStore<StatefulMongoDBRdfConfiguration> ryaStore = new RdfCloudTripleStore<>();
         ryaStore.setRyaDAO(dao);
         ryaStore.initialize();
         final SailRepositoryConnection ryaConn = new RyaSailRepository(ryaStore).getConnection();

--- a/extras/rya.indexing.pcj/src/test/java/org/apache/rya/indexing/pcj/storage/mongo/PcjDocumentsWithMockTest.java
+++ b/extras/rya.indexing.pcj/src/test/java/org/apache/rya/indexing/pcj/storage/mongo/PcjDocumentsWithMockTest.java
@@ -50,7 +50,7 @@ public class PcjDocumentsWithMockTest extends MongoRyaITBase {
 
     @Test
     public void populatePcj() throws Exception {
-        final RdfCloudTripleStore ryaStore = new RdfCloudTripleStore();
+        final RdfCloudTripleStore<StatefulMongoDBRdfConfiguration> ryaStore = new RdfCloudTripleStore<>();
         final MongoDBRyaDAO dao = new MongoDBRyaDAO();
         dao.setConf(new StatefulMongoDBRdfConfiguration(conf, getMongoClient()));
         dao.init();

--- a/extras/rya.streams/geo/src/test/java/org/apache/rya/streams/kafka/processors/filter/GeoFilterIT.java
+++ b/extras/rya.streams/geo/src/test/java/org/apache/rya/streams/kafka/processors/filter/GeoFilterIT.java
@@ -72,13 +72,15 @@ public class GeoFilterIT {
         int count = 0;
         final Collection<Function> funcs = FunctionRegistry.getInstance().getAll();
         for (final Function fun : funcs) {
-            if (fun.getURI().startsWith(GEO)) {
+            final String uri = fun.getURI();
+            if (uri.startsWith(GEO)) {
                 count++;
+                System.out.println(String.format("Geo Registered Function #%02d: %s", count, uri));
             }
         }
 
-        // There are 30 geo functions registered, ensure that there are 30.
-        assertEquals(30, count);
+        // There are 35 geo functions registered, ensure that there are 35.
+        assertEquals(35, count);
     }
 
     @Test

--- a/extras/shell/src/main/java/org/apache/rya/shell/RyaConnectionCommands.java
+++ b/extras/shell/src/main/java/org/apache/rya/shell/RyaConnectionCommands.java
@@ -43,6 +43,7 @@ import org.apache.rya.shell.util.ConnectorFactory;
 import org.apache.rya.shell.util.PasswordPrompt;
 import org.apache.rya.streams.api.RyaStreamsClient;
 import org.apache.rya.streams.kafka.KafkaRyaStreamsClientFactory;
+import org.bson.Document;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.shell.core.CommandMarker;
 import org.springframework.shell.core.annotation.CliAvailabilityIndicator;
@@ -205,10 +206,15 @@ public class RyaConnectionCommands implements CommandMarker {
             });
 
             try {
-                //attempt to get the connection point, essentially pinging mongo server.
-                adminClient.getConnectPoint();
+                // Pinging mongo server.
+                final Document ping = new Document("ping", 1);
+                final Document result = adminClient.getDatabase(adminClient.listDatabaseNames().first()).runCommand(ping);
+                final Document ok = new Document("ok", 1.0);
+                if (!result.equals(ok)) {
+                    adminClient.close();
+                }
             } catch(final MongoException e) {
-            	//had to rethrow to get scope on adminClient.
+                //had to rethrow to get scope on adminClient.
                 adminClient.close();
                 throw e;
             }

--- a/extras/shell/src/test/java/org/apache/rya/shell/MongoRyaShellIT.java
+++ b/extras/shell/src/test/java/org/apache/rya/shell/MongoRyaShellIT.java
@@ -28,7 +28,6 @@ import java.io.IOException;
 import org.apache.rya.api.client.Install.InstallConfiguration;
 import org.apache.rya.shell.SharedShellState.ConnectionState;
 import org.apache.rya.shell.SharedShellState.ShellState;
-import org.apache.rya.shell.util.ConsolePrinter;
 import org.apache.rya.shell.util.InstallPrompt;
 import org.apache.rya.shell.util.PasswordPrompt;
 import org.junit.Test;
@@ -193,26 +192,4 @@ public class MongoRyaShellIT extends RyaShellMongoITBase {
 
     // TODO the rest of them?
 
-    private static final ConsolePrinter systemPrinter = new ConsolePrinter() {
-
-        @Override
-        public void print(final CharSequence cs) throws IOException {
-            System.out.print(cs);
-        }
-
-        @Override
-        public void println(final CharSequence cs) throws IOException {
-            System.out.println(cs);
-        }
-
-        @Override
-        public void println() throws IOException {
-            System.out.println();
-        }
-
-        @Override
-        public void flush() throws IOException {
-            System.out.flush();
-        }
-    };
 }

--- a/pom.xml
+++ b/pom.xml
@@ -81,8 +81,8 @@ under the License.
         <lucene.version>5.2.1</lucene.version> <!-- Newest: 5.3.1 -->
         <joda-time.version>2.1</joda-time.version> <!-- Newest: 2.9.1 -->
 
-        <mongodb.version>3.3.0</mongodb.version>
-        <embed.mongo.version>1.50.5</embed.mongo.version>
+        <mongodb.version>3.10.2</mongodb.version>
+        <embed.mongo.version>2.2.0</embed.mongo.version>
 
         <tinkerpop.version>3.2.2</tinkerpop.version> <!-- Newest: Apache 3.2.2 -->
 

--- a/test/mongo/pom.xml
+++ b/test/mongo/pom.xml
@@ -41,10 +41,6 @@ under the License.
             <artifactId>findbugs-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.accumulo</groupId>
-            <artifactId>accumulo-core</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongo-java-driver</artifactId>
         </dependency>
@@ -52,7 +48,7 @@ under the License.
             <groupId>de.flapdoodle.embed</groupId>
             <artifactId>de.flapdoodle.embed.mongo</artifactId>
         </dependency>
-    
+
         <!-- Testing dependencies. -->
         <dependency>
             <groupId>junit</groupId>

--- a/test/mongo/src/main/java/org/apache/rya/test/mongo/EmbeddedMongoSingleton.java
+++ b/test/mongo/src/main/java/org/apache/rya/test/mongo/EmbeddedMongoSingleton.java
@@ -37,7 +37,7 @@ import de.flapdoodle.embed.mongo.config.IMongodConfig;
 public class EmbeddedMongoSingleton {
 
     public static MongoClient getNewMongoClient() throws UnknownHostException, MongoException {
-    	final MongoClient client = InstanceHolder.SINGLETON.factory.newMongoClient();
+        final MongoClient client = InstanceHolder.SINGLETON.factory.newMongoClient();
 
         Runtime.getRuntime().addShutdownHook(new Thread() {
             @Override
@@ -76,7 +76,7 @@ public class EmbeddedMongoSingleton {
         InstanceHolder() {
             log = LoggerFactory.getLogger(EmbeddedMongoSingleton.class);
             try {
-            	factory = EmbeddedMongoFactory.newFactory();
+                factory = EmbeddedMongoFactory.newFactory();
                 mongodConfig = factory.getMongoServerDetails();
             } catch (final IOException e) {
                 log.error("Unexpected error while starting mongo client", e);

--- a/test/mongo/src/main/java/org/apache/rya/test/mongo/MongoITBase.java
+++ b/test/mongo/src/main/java/org/apache/rya/test/mongo/MongoITBase.java
@@ -38,7 +38,7 @@ public class MongoITBase {
         // Remove any DBs that were created by previous tests.
         for(final String dbName : mongoClient.listDatabaseNames()) {
             if (!MongoUtils.ADMIN_DATABASE_NAME.equals(dbName)) {
-                mongoClient.dropDatabase(dbName);
+                mongoClient.getDatabase(dbName).drop();
             }
         }
 

--- a/test/mongo/src/main/java/org/apache/rya/test/mongo/MongoITBase.java
+++ b/test/mongo/src/main/java/org/apache/rya/test/mongo/MongoITBase.java
@@ -29,7 +29,6 @@ import com.mongodb.MongoClient;
  * JUnit framework.
  */
 public class MongoITBase {
-
     private MongoClient mongoClient = null;
 
     @Before
@@ -38,7 +37,9 @@ public class MongoITBase {
 
         // Remove any DBs that were created by previous tests.
         for(final String dbName : mongoClient.listDatabaseNames()) {
-            mongoClient.dropDatabase(dbName);
+            if (!MongoUtils.ADMIN_DATABASE_NAME.equals(dbName)) {
+                mongoClient.dropDatabase(dbName);
+            }
         }
 
         // Let subclasses do more setup.

--- a/test/mongo/src/main/java/org/apache/rya/test/mongo/MongoUtils.java
+++ b/test/mongo/src/main/java/org/apache/rya/test/mongo/MongoUtils.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.test.mongo;
+
+/**
+ * Utility methods and constants for MongoDB.
+ */
+public final class MongoUtils {
+    /**
+     * Default "authSource" value for the admin database in the mongo URI
+     * connection string.
+     */
+    public static final String ADMIN_DATABASE_NAME = "admin";
+
+    /**
+     * Private constructor to prevent instantiation.
+     */
+    private MongoUtils() {
+    }
+}


### PR DESCRIPTION
## Description
Upgraded the mongo-java-driver to 3.10.2 (the latest non-beta version) which supports MongoDB server versions from the 2.6 release through the 4.0 release.

Replaced methods that were marked as deprecated and also switched `DBObject`/`BasicDBObject` usage to `Document`. Though `DBObject` isn't officially deprecated, `Document` supports the recommended `com.mongodb.client.MongoDatabase` and `com.mongodb.client.MongoCollection` classes, while `DBObject` is for the deprecated `com.mongodb.DB` and `com.mongodb.DBCollection` classes.

Several integration tests were already failing before the upgrade. I fixed most of them and `@Ignored` one.  But running the build with `-Penable-it` will still randomly fail several integration tests attempting to setup Accumulo repositories which should be looked into in another ticket.

### Tests
Ran unit tests.
Built with integration tests. (`mvn clean install -Pgeoindexing -Pgiraph -Pbenchmark -Penable-it`)

### Links
[Jira](https://issues.apache.org/jira/browse/RYA-515)

### Checklist
- [ ] Code Review
- [ ] Squash Commits

#### People To Review
@pujav65 
@jdasch 
@jessehatfield 
@DLotts
